### PR TITLE
Initial push

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Datadog CLI Contributors
+Copyright (c) 2026, Datadog <info@datadoghq.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Datadog CLI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npx skills add datadog-labs/agent-skills \
 | Search error logs | `pup logs search --query "status:error" --duration 1h` |
 | List monitors | `pup monitors list` |
 | Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
-| Find slow traces | `pup traces search --service api --min-duration 500ms` |
+| Find slow traces | `pup apm traces list --service api --min-duration 500ms` |
 | Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
 | List services | `pup apm services list` |
 | Check auth | `pup auth status` |

--- a/README.md
+++ b/README.md
@@ -14,17 +14,7 @@
 
 ## Install
 
-```bash
-npx skills add datadog-ai-labs/agent-skills \
-  --skill dd-pup \
-  --skill dd-monitors \
-  --skill dd-logs \
-  --skill dd-apm \
-  --skill dd-docs \
-  --full-depth -y
-```
-
-## Setup
+### Setup Pup
 
 ```bash
 # Install pup CLI
@@ -33,6 +23,26 @@ export PATH="$HOME/go/bin:$PATH"
 
 # Authenticate
 pup auth login
+```
+
+### Add Skill(s) 
+
+For JUST `dd-pup`:
+
+```bash
+npx skills add datadog-labs/agent-skills \
+  --skill dd-pup \
+  --full-depth -y
+```
+
+```bash
+npx skills add datadog-labs/agent-skills \
+  --skill dd-pup \
+  --skill dd-monitors \
+  --skill dd-logs \
+  --skill dd-apm \
+  --skill dd-docs \
+  --full-depth -y
 ```
 
 ## Quick Reference
@@ -64,7 +74,7 @@ Additional skills available soon.
 
 ```bash
 # List all available
-npx skills add datadog-ai-labs/agent-skills --list --full-depth
+npx skills add datadog-labs/agent-skills --list --full-depth
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -60,13 +60,7 @@ Tokens expire (~1 hour). Run `pup auth refresh` if you get 401/403 errors.
 
 ## More Skills
 
-100+ additional skills available in [SKILL_FULL.md](./SKILL_FULL.md):
-
-- Security: kubehound, guarddog, stratus-red-team
-- Infrastructure: dd-infra, dd-containers, cloudcraft  
-- CI/CD: dd-ci, dd-dora
-- Incidents: dd-oncall, dd-incident-commander
-- And more...
+Additional skills available soon.
 
 ```bash
 # List all available

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,5 +70,5 @@ pup auth refresh        # Refresh expired token
 Additional skills available shortly.
 
 ```bash
-npx skills add datadog-ai-labs/agent-skills --list --full-depth
+npx skills add datadog-labs/agent-skills --list --full-depth
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,20 +1,27 @@
-# Datadog Skills for AI Agents
+---
+name: datadog-ai-labs/agent-skills
+description: Datadog skills for AI agents. Essential monitoring and observability.
+version: 1.0.0
+---
 
-5 essential Datadog skills for Claude Code, Cursor, OpenCode, and other AI agents.
+# Datadog Skills
 
-## Skills
+Essential Datadog skills for AI agents.
+
+## Core Skills
 
 | Skill | Description |
 |-------|-------------|
-| **dd-pup** | Primary CLI - commands, auth, PATH setup |
-| **dd-monitors** | Create, manage, mute monitors |
-| **dd-logs** | Search logs |
-| **dd-apm** | Traces, services, performance |
+| **dd-pup** | Primary CLI - all pup commands, auth, PATH setup |
+| **dd-monitors** | Create, manage, mute monitors and alerts |
+| **dd-logs** | Search logs, pipelines, archives |
+| **dd-apm** | Traces, services, performance analysis |
 | **dd-docs** | Search Datadog documentation |
 
 ## Install
 
 ```bash
+# Install core skills
 npx skills add datadog-ai-labs/agent-skills \
   --skill dd-pup \
   --skill dd-monitors \
@@ -24,7 +31,7 @@ npx skills add datadog-ai-labs/agent-skills \
   --full-depth -y
 ```
 
-## Setup
+## Prerequisites
 
 ```bash
 # Install pup CLI
@@ -44,36 +51,23 @@ pup auth login
 | Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
 | Find slow traces | `pup traces search --service api --min-duration 500ms` |
 | Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
-| List services | `pup apm services list` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |
 
 ## Auth
 
 ```bash
-pup auth login      # OAuth2 browser flow
-pup auth status     # Check token
-pup auth refresh    # Refresh expired token
+pup auth login          # OAuth2 (recommended)
+pup auth status         # Check token
+pup auth refresh        # Refresh expired token
 ```
 
-Tokens expire (~1 hour). Run `pup auth refresh` if you get 401/403 errors.
+**⚠️ Token Expiry**: OAuth tokens expire (~1 hour). Run `pup auth refresh` if commands fail with 401/403.
 
 ## More Skills
 
-100+ additional skills available in [SKILL_FULL.md](./SKILL_FULL.md):
-
-- Security: kubehound, guarddog, stratus-red-team
-- Infrastructure: dd-infra, dd-containers, cloudcraft  
-- CI/CD: dd-ci, dd-dora
-- Incidents: dd-oncall, dd-incident-commander
-- And more...
+Additional skills available shortly.
 
 ```bash
-# List all available
 npx skills add datadog-ai-labs/agent-skills --list --full-depth
 ```
-
-## License
-
-MIT
-

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-skills
 description: Datadog skills for AI agents. Essential monitoring, logging, tracing and observability.
-version: 1.0.0
+metadata:
+  version: "1.0.0"
 ---
 
 # Datadog Skills

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: datadog-ai-labs/agent-skills
-description: Datadog skills for AI agents. Essential monitoring and observability.
+name: agent-skills
+description: Datadog skills for AI agents. Essential monitoring, logging, tracing and observability.
 version: 1.0.0
 ---
 
@@ -22,7 +22,7 @@ Essential Datadog skills for AI agents.
 
 ```bash
 # Install core skills
-npx skills add datadog-ai-labs/agent-skills \
+npx skills add datadog-labs/agent-skills \
   --skill dd-pup \
   --skill dd-monitors \
   --skill dd-logs \

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,7 @@ pup auth login
 | Search error logs | `pup logs search --query "status:error" --duration 1h` |
 | List monitors | `pup monitors list` |
 | Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
-| Find slow traces | `pup traces search --service api --min-duration 500ms` |
+| Find slow traces | `pup apm traces list --service api --min-duration 500ms` |
 | Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: dd-apm
+description: APM - traces, services, dependencies, performance analysis.
+version: 1.0.0
+author: dd-skill-test
+repository: https://github.com/dd-skill-test/dd-skills
+tags:
+  - datadog
+  - apm
+  - tracing
+  - performance
+  - distributed-tracing
+  - dd-apm
+globs:
+  - "**/ddtrace*"
+  - "**/datadog*.yaml"
+  - "**/*trace*"
+alwaysApply: false
+---
+
+# Datadog APM
+
+Distributed tracing, service maps, and performance analysis.
+
+## Quick Start
+
+```bash
+pup auth login
+pup apm services list
+pup apm traces list --service api-gateway --duration 1h
+```
+
+## Services
+
+### List Services
+
+```bash
+pup apm services list
+pup apm services list --env production
+```
+
+### Service Details
+
+```bash
+pup apm services get api-gateway --json
+```
+
+### Service Map
+
+```bash
+# View dependencies
+pup apm service-map --service api-gateway --json
+```
+
+## Traces
+
+### Search Traces
+
+```bash
+# By service
+pup apm traces list --service api-gateway --duration 1h
+
+# Errors only
+pup apm traces list --service api-gateway --status error
+
+# Slow traces (>1s)
+pup apm traces list --service api-gateway --min-duration 1000ms
+
+# With specific tag
+pup apm traces list --query "@http.url:/api/users"
+```
+
+### Get Trace Detail
+
+```bash
+pup apm traces get <trace_id> --json
+```
+
+## Key Metrics
+
+| Metric | What It Measures |
+|--------|------------------|
+| `trace.http.request.hits` | Request count |
+| `trace.http.request.duration` | Latency |
+| `trace.http.request.errors` | Error count |
+| `trace.http.request.apdex` | User satisfaction |
+
+## ⚠️ Trace Sampling
+
+**Not all traces are kept.** Understand sampling:
+
+| Mode | What's Kept |
+|------|-------------|
+| **Head-based** | Random % at start |
+| **Error/Slow** | All errors, slow traces |
+| **Retention** | What's indexed (billed) |
+
+```bash
+# Check retention filters
+pup apm retention-filters list
+```
+
+### Trace Retention Costs
+
+| Retention | Cost |
+|-----------|------|
+| Indexed spans | $$$ per million |
+| Ingested spans | $ per million |
+
+**Best practice:** Only index what you need for search.
+
+## Service Level Objectives
+
+Link APM to SLOs:
+
+```bash
+pup slos create \
+  --name "API Latency p99 < 200ms" \
+  --type metric \
+  --numerator "sum:trace.http.request.hits{service:api,@duration:<200000000}" \
+  --denominator "sum:trace.http.request.hits{service:api}" \
+  --target 99.0
+```
+
+## Common Queries
+
+| Goal | Query |
+|------|-------|
+| Slowest endpoints | `avg:trace.http.request.duration{*} by {resource_name}` |
+| Error rate | `sum:trace.http.request.errors{*} / sum:trace.http.request.hits{*}` |
+| Throughput | `sum:trace.http.request.hits{*}.as_rate()` |
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| No traces | Check ddtrace installed, DD_TRACE_ENABLED=true |
+| Missing service | Verify DD_SERVICE env var |
+| Traces not linked | Check trace headers propagated |
+| High cardinality | Don't tag with user_id/request_id |
+
+## References/Docs
+
+- [APM Setup](https://docs.datadoghq.com/tracing/)
+- [Trace Search](https://docs.datadoghq.com/tracing/trace_explorer/)
+- [Retention Filters](https://docs.datadoghq.com/tracing/trace_pipeline/trace_retention/)
+

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -2,8 +2,8 @@
 name: dd-apm
 description: APM - traces, services, dependencies, performance analysis.
 version: 1.0.0
-author: dd-skill-test
-repository: https://github.com/dd-skill-test/dd-skills
+author: datadog-labs
+repository: https://github.com/datadog-labs/dd-skills
 tags:
   - datadog
   - apm

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -4,7 +4,7 @@ description: APM - traces, services, dependencies, performance analysis.
 metadata:
   version: "1.0.0"
   author: datadog-labs
-  repository: https://github.com/datadog-labs/dd-skills
+  repository: https://github.com/datadog-labs/agent-skills
   tags: datadog,apm,tracing,performance,distributed-tracing,dd-apm
   globs: "**/ddtrace*,**/datadog*.yaml,**/*trace*"
   alwaysApply: "false"

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -1,21 +1,13 @@
 ---
 name: dd-apm
 description: APM - traces, services, dependencies, performance analysis.
-version: 1.0.0
-author: datadog-labs
-repository: https://github.com/datadog-labs/dd-skills
-tags:
-  - datadog
-  - apm
-  - tracing
-  - performance
-  - distributed-tracing
-  - dd-apm
-globs:
-  - "**/ddtrace*"
-  - "**/datadog*.yaml"
-  - "**/*trace*"
-alwaysApply: false
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/dd-skills
+  tags: datadog,apm,tracing,performance,distributed-tracing,dd-apm
+  globs: "**/ddtrace*,**/datadog*.yaml,**/*trace*"
+  alwaysApply: "false"
 ---
 
 # Datadog APM

--- a/dd-docs/SKILL.md
+++ b/dd-docs/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: dd-docs
+description: Datadog docs lookup using docs.datadoghq.com/llms.txt and linked Markdown pages.
+version: 1.0.0
+author: dd-skill-test
+repository: https://github.com/datadog-ai-labs/agent-skills
+tags:
+  - datadog
+  - docs
+  - llms.txt
+  - dd-docs
+alwaysApply: false
+---
+
+# Datadog Docs
+
+Use this skill to locate Datadog documentation and limits.
+
+## LLM-Friendly Documentation
+
+Datadog provides an LLM-optimized documentation index at:
+
+```
+https://docs.datadoghq.com/llms.txt
+```
+
+This file contains:
+- Overview of all Datadog products organized by use case
+- Full list of documentation pages with URLs and descriptions
+- Direct links to Markdown sources (append `.md` to URLs)
+
+### How to Use llms.txt
+
+1. **Fetch the index** to understand available documentation:
+   ```bash
+   curl -s https://docs.datadoghq.com/llms.txt | head -100
+   ```
+
+2. **Search for specific topics**:
+
+Examples:
+
+   ```bash
+   curl -s https://docs.datadoghq.com/llms.txt | grep -i "monitors"
+   curl -s https://docs.datadoghq.com/llms.txt | grep -i "apm"
+   curl -s https://docs.datadoghq.com/llms.txt | grep -i "logs"
+   ```
+
+3. **Fetch specific doc pages** (add .md to most Datadog Docs URLs for raw content):
+   ```bash
+   curl -s https://docs.datadoghq.com/monitors.md
+   curl -s https://docs.datadoghq.com/tracing.md
+   ```
+
+### Key Documentation Sections
+
+| Topic | URL |
+|-------|-----|
+| APM/Tracing | https://docs.datadoghq.com/tracing/ |
+| Logs | https://docs.datadoghq.com/logs/ |
+| Metrics | https://docs.datadoghq.com/metrics/ |
+| Monitors | https://docs.datadoghq.com/monitors/ |
+| Dashboards | https://docs.datadoghq.com/dashboards/ |
+| Security | https://docs.datadoghq.com/security/ |
+| Synthetics | https://docs.datadoghq.com/synthetics/ |
+| RUM | https://docs.datadoghq.com/real_user_monitoring/ |
+| Incidents | https://docs.datadoghq.com/service_management/incident_management/ |
+| API Reference | https://docs.datadoghq.com/api/ |
+
+## Scope Guardrails
+
+- Use llms.txt for documentation lookups
+- Defer to official docs for feature availability and limits
+
+## Failure Handling
+
+- If docs.datadoghq.com is unreachable, check network connectivity
+- For region-specific docs, use appropriate site (datadoghq.eu, etc.)

--- a/dd-docs/SKILL.md
+++ b/dd-docs/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: dd-docs
 description: Datadog docs lookup using docs.datadoghq.com/llms.txt and linked Markdown pages.
-version: 1.0.0
-author: datadog-labs
-repository: https://github.com/datadog-labs/agent-skills
-tags:
-  - datadog
-  - docs
-  - llms.txt
-  - dd-docs
-alwaysApply: false
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,docs,llms.txt,dd-docs
+  alwaysApply: "false"
 ---
 
 # Datadog Docs

--- a/dd-docs/SKILL.md
+++ b/dd-docs/SKILL.md
@@ -2,8 +2,8 @@
 name: dd-docs
 description: Datadog docs lookup using docs.datadoghq.com/llms.txt and linked Markdown pages.
 version: 1.0.0
-author: dd-skill-test
-repository: https://github.com/datadog-ai-labs/agent-skills
+author: datadog-labs
+repository: https://github.com/datadog-labs/agent-skills
 tags:
   - datadog
   - docs

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -2,8 +2,8 @@
 name: dd-logs
 description: Log management - search, pipelines, archives, and cost control.
 version: 1.0.0
-author: dd-skill-test
-repository: https://github.com/dd-skill-test/dd-skills
+author: datadog-labs
+repository: https://github.com/datadog-labs/dd-skills
 tags:
   - datadog
   - logs

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: dd-logs
+description: Log management - search, pipelines, archives, and cost control.
+version: 1.0.0
+author: dd-skill-test
+repository: https://github.com/dd-skill-test/dd-skills
+tags:
+  - datadog
+  - logs
+  - logging
+  - search
+  - dd-logs
+globs:
+  - "**/datadog*.yaml"
+  - "**/*log*"
+alwaysApply: false
+---
+
+# Datadog Logs
+
+Search, process, and archive logs with cost awareness.
+
+## Prerequisites
+
+Datadog Pup (dd-pup/pup) should already be installed.
+
+## Quick Start
+
+```bash
+pup auth login
+# or: 
+# export DD_API_KEY=your-api-key
+# export DD_APP_KEY=your-app-key
+# Optional: export DD_SITE=datadoghq.eu  # For EU region
+```
+
+## Search Logs
+
+```bash
+# Basic search
+pup logs search "status:error" --from -1h
+
+# With filters
+pup logs search "service:api status:error" --from -1h --limit 100
+
+# JSON output
+pup logs search "@http.status_code:>=500" --from -1h --json
+```
+
+### Search Syntax
+
+| Query | Meaning |
+|-------|---------|
+| `error` | Full-text search |
+| `status:error` | Tag equals |
+| `@http.status_code:500` | Attribute equals |
+| `@http.status_code:>=400` | Numeric range |
+| `service:api AND env:prod` | Boolean |
+| `@message:*timeout*` | Wildcard |
+
+## Pipelines
+
+Process logs before indexing:
+
+```bash
+# List pipelines
+pup logs pipelines list
+
+# Create pipeline (JSON)
+pup logs pipelines create --json @pipeline.json
+```
+
+### Common Processors
+
+```json
+{
+  "name": "API Logs",
+  "filter": {"query": "service:api"},
+  "processors": [
+    {
+      "type": "grok-parser",
+      "name": "Parse nginx",
+      "source": "message",
+      "grok": {"match_rules": "%{IPORHOST:client_ip} %{DATA:method} %{DATA:path} %{NUMBER:status}"}
+    },
+    {
+      "type": "status-remapper",
+      "name": "Set severity",
+      "sources": ["level", "severity"]
+    },
+    {
+      "type": "attribute-remapper",
+      "name": "Remap user_id",
+      "sources": ["user_id"],
+      "target": "usr.id"
+    }
+  ]
+}
+```
+
+## ⚠️ Exclusion Filters (Cost Control)
+
+**Index only what matters:**
+
+```json
+{
+  "name": "Drop debug logs",
+  "filter": {"query": "status:debug"},
+  "is_enabled": true
+}
+```
+
+### High-Volume Exclusions
+
+```bash
+# Find noisiest log sources
+pup logs search "*" --from -1h --json | jq 'group_by(.service) | map({service: .[0].service, count: length}) | sort_by(-.count)[:10]'
+```
+
+| Exclude | Query |
+|---------|-------|
+| Health checks | `@http.url:"/health" OR @http.url:"/ready"` |
+| Debug logs | `status:debug` |
+| Static assets | `@http.url:*.css OR @http.url:*.js` |
+| Heartbeats | `@message:*heartbeat*` |
+
+## Archives
+
+Store logs cheaply for compliance:
+
+```bash
+# List archives
+pup logs archives list
+
+# Archive config (S3 example)
+{
+  "name": "compliance-archive",
+  "query": "*",
+  "destination": {
+    "type": "s3",
+    "bucket": "my-logs-archive",
+    "path": "/datadog"
+  },
+  "rehydration_tags": ["team:platform"]
+}
+```
+
+### Rehydrate (Restore)
+
+```bash
+# Rehydrate archived logs
+pup logs rehydrate create \
+  --archive-id abc123 \
+  --from "2024-01-01T00:00:00Z" \
+  --to "2024-01-02T00:00:00Z" \
+  --query "service:api status:error"
+```
+
+## Log-Based Metrics
+
+Create metrics from logs (cheaper than indexing):
+
+```bash
+# Count errors per service
+pup logs metrics create \
+  --name "api.errors.count" \
+  --query "service:api status:error" \
+  --group-by "endpoint"
+```
+
+**⚠️ Cardinality warning:** Group by bounded values only.
+
+## Sensitive Data
+
+### Scrubbing Rules
+
+```json
+{
+  "type": "hash-remapper",
+  "name": "Hash emails",
+  "sources": ["email", "@user.email"]
+}
+```
+
+### Never Log
+
+```python
+# In your app - sanitize before sending
+import re
+
+def sanitize_log(message: str) -> str:
+    # Remove credit cards
+    message = re.sub(r'\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b', '[REDACTED]', message)
+    # Remove SSNs
+    message = re.sub(r'\b\d{3}-\d{2}-\d{4}\b', '[REDACTED]', message)
+    return message
+```
+
+## Terminal Sparklines
+
+Log volume and error trends:
+
+```bash
+# Log volume
+python3 scripts/sparkline.py --metric "sum:datadog.estimated_usage.logs.ingested_bytes{*}" --hours 24
+
+# Error log rate
+python3 scripts/sparkline.py --metric "sum:log.error{*}.as_rate()" --hours 1
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Logs not appearing | Check agent, pipeline filters |
+| High costs | Add exclusion filters |
+| Search slow | Narrow time range, use indexes |
+| Missing attributes | Check grok parser |
+
+## References/Documentation
+
+- [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/)
+- [Pipelines](https://docs.datadoghq.com/logs/log_configuration/pipelines/)
+- [Exclusion Filters](https://docs.datadoghq.com/logs/indexes/#exclusion-filters)
+- [Archives](https://docs.datadoghq.com/logs/archives/)
+

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -4,7 +4,7 @@ description: Log management - search, pipelines, archives, and cost control.
 metadata:
   version: "1.0.0"
   author: datadog-labs
-  repository: https://github.com/datadog-labs/dd-skills
+  repository: https://github.com/datadog-labs/agent-skills
   tags: datadog,logs,logging,search,dd-logs
   globs: "**/datadog*.yaml,**/*log*"
   alwaysApply: "false"

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -190,18 +190,6 @@ def sanitize_log(message: str) -> str:
     return message
 ```
 
-## Terminal Sparklines
-
-Log volume and error trends:
-
-```bash
-# Log volume
-python3 scripts/sparkline.py --metric "sum:datadog.estimated_usage.logs.ingested_bytes{*}" --hours 24
-
-# Error log rate
-python3 scripts/sparkline.py --metric "sum:log.error{*}.as_rate()" --hours 1
-```
-
 ## Troubleshooting
 
 | Problem | Fix |

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -1,19 +1,13 @@
 ---
 name: dd-logs
 description: Log management - search, pipelines, archives, and cost control.
-version: 1.0.0
-author: datadog-labs
-repository: https://github.com/datadog-labs/dd-skills
-tags:
-  - datadog
-  - logs
-  - logging
-  - search
-  - dd-logs
-globs:
-  - "**/datadog*.yaml"
-  - "**/*log*"
-alwaysApply: false
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/dd-skills
+  tags: datadog,logs,logging,search,dd-logs
+  globs: "**/datadog*.yaml,**/*log*"
+  alwaysApply: "false"
 ---
 
 # Datadog Logs

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -32,13 +32,13 @@ pup auth login
 
 ```bash
 # Basic search
-pup logs search "status:error" --from -1h
+pup logs search --query="status:error" --from="1h"
 
 # With filters
-pup logs search "service:api status:error" --from -1h --limit 100
+pup logs search --query="service:api status:error" --from="1h" --limit 100
 
 # JSON output
-pup logs search "@http.status_code:>=500" --from -1h --json
+pup logs search --query="@http.status_code:>=500" --from="1h" --json
 ```
 
 ### Search Syntax
@@ -108,7 +108,7 @@ pup logs pipelines create --json @pipeline.json
 
 ```bash
 # Find noisiest log sources
-pup logs search "*" --from -1h --json | jq 'group_by(.service) | map({service: .[0].service, count: length}) | sort_by(-.count)[:10]'
+pup logs search --query="*" --from="1h" --json | jq 'group_by(.service) | map({service: .[0].service, count: length}) | sort_by(-.count)[:10]'
 ```
 
 | Exclude | Query |

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -58,11 +58,14 @@ pup monitors create \
 ### Mute/Unmute
 
 ```bash
-# Mute with end time (REQUIRED)
-pup monitors mute <id> --end "2024-01-15T18:00:00Z"
+# Mute with duration
+pup monitors mute --id 12345 --duration 1h
+
+# Or mute with specific end time
+pup monitors mute --id 12345 --end "2024-01-15T18:00:00Z"
 
 # Unmute
-pup monitors unmute <id>
+pup monitors unmute --id 12345
 ```
 
 ## ⚠️ Monitor Creation Best Practices

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -2,7 +2,7 @@
 name: dd-monitors
 description: Monitor management - create, update, mute, and alerting best practices.
 version: 1.0.0
-author: dd-skill-test
+author: datadog-labs
 repository: https://github.com/datadog-labs/agent-skills
 tags:
   - datadog

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: dd-monitors
+description: Monitor management - create, update, mute, and alerting best practices.
+version: 1.0.0
+author: dd-skill-test
+repository: https://github.com/datadog-ai-labs/agent-skills
+tags:
+  - datadog
+  - monitors
+  - alerting
+  - alerts
+  - dd-monitors
+globs:
+  - "**/datadog*.yaml"
+  - "**/*monitor*"
+alwaysApply: false
+---
+
+# Datadog Monitors
+
+Create, manage, and maintain monitors for alerting.
+
+
+## Prerequisites
+This requires Go or the pup binary in your path. 
+
+`pup` - `go install github.com/DataDog/pup@latest`
+Or ensure `~/go/bin` is in `$PATH`.
+
+
+## Quick Start
+
+```bash
+pup auth login
+# or: export DD_API_KEY=xxx && export DD_APP_KEY=xxx
+```
+
+## Common Operations
+
+### List Monitors
+
+```bash
+pup monitors list
+pup monitors list --tags "team:platform"
+pup monitors list --status "Alert"
+```
+
+### Get Monitor
+
+```bash
+pup monitors get <id> --json
+```
+
+### Create Monitor
+
+```bash
+pup monitors create \
+  --name "High CPU on web servers" \
+  --type "metric alert" \
+  --query "avg(last_5m):avg:system.cpu.user{env:prod} > 80" \
+  --message "CPU above 80% @slack-ops"
+```
+
+### Mute/Unmute
+
+```bash
+# Mute with end time (REQUIRED)
+pup monitors mute <id> --end "2024-01-15T18:00:00Z"
+
+# Unmute
+pup monitors unmute <id>
+```
+
+## ⚠️ Monitor Creation Best Practices
+
+### 1. Avoid Alert Fatigue
+
+| Rule | Why |
+|------|-----|
+| **No flapping alerts** | Use `last_Xm` not `last_1m` |
+| **Meaningful thresholds** | Based on SLOs, not guesses |
+| **Actionable alerts** | If no action needed, don't alert |
+| **Include runbook** | `@runbook-url` in message |
+
+```python
+# WRONG - will flap constantly
+query = "avg(last_1m):avg:system.cpu.user{*} > 50"  # ❌ Too sensitive
+
+# CORRECT - stable alerting
+query = "avg(last_5m):avg:system.cpu.user{env:prod} by {host} > 80"  # ✅ Reasonable window
+```
+
+### 2. Use Proper Scoping
+
+```python
+# WRONG - alerts on everything
+query = "avg(last_5m):avg:system.cpu.user{*} > 80"  # ❌ No scope
+
+# CORRECT - scoped to what matters
+query = "avg(last_5m):avg:system.cpu.user{env:prod,service:api} by {host} > 80"  # ✅
+```
+
+### 3. Set Recovery Thresholds
+
+```python
+monitor = {
+    "query": "avg(last_5m):avg:system.cpu.user{env:prod} > 80",
+    "options": {
+        "thresholds": {
+            "critical": 80,
+            "critical_recovery": 70,  # ✅ Prevents flapping
+            "warning": 60,
+            "warning_recovery": 50
+        }
+    }
+}
+```
+
+### 4. Include Context in Messages
+
+```python
+message = """
+## High CPU Alert
+
+Host: {{host.name}}
+Current Value: {{value}}
+Threshold: {{threshold}}
+
+### Runbook
+1. Check top processes: `ssh {{host.name}} 'top -bn1 | head -20'`
+2. Check recent deploys
+3. Scale if needed
+
+@slack-ops @pagerduty-oncall
+"""
+```
+
+## ⚠️ NEVER Delete Monitors Directly
+
+Use safe deletion workflow (same as dashboards):
+
+```python
+def safe_mark_monitor_for_deletion(monitor_id: str, client) -> bool:
+    """Mark monitor instead of deleting."""
+    monitor = client.get_monitor(monitor_id)
+    name = monitor.get("name", "")
+    
+    if "[MARKED FOR DELETION]" in name:
+        print(f"Already marked: {name}")
+        return False
+    
+    new_name = f"[MARKED FOR DELETION] {name}"
+    client.update_monitor(monitor_id, {"name": new_name})
+    print(f"✓ Marked: {new_name}")
+    return True
+```
+
+## Monitor Types
+
+| Type | Use Case |
+|------|----------|
+| `metric alert` | CPU, memory, custom metrics |
+| `query alert` | Complex metric queries |
+| `service check` | Agent check status |
+| `event alert` | Event stream patterns |
+| `log alert` | Log pattern matching |
+| `composite` | Combine multiple monitors |
+| `apm` | APM metrics |
+
+## Audit Monitors
+
+```bash
+# Find monitors without owners
+pup monitors list --json | jq '.[] | select(.tags | contains(["team:"]) | not) | {id, name}'
+
+# Find noisy monitors (high alert count)
+pup monitors list --json | jq 'sort_by(.overall_state_modified) | .[:10] | .[] | {id, name, status: .overall_state}'
+```
+
+## Downtime vs Muting
+
+| Use | When |
+|-----|------|
+| **Mute monitor** | Quick one-off, < 1 hour |
+| **Downtime** | Scheduled maintenance, recurring |
+
+```bash
+# Downtime (preferred)
+pup downtime create \
+  --scope "env:prod" \
+  --monitor-tags "team:platform" \
+  --start "2024-01-15T02:00:00Z" \
+  --end "2024-01-15T06:00:00Z"
+```
+
+## Failure Handling
+
+| Problem | Fix |
+|---------|-----|
+| Alert not firing | Check query returns data, thresholds |
+| Too many alerts | Increase window, add recovery threshold |
+| No data alerts | Check agent connectivity, metric exists |
+| Auth error | `pup auth refresh` |
+
+## References
+
+- [Monitor Types](https://docs.datadoghq.com/monitors/types/)
+- [Alerting Best Practices](https://docs.datadoghq.com/monitors/guide/)
+- [SLO Monitors](https://docs.datadoghq.com/service_management/service_level_objectives/)
+

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -1,19 +1,13 @@
 ---
 name: dd-monitors
 description: Monitor management - create, update, mute, and alerting best practices.
-version: 1.0.0
-author: datadog-labs
-repository: https://github.com/datadog-labs/agent-skills
-tags:
-  - datadog
-  - monitors
-  - alerting
-  - alerts
-  - dd-monitors
-globs:
-  - "**/datadog*.yaml"
-  - "**/*monitor*"
-alwaysApply: false
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,monitors,alerting,alerts,dd-monitors
+  globs: "**/datadog*.yaml,**/*monitor*"
+  alwaysApply: "false"
 ---
 
 # Datadog Monitors

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -3,7 +3,7 @@ name: dd-monitors
 description: Monitor management - create, update, mute, and alerting best practices.
 version: 1.0.0
 author: dd-skill-test
-repository: https://github.com/datadog-ai-labs/agent-skills
+repository: https://github.com/datadog-labs/agent-skills
 tags:
   - datadog
   - monitors

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -1,7 +1,9 @@
 ---
-name: pup
+name: dd-pup
 description: Datadog CLI (Go). OAuth2 auth with token refresh.
 version: 1.0.0
+author: datadog-labs
+repository: https://github.com/datadog-labs/agent-skills
 tags:
   - datadog
   - cli

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -161,9 +161,9 @@ pup events post --title "Deploy started" --text "v1.2.3" --tags "env:prod"
 
 ### Downtimes
 ```bash
-pup downtimes list
-pup downtimes create --scope "env:staging" --duration 2h --message "Maintenance"
-pup downtimes cancel --id 12345
+pup downtime list
+pup downtime create --scope "env:staging" --duration 2h --message "Maintenance"
+pup downtime cancel --id 12345
 ```
 
 ### Users / Teams

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: dd-pup
 description: Datadog CLI (Go). OAuth2 auth with token refresh.
-version: 1.0.0
-author: datadog-labs
-repository: https://github.com/datadog-labs/agent-skills
-tags:
-  - datadog
-  - cli
-  - dd-pup
-  - pup
-alwaysApply: false
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,cli,dd-pup,pup
+  alwaysApply: "false"
 ---
 
 # pup (Datadog CLI)

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -20,7 +20,7 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 | Search error logs | `pup logs search --query "status:error" --duration 1h` |
 | List monitors | `pup monitors list` |
 | Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
-| Find slow traces | `pup traces search --service api --min-duration 500ms` |
+| Find slow traces | `pup apm traces list --service api --min-duration 500ms` |
 | List active incidents | `pup incidents list --status active` |
 | Create incident | `pup incidents create --title "Issue" --severity SEV-2` |
 | Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
@@ -100,10 +100,10 @@ pup metrics list --filter "system.*"
 ### APM / Traces
 ```bash
 pup apm services list
-pup traces search --service my-service --duration 1h
-pup traces search --service api --min-duration 500ms --duration 1h
-pup traces search --service api --status error --duration 1h
-pup traces get --trace-id abc123
+pup apm traces list --service my-service --duration 1h
+pup apm traces list --service api --min-duration 500ms --duration 1h
+pup apm traces list --service api --status error --duration 1h
+pup apm traces get <trace_id>
 ```
 
 ### Incidents

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -103,7 +103,7 @@ pup apm services list
 pup apm traces list --service my-service --duration 1h
 pup apm traces list --service api --min-duration 500ms --duration 1h
 pup apm traces list --service api --status error --duration 1h
-pup apm traces get <trace_id>
+pup apm traces get abc123def456
 ```
 
 ### Incidents

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: pup
+description: Datadog CLI (Go). OAuth2 auth with token refresh.
+version: 1.0.0
+tags:
+  - datadog
+  - cli
+  - dd-pup
+  - pup
+alwaysApply: false
+---
+
+# pup (Datadog CLI)
+
+Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Search error logs | `pup logs search --query "status:error" --duration 1h` |
+| List monitors | `pup monitors list` |
+| Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
+| Find slow traces | `pup traces search --service api --min-duration 500ms` |
+| List active incidents | `pup incidents list --status active` |
+| Create incident | `pup incidents create --title "Issue" --severity SEV-2` |
+| Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
+| List hosts | `pup hosts list` |
+| Check SLOs | `pup slos list` |
+| Who's on call | `pup on-call who --team my-team` |
+| Security signals | `pup security signals list --severity critical` |
+| Check auth | `pup auth status` |
+| Refresh token | `pup auth refresh` |
+
+## Prerequisites
+
+```bash
+# Install pup
+go install github.com/DataDog/pup@latest
+export PATH="$HOME/go/bin:$PATH"
+
+# For headless/CI environments
+export DD_API_KEY=your-api-key
+export DD_APP_KEY=your-app-key
+export DD_SITE=datadoghq.com  # Optional: datadoghq.eu, us3.datadoghq.com, etc.
+```
+
+## Auth
+
+```bash
+pup auth login          # OAuth2 browser flow (recommended)
+pup auth status         # Check token validity
+pup auth refresh        # Refresh expired token (no browser)
+pup auth logout         # Clear credentials
+```
+
+**⚠️ Tokens expire (~1 hour)**. If a command fails with 401/403 mid-conversation:
+
+```bash
+pup auth refresh        # Try refresh first
+pup auth login          # If refresh fails, full re-auth
+```
+
+### Headless/CI (no browser)
+
+```bash
+export DD_API_KEY=your-api-key
+export DD_APP_KEY=your-app-key
+export DD_SITE=datadoghq.com    # or datadoghq.eu, etc.
+```
+
+## Command Reference
+
+### Monitors
+```bash
+pup monitors list --limit 10
+pup monitors list --tags "env:prod"
+pup monitors get --id 12345
+pup monitors mute --id 12345 --duration 1h
+pup monitors unmute --id 12345
+pup monitors create --name "High CPU" --type "metric alert" \
+  --query "avg(last_5m):avg:system.cpu.user{*} > 80" \
+  --message "CPU high @slack-ops"
+```
+
+### Logs
+```bash
+pup logs search --query "status:error" --duration 1h
+pup logs search --query "service:payment-api" --duration 1h --limit 100
+pup logs search --query "@http.status_code:5*" --duration 24h
+pup logs search --query "env:prod level:error" --duration 1h --json
+```
+
+### Metrics
+```bash
+pup metrics query --query "avg:system.cpu.user{*}" --duration 1h
+pup metrics query --query "sum:trace.express.request.hits{service:api}" --duration 1h
+pup metrics list --filter "system.*"
+```
+
+### APM / Traces
+```bash
+pup apm services list
+pup traces search --service my-service --duration 1h
+pup traces search --service api --min-duration 500ms --duration 1h
+pup traces search --service api --status error --duration 1h
+pup traces get --trace-id abc123
+```
+
+### Incidents
+```bash
+pup incidents list --status active
+pup incidents list --status resolved --duration 7d
+pup incidents create --title "API Degradation" --severity SEV-2
+pup incidents update --id abc-123 --status stable
+pup incidents resolve --id abc-123
+```
+
+### Dashboards
+```bash
+pup dashboards list
+pup dashboards list --tags "team:platform"
+pup dashboards get --id abc-123
+pup dashboards create --title "My Dashboard" --description "..." --widgets '[...]'
+```
+
+### SLOs
+```bash
+pup slos list
+pup slos get --id slo-123
+pup slos history --id slo-123 --duration 30d
+```
+
+### Synthetics
+```bash
+pup synthetics list
+pup synthetics results --test-id abc-123
+pup synthetics trigger --test-id abc-123
+```
+
+### On-Call
+```bash
+pup on-call teams list
+pup on-call schedules list
+pup on-call who --team platform-team
+```
+
+### Hosts / Infrastructure
+```bash
+pup hosts list --limit 50
+pup hosts list --filter "env:prod"
+pup hosts mute --hostname web-01 --duration 1h
+pup hosts get --hostname web-01
+```
+
+### Events
+```bash
+pup events list --duration 24h
+pup events list --tags "source:deploy"
+pup events post --title "Deploy started" --text "v1.2.3" --tags "env:prod"
+```
+
+### Downtimes
+```bash
+pup downtimes list
+pup downtimes create --scope "env:staging" --duration 2h --message "Maintenance"
+pup downtimes cancel --id 12345
+```
+
+### Users / Teams
+```bash
+pup users list
+pup teams list
+```
+
+### Security
+```bash
+pup security signals list --duration 24h
+pup security signals list --severity critical
+```
+
+### Service Catalog
+```bash
+pup services list
+pup services get --name payment-api
+```
+
+### Notebooks
+```bash
+pup notebooks list
+pup notebooks get --id 12345
+```
+
+### Workflows
+```bash
+pup workflows list
+pup workflows trigger --id workflow-123 --input '{"key": "value"}'
+```
+
+## Subcommand Discovery
+
+```bash
+pup --help              # List all commands
+pup <command> --help    # Command-specific help
+```
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| 401 Unauthorized | Token expired | `pup auth refresh` |
+| 403 Forbidden | Missing scope | Check app key permissions |
+| 404 Not Found | Wrong ID/resource | Verify resource exists |
+| Rate limited | Too many requests | Add delays between calls |
+
+## Install
+
+```bash
+go install github.com/DataDog/pup@latest
+```
+
+### Verify Installation
+
+```bash
+# Check if pup is in PATH
+which pup
+
+# If not found, check if it was installed
+ls ~/go/bin/pup
+```
+
+### PATH Troubleshooting
+
+If `pup` is installed but `which pup` returns nothing, Go's bin directory isn't in your PATH.
+
+**Check where pup is:**
+```bash
+ls ~/go/bin/pup           # Standard location
+ls $GOPATH/bin/pup        # If GOPATH is set
+ls $GOBIN/pup             # If GOBIN is set
+```
+
+**Add to PATH (pick your shell):**
+
+For **zsh** (macOS default):
+```bash
+# Add this line to ~/.zshrc
+export PATH="$HOME/go/bin:$PATH"
+
+# Then reload
+source ~/.zshrc
+```
+
+For **bash**:
+```bash
+# Add this line to ~/.bashrc or ~/.bash_profile
+export PATH="$HOME/go/bin:$PATH"
+
+# Then reload
+source ~/.bashrc
+```
+
+For **fish**:
+```fish
+# Add this line to ~/.config/fish/config.fish
+fish_add_path $HOME/go/bin
+
+# Or set permanently
+set -Ux fish_user_paths $HOME/go/bin $fish_user_paths
+
+# Then reload
+source ~/.config/fish/config.fish
+```
+
+**Verify:**
+```bash
+which pup        # Should show path
+pup --version    # Should show version
+```
+
+### Alternative: Full Path
+
+If you don't want to modify PATH, use the full path:
+```bash
+~/go/bin/pup auth login
+~/go/bin/pup monitors list
+```
+
+Or create an alias:
+```bash
+alias pup="$HOME/go/bin/pup"
+```
+
+## Sites
+
+| Site | `DD_SITE` value |
+|------|-----------------|
+| US1 (default) | `datadoghq.com` |
+| US3 | `us3.datadoghq.com` |
+| US5 | `us5.datadoghq.com` |
+| EU1 | `datadoghq.eu` |
+| AP1 | `ap1.datadoghq.com` |
+| US1-FED | `ddog-gov.com` |
+


### PR DESCRIPTION
This pull request adds docs and skill definitions for Datadog agent skills, targeting AI agents and developers. It adds skill guides for Datadog's CLI (`pup`), monitors, logs, APM, and documentation lookup, as well as installation instructions and best practices. 

**Core skill documentation and onboarding:**

* Added a detailed `README.md` outlining the five essential Datadog skills for AI agents, installation steps, quick reference commands, and authentication instructions.
* Introduced a top-level `SKILL.md` describing the agent-skills package, core skills, prerequisites, installation, and quick reference for Datadog operations.
* Added a `LICENSE` file specifying the MIT license for the project.

**Individual skill guides:**

* Created `dd-apm/SKILL.md` with instructions for distributed tracing, service maps, trace search, retention, SLO integration, troubleshooting, and best practices for Datadog APM.
* Added `dd-monitors/SKILL.md` covering monitor management, alerting best practices, safe deletion workflow, types of monitors, audit commands, downtime vs muting, and troubleshooting.
* Added `dd-logs/SKILL.md` providing guidance on log search, pipelines, exclusion filters for cost control, archives, log-based metrics, sensitive data scrubbing, and troubleshooting.
* Introduced `dd-docs/SKILL.md` for Datadog documentation lookup, including usage of the LLM-optimized `llms.txt` index, doc search strategies, scope guardrails, and failure handling.
