### PR TITLE
Added instructions for connecting to Datadog MCP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ npx skills add datadog-labs/agent-skills \
   --full-depth -y
 ```
 
+### LLM Observability 
+
+For llmo skills, copy the relevant skill directories from dd-llmo to their local home. 
+Ex - for Claude Code cp -r dd-llmo/experiment-analyzer ~/.claude/skills
+
+These have a dependency on the llmo toolset in the Datadog MCP server. The easiest way to add it is:
+
+claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'
+
+This will add it as an independent MCP server from the core datadog MCP tools. 
+
+If you'd like the ability to export results to a Datadog notebook, also install the core MCP tools. 
+
+claude mcp add --scope user --transport http "datadog-mcp-core" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core'
+
 ## Quick Reference
 
 | Task | Command |


### PR DESCRIPTION
LLMO MCP tools are needed for the skill to work at all. Optionally, Datadog core MCP tools get notebook skills, which are very useful for piping the output to a DD notebook.