### PR TITLE
Update pup install instructions for Rust-based CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,19 @@
 ### Setup Pup
 
 ```bash
-# Install pup CLI
-go install github.com/datadog-labs/pup@latest
-export PATH="$HOME/go/bin:$PATH"
+# Homebrew (macOS/Linux) — recommended
+brew tap datadog-labs/pack
+brew install datadog-labs/pack/pup
 
+# Or build from source
+git clone https://github.com/datadog-labs/pup.git && cd pup
+cargo build --release
+cp target/release/pup /usr/local/bin/pup
+```
+
+Pre-built binaries are also available from the [latest release](https://github.com/datadog-labs/pup/releases/latest).
+
+```bash
 # Authenticate
 pup auth login
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,14 +35,7 @@ npx skills add datadog-labs/agent-skills \
 
 ## Prerequisites
 
-```bash
-# Install pup CLI
-go install github.com/DataDog/pup@latest
-export PATH="$HOME/go/bin:$PATH"
-
-# Authenticate
-pup auth login
-```
+See [Setup Pup](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup) for installation and authentication.
 
 ## Quick Reference
 

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -16,11 +16,7 @@ Distributed tracing, service maps, and performance analysis.
 
 ## Requirements
 
-Datadog Labs Pup should be installed via:
-
-```bash
-go install github.com/datadog-labs/pup@latest
-```
+Datadog Labs Pup should be installed. See [Setup Pup](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup) if not.
 
 ## Quick Start
 

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -16,11 +16,7 @@ Search, process, and archive logs with cost awareness.
 
 ## Prerequisites
 
-Datadog Pup (dd-pup/pup) should already be installed:
-
-```bash
-go install github.com/datadog-labs/pup@latest
-```
+Datadog Pup should already be installed. See [Setup Pup](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup) if not.
 
 ## Quick Start
 

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -16,10 +16,7 @@ Create, manage, and maintain monitors for alerting.
 
 
 ## Prerequisites
-This requires Go or the pup binary in your path. 
-
-`pup` - `go install github.com/datadog-labs/pup@latest`
-Ensure `~/go/bin` is in `$PATH`.
+This requires pup in your path. See [Setup Pup](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup).
 
 
 ## Quick Start

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -33,11 +33,7 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 
 ## Prerequisites
 
-```bash
-# Install pup
-go install github.com/datadog-labs/pup@latest
-export PATH="$HOME/go/bin:$PATH"
-```
+Install pup using the [setup instructions](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup).
 
 ## Auth
 
@@ -210,80 +206,13 @@ pup <command> --help    # Command-specific help
 
 ## Install
 
-```bash
-go install github.com/DataDog/pup@latest
-```
+See [Setup Pup](https://github.com/datadog-labs/agent-skills/tree/main?tab=readme-ov-file#setup-pup) for installation instructions.
 
 ### Verify Installation
 
 ```bash
-# Check if pup is in PATH
 which pup
-
-# If not found, check if it was installed
-ls ~/go/bin/pup
-```
-
-### PATH Troubleshooting
-
-If `pup` is installed but `which pup` returns nothing, Go's bin directory isn't in your PATH.
-
-**Check where pup is:**
-```bash
-ls ~/go/bin/pup           # Standard location
-ls $GOPATH/bin/pup        # If GOPATH is set
-ls $GOBIN/pup             # If GOBIN is set
-```
-
-**Add to PATH (pick your shell):**
-
-For **zsh** (macOS default):
-```bash
-# Add this line to ~/.zshrc
-export PATH="$HOME/go/bin:$PATH"
-
-# Then reload
-source ~/.zshrc
-```
-
-For **bash**:
-```bash
-# Add this line to ~/.bashrc or ~/.bash_profile
-export PATH="$HOME/go/bin:$PATH"
-
-# Then reload
-source ~/.bashrc
-```
-
-For **fish**:
-```fish
-# Add this line to ~/.config/fish/config.fish
-fish_add_path $HOME/go/bin
-
-# Or set permanently
-set -Ux fish_user_paths $HOME/go/bin $fish_user_paths
-
-# Then reload
-source ~/.config/fish/config.fish
-```
-
-**Verify:**
-```bash
-which pup        # Should show path
-pup --version    # Should show version
-```
-
-### Alternative: Full Path
-
-If you don't want to modify PATH, use the full path:
-```bash
-~/go/bin/pup auth login
-~/go/bin/pup monitors list
-```
-
-Or create an alias:
-```bash
-alias pup="$HOME/go/bin/pup"
+pup --version
 ```
 
 ## Sites


### PR DESCRIPTION
## Summary
- Replace old Go-based `go install` instructions with Homebrew (recommended) and build-from-source via Cargo
- Add link to pre-built binaries from the latest GitHub release

## Test plan
- [x] Verify Homebrew install commands work: `brew tap datadog-labs/pack && brew install datadog-labs/pack/pup`
- [x] Verify release binaries link resolves: https://github.com/datadog-labs/pup/releases/latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)