### PR TITLE
feat(dd-apm): add k8s SSI onboarding skill suite

### DIFF
--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: dd-apm-k8s-agent-install
+description: Install the Datadog Agent on Kubernetes using the Datadog Operator. Covers Operator install, API key setup, DatadogAgent CR deployment, and key verification.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,agent,operator,install
+  alwaysApply: "false"
+---
+
+# Install the Datadog Agent on Kubernetes
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Install or set up the Datadog Agent on a Kubernetes cluster
+- Deploy the Datadog Operator or a `DatadogAgent` custom resource
+- Get Datadog running on Kubernetes before enabling any product
+
+Do NOT invoke this skill if:
+- The Agent is already deployed — confirm with Step 1 first
+- The user only wants APM and the Agent is confirmed healthy — use `enable-ssi`
+
+---
+
+## Prerequisites
+
+- [ ] Kubernetes v1.20+ — `kubectl version`
+- [ ] helm v3+ — `helm version`
+- [ ] kubectl configured to target cluster — `kubectl config current-context`
+- [ ] User has a Datadog API key for the correct org and site
+- [ ] pup-cli installed — check with `pup --version`; if missing, install with `brew tap datadog-labs/pack && brew install pup`
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `CLUSTER_NAME` | Check repo IaC, scripts, or `kubectl config current-context` |
+| `DD_SITE` | Ask the user. Default: `datadoghq.com`. Options: `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com` |
+| `AGENT_NAMESPACE` | Use `datadog` unless the repo already uses `datadog-agent` consistently |
+| `CHART_VERSION` | Run `helm search repo datadog/datadog-operator --versions \| head -5` and use the latest stable |
+
+---
+
+## Step 1: Check for an Existing Agent Installation
+
+### Claude runs
+
+```bash
+helm list -A | grep -i datadog
+```
+
+✅ A release shows `deployed` — Agent already installed. Skip to Step 5 to confirm health, then exit.
+
+✅ No output — no existing install. Continue to Step 2.
+
+---
+
+## Step 2: Install the Datadog Operator
+
+### Claude runs
+
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm upgrade --install datadog-operator datadog/datadog-operator \
+  --namespace <AGENT_NAMESPACE> \
+  --create-namespace \
+  --version <CHART_VERSION>
+
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=datadog-operator \
+  -n <AGENT_NAMESPACE> \
+  --timeout=120s
+```
+
+✅ Operator pod is Running.
+
+❌ Pod not ready after 120s — check image pull: `kubectl describe pod -l app.kubernetes.io/name=datadog-operator -n <AGENT_NAMESPACE>`.
+
+---
+
+## Step 3: Create the API Key Secret
+
+### What you need to do in a terminal
+
+```bash
+export DD_API_KEY=<your-api-key>
+
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=$DD_API_KEY \
+  --namespace <AGENT_NAMESPACE>
+```
+
+✅ `secret/datadog-secret created`
+
+❌ `AlreadyExists` — confirm which key it holds via Step 5 before deciding whether to recreate.
+
+---
+
+## Step 4: Deploy the DatadogAgent Resource
+
+[DECISION: cluster type]
+- Self-hosted (minikube, kind): include `kubelet.tlsVerify: false` inside `spec.global`
+- Managed (GKE, EKS, AKS): omit `kubelet.tlsVerify` entirely
+
+[DECISION: APM/SSI also being enabled in this session]
+- If yes: do not create a separate `DatadogAgent` for APM — extend this same manifest with `features.apm` per `enable-ssi`. One manifest, not two.
+- If no: use the manifest below as-is.
+
+Save the following as `datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  namespace: <AGENT_NAMESPACE>
+spec:
+  global:
+    clusterName: <CLUSTER_NAME>
+    site: <DD_SITE>
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+    # Self-hosted clusters only (minikube, kind):
+    # kubelet:
+    #   tlsVerify: false
+  features:
+    orchestratorExplorer:
+      enabled: true
+    clusterChecks:
+      enabled: true
+    logCollection:
+      enabled: true
+      containerCollectAll: false
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/component=agent \
+  -n <AGENT_NAMESPACE> \
+  --timeout=120s 2>/dev/null || true
+```
+
+---
+
+## Step 5: Verify the API Key
+
+### Claude runs
+
+```bash
+kubectl logs -l app.kubernetes.io/component=agent \
+  -n <AGENT_NAMESPACE> \
+  --tail=50 2>/dev/null \
+  | grep -iE "invalid.*api\.?key|api\.?key.*invalid" \
+  || echo "No authentication errors found"
+```
+
+✅ `No authentication errors found` — key is accepted.
+
+❌ Authentication errors found — validate the key directly:
+
+### Claude runs
+
+```bash
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X GET "https://api.<DD_SITE>/api/v1/validate" \
+  -H "DD-API-KEY: $DD_API_KEY")
+
+if [ "$RESPONSE" = "200" ]; then
+  echo "✅ API key is valid for <DD_SITE>"
+else
+  echo "❌ Validation failed (HTTP $RESPONSE) — check key and site alignment"
+fi
+```
+
+If key is invalid:
+
+### What you need to do in a terminal
+
+```bash
+export DD_API_KEY=<new-api-key>
+
+kubectl delete secret datadog-secret -n <AGENT_NAMESPACE>
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=$DD_API_KEY \
+  -n <AGENT_NAMESPACE>
+
+kubectl rollout restart daemonset datadog-agent -n <AGENT_NAMESPACE>
+kubectl rollout restart deployment datadog-cluster-agent -n <AGENT_NAMESPACE>
+```
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Datadog Operator pod is Running in `AGENT_NAMESPACE`
+- [ ] `datadog-secret` exists in `AGENT_NAMESPACE`
+- [ ] Agent DaemonSet pods are Running
+- [ ] Step 5 returns no authentication errors
+
+Automatically proceed to `enable-ssi` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file, YAML block, or chat message — always use `$DD_API_KEY`
+- Never create a Kubernetes Secret manifest file — always use `kubectl create secret` imperatively
+- Never use `apiKey:` directly in `DatadogAgent` spec — always use `apiSecret:` with a secret reference
+- Never use `--set datadog.apiKey=...` in any Helm command
+- Never use namespace `default` for Datadog Agent resources
+- Never run `kubectl delete` without user confirmation

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: dd-apm-k8s-enable-ssi
+description: Enable APM on Kubernetes via Single Step Instrumentation (SSI). Configures the DatadogAgent CR, adds Unified Service Tags, restarts pods, and triggers verification.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,instrumentation,single-step
+  alwaysApply: "false"
+---
+
+# Enable APM on Kubernetes via Single Step Instrumentation
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 0 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Enable APM on a Kubernetes cluster
+- Instrument Kubernetes applications with Datadog tracing
+- Set up Single Step Instrumentation (SSI)
+
+Do NOT invoke this skill if:
+- The Datadog Agent is not yet installed — run `agent-install` first
+- The user wants to verify SSI after setup — use `verify-ssi`
+- The user wants to enable Profiler, AppSec, or Data Streams — use `dd-apm-k8s-sdk-features`
+
+---
+
+## Prerequisites
+
+**Environment**
+- [ ] Datadog Agent is installed and healthy — `agent-install` complete
+- [ ] Kubernetes v1.20+
+- [ ] Linux node pools only — Windows pods require explicit namespace exclusion
+- [ ] Cluster is not ECS Fargate — unsupported
+- [ ] Not a hardened SELinux environment — unsupported
+- [ ] Not a very small VM instance (e.g. t2.micro) — SSI can hit init timeouts
+- [ ] No PodSecurity baseline or restricted policy enforced
+- [ ] Application container is **not Alpine Linux** — SSI requires glibc; Alpine uses musl libc which is ABI-incompatible. Use `python:3.x-slim`, `node:x-bookworm`, or any Debian/Ubuntu-based image
+
+**Language and runtime**
+- [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
+- [ ] Runtime version is within SSI's supported range — verify against the [SSI compatibility matrix](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/)
+- [ ] Node.js app is not using ESM — SSI does not support ESM
+- [ ] Java app is not already using a `-javaagent` JVM flag
+
+**Existing instrumentation**
+- [ ] Application has no existing `ddtrace` imports, OTel SDK calls, or custom `tracer.trace()` calls — SSI silently disables itself when detected; complete Step 0 first
+- [ ] `ddtrace` is not listed in the app's dependency manifest (`requirements.txt`, `package.json`, `Gemfile`, etc.) — SSI installs the tracer automatically
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Same namespace used in `agent-install` (e.g. `datadog`) |
+| `APP_NAMESPACE` | Ask the user which namespace their application runs in |
+| `TARGET_LANGUAGES` | Identify from repo — check Dockerfiles, package manifests, or ask the user |
+| `DEPLOYMENT_NAME` | Identify from repo or ask the user |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+| `CLUSTER_NAME` | Check `spec.global.clusterName` in `datadog-agent.yaml`, or `kubectl config current-context` — needed for kind clusters in Step 0 |
+
+---
+
+## Step 0 (Only if existing instrumentation detected): Remove Manual Instrumentation
+
+Scan all source files for: `import ddtrace`, `from ddtrace`, `require 'ddtrace'`, `require("dd-trace")`, `opentelemetry`, `tracer.trace(`
+
+Also check dependency manifests for `ddtrace` / `dd-trace` / OTel SDK packages.
+
+If found — remove the import/package, then rebuild and reload:
+
+### Claude runs
+
+```bash
+docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
+```
+
+[DECISION: cluster type]
+- kind (local): load the image into the cluster
+
+### Claude runs
+
+```bash
+kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
+```
+
+- Registry-based: skip — image will be pulled on next deployment
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod \
+  -l app=<APP_LABEL> \
+  -n <APP_NAMESPACE> \
+  --timeout=120s
+```
+
+---
+
+## Step 1: Extend the DatadogAgent Manifest with APM
+
+SSI is configured on the existing `DatadogAgent` resource — do not create a separate manifest.
+
+[DECISION: targeting scope — ask the user if unclear]
+- Cluster-wide: `enabled: true` with no `targets` or `enabledNamespaces`
+- Specific namespaces: `enabledNamespaces`
+- Specific pods: `targets` with `podSelector`
+- Excluding namespaces: `disabledNamespaces`
+
+Recommended `ddTraceVersions`: `java: "1"`, `python: "2"`, `js: "5"`, `dotnet: "3"`, `ruby: "2"`, `php: "1"`
+
+**Option A — Target specific workloads (recommended for production):**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      targets:
+        - name: <TARGET_NAME>
+          namespaceSelector:
+            matchNames:
+              - <APP_NAMESPACE>
+          ddTraceVersions:
+            <LANGUAGE>: "<MAJOR_VERSION>"
+```
+
+**Option B — Specific namespaces only:**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      enabledNamespaces:
+        - <APP_NAMESPACE>
+```
+
+**Option C — Cluster-wide with exclusions:**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      disabledNamespaces:
+        - jenkins
+        - kube-system
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+```
+
+✅ `datadogagent.datadoghq.com/datadog configured`
+
+❌ Validation error — check YAML. `enabledNamespaces` and `disabledNamespaces` cannot both be set.
+
+---
+
+## Step 2: Configure Unified Service Tags on Application Workloads
+
+Add UST labels to the Deployment under both `metadata.labels` and `spec.template.metadata.labels`:
+
+```yaml
+metadata:
+  labels:
+    tags.datadoghq.com/env: "<ENV>"
+    tags.datadoghq.com/service: "<SERVICE_NAME>"
+    tags.datadoghq.com/version: "<VERSION>"
+spec:
+  template:
+    metadata:
+      labels:
+        tags.datadoghq.com/env: "<ENV>"
+        tags.datadoghq.com/service: "<SERVICE_NAME>"
+        tags.datadoghq.com/version: "<VERSION>"
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f <your-app-deployment.yaml>
+```
+
+---
+
+## Step 3: Restart Application Pods
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+
+kubectl wait --for=condition=Ready pod \
+  -l app=<APP_LABEL> \
+  -n <APP_NAMESPACE> \
+  --timeout=120s
+```
+
+✅ Pods restart cleanly. Init containers named `datadog-lib-<language>-init` visible in pod spec.
+
+❌ Pods crash-looping — check for existing custom instrumentation. See `troubleshoot-ssi`.
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] `features.apm.instrumentation` is present in the applied `DatadogAgent` manifest
+- [ ] Application pods have been restarted and are Running
+- [ ] UST labels are present on the Deployment and pod template
+- [ ] Scope confirmed: which workloads are instrumented, which were skipped and why
+
+Automatically proceed to `verify-ssi` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never use namespace `default` for Datadog resources
+- Never modify `admissionController` settings directly — SSI manages this via the Operator
+- Do not add APM config to application manifests — configure only via `DatadogAgent`
+- Exception: UST labels (`tags.datadoghq.com/*`) on application Deployments are required and intentional
+- Never run `kubectl delete` without user confirmation
+- `docker push` to a registry always requires user confirmation

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -29,6 +29,8 @@ Do NOT invoke this skill if:
 
 ## Prerequisites
 
+> **These are not a reading exercise — actively verify each one before proceeding.**
+
 **Environment**
 - [ ] Datadog Agent is installed and healthy — `agent-install` complete
 - [ ] Kubernetes v1.20+
@@ -37,7 +39,18 @@ Do NOT invoke this skill if:
 - [ ] Not a hardened SELinux environment — unsupported
 - [ ] Not a very small VM instance (e.g. t2.micro) — SSI can hit init timeouts
 - [ ] No PodSecurity baseline or restricted policy enforced
-- [ ] Application container is **not Alpine Linux** — SSI requires glibc; Alpine uses musl libc which is ABI-incompatible. Use `python:3.x-slim`, `node:x-bookworm`, or any Debian/Ubuntu-based image
+
+**Base image — verify before proceeding:**
+
+### Claude runs
+
+```bash
+kubectl exec -n <APP_NAMESPACE> -l app=<APP_LABEL> -- ldd --version 2>&1 | head -1
+```
+
+✅ Output contains `glibc` or `GLIBC` or `GNU libc` — proceed.
+
+❌ Output contains `musl` — **stop**. SSI's injector requires glibc and is ABI-incompatible with musl libc. The injector will load but silently abort injection, and no traces will be sent. Switch the base image to a glibc-based equivalent (e.g. `python:X-slim`, `node:X-bookworm-slim`, any Debian/Ubuntu/UBI image), then rebuild, reload, restart the pod, and rerun this check before continuing.
 
 **Language and runtime**
 - [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
@@ -45,9 +58,21 @@ Do NOT invoke this skill if:
 - [ ] Node.js app is not using ESM — SSI does not support ESM
 - [ ] Java app is not already using a `-javaagent` JVM flag
 
-**Existing instrumentation**
-- [ ] Application has no existing `ddtrace` imports, OTel SDK calls, or custom `tracer.trace()` calls — SSI silently disables itself when detected; complete Step 0 first
-- [ ] `ddtrace` is not listed in the app's dependency manifest (`requirements.txt`, `package.json`, `Gemfile`, etc.) — SSI installs the tracer automatically
+**Existing instrumentation — verify before proceeding:**
+
+### Claude runs
+
+```bash
+# Check source files for manual tracer imports
+grep -r "import ddtrace\|from ddtrace\|require 'ddtrace'\|require(\"dd-trace\")\|opentelemetry\|tracer\.trace(" <SOURCE_DIR> 2>/dev/null || echo "No manual instrumentation found"
+
+# Check dependency manifests
+grep -rE "ddtrace|dd-trace|opentelemetry" requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null || echo "No tracer dependency found"
+```
+
+❌ Any match found — remove the import/package before continuing (see Step 0). SSI silently disables itself when existing instrumentation is detected.
+
+✅ No matches — proceed.
 
 ---
 
@@ -78,14 +103,19 @@ If found — remove the import/package, then rebuild and reload:
 docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
 ```
 
-[DECISION: cluster type]
-- kind (local): load the image into the cluster
+[DECISION: how does this cluster get local images?]
 
-### Claude runs
+Check the repo's setup script (e.g. `create.sh`, `Makefile`, `justfile`) for how images are loaded — do not guess from the cluster name or context. Common patterns:
 
-```bash
-kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
-```
+| What you find in the setup script | Load command |
+|---|---|
+| `minikube image load` or `minikube cache add` | `minikube -p <PROFILE> image load <IMAGE_NAME>` — profile is the `-p` flag value in the script, NOT necessarily the kubectl context name |
+| `kind load docker-image` | `kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>` |
+| `docker push` to a registry | Push the new image; the cluster will pull on restart — skip local load |
+| `k3d image import` | `k3d image import <IMAGE_NAME> -c <CLUSTER_NAME>` |
+| No image load step (cloud cluster, always pulls from registry) | Skip — image will be pulled on next deployment |
+
+If the setup script is ambiguous, run the load command it uses exactly as written.
 
 - Registry-based: skip — image will be pulled on next deployment
 

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: dd-apm-k8s-onboarding-summary
+description: Generate a live APM onboarding confirmation report with deep links into the Datadog UI. Collects real data from the cluster and Datadog backend to confirm everything is working end-to-end.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,summary,verification
+  alwaysApply: "false"
+---
+
+# APM Onboarding Summary
+
+## Triggers
+
+Invoke this skill when:
+- All steps in `verify-ssi` have passed
+- All checks in `troubleshoot-ssi` have been resolved
+- The user asks "is everything working?", "show me the status", or "confirm APM is set up"
+
+Do NOT invoke this skill if any verification or troubleshooting check is still failing — resolve those first.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Namespace where Datadog Agent is installed |
+| `APP_NAMESPACE` | Namespace of the application |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+| `CLUSTER_NAME` | `spec.global.clusterName` in `datadog-agent.yaml` |
+| `SERVICE_NAME` | `tags.datadoghq.com/service` label on the Deployment |
+| `ENV` | `tags.datadoghq.com/env` label on the Deployment |
+| `DD_SITE` | `spec.global.site` in `datadog-agent.yaml` |
+
+---
+
+## Prerequisites
+
+### Claude runs
+
+```bash
+pup auth status
+```
+
+✅ Valid token — proceed.
+
+❌ Not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status` before continuing.
+
+---
+
+## Collect live confirmation data
+
+Run all of the following. Each populates a row in the final report.
+
+### Claude runs
+
+```bash
+# Agent pod count and status
+kubectl get pods -n <AGENT_NAMESPACE> \
+  -l app.kubernetes.io/component=agent \
+  --no-headers
+
+# SSI instrumentation config live in cluster
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> \
+  -o jsonpath='{.spec.features.apm.instrumentation}'
+
+# Init container confirmed in app pod spec
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
+
+# Pod confirmed in Datadog's instrumented-pods list
+pup fleet instrumented-pods list <CLUSTER_NAME>
+
+# Tracer active and reporting
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
+
+# Service visible in APM
+pup apm services list --env <ENV>
+
+# Traces arriving in the last hour
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+```
+
+---
+
+## Present the report
+
+Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row ❌ and link to `troubleshoot-ssi`.
+
+---
+
+**APM onboarding complete**
+
+| Check | Detail | Status |
+|---|---|---|
+| Datadog Agent | `<N>` pod(s) Running in `<AGENT_NAMESPACE>` | ✅ |
+| SSI enabled | Targeting namespace `<APP_NAMESPACE>`, language `<LANGUAGE>` v`<MAJOR_VERSION>` | ✅ |
+| Init container injected | `datadog-lib-<language>-init` present in pod spec | ✅ |
+| Pod instrumented | `<POD_NAME>` in `pup fleet instrumented-pods list` | ✅ |
+| Tracer reporting | Service `<SERVICE_NAME>`, `<LANGUAGE>`, tracer v`<TRACER_VERSION>` | ✅ |
+| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | ✅ |
+| Traces arriving | `<N>` trace(s) found in the last hour | ✅ |
+
+---
+
+**Your service in Datadog — click to open:**
+
+Construct each URL by substituting real values. Do not print placeholder URLs.
+
+| View | URL |
+|---|---|
+| Service overview | `https://app.<DD_SITE>/apm/services/<SERVICE_NAME>?env=<ENV>` |
+| Traces explorer | `https://app.<DD_SITE>/apm/traces?query=service:<SERVICE_NAME>%20env:<ENV>` |
+| Service map | `https://app.<DD_SITE>/apm/map?env=<ENV>&service=<SERVICE_NAME>` |
+| Agent fleet | `https://app.<DD_SITE>/fleet-automation` |
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -41,7 +41,7 @@ Do NOT invoke this skill if any verification or troubleshooting check is still f
 ### Claude runs
 
 ```bash
-pup auth status
+pup auth status --site <DD_SITE>
 ```
 
 ✅ Valid token — proceed.
@@ -51,10 +51,10 @@ pup auth status
 ### What you need to do in a terminal
 
 ```bash
-pup auth login
+pup auth login --site <DD_SITE>
 ```
 
-Confirm with `pup auth status` before continuing.
+Confirm with `pup auth status --site <DD_SITE>` before continuing.
 
 ---
 
@@ -78,17 +78,15 @@ kubectl get datadogagent datadog -n <AGENT_NAMESPACE> \
 kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
   -o jsonpath='{.items[0].spec.initContainers[*].name}'
 
-# Pod confirmed in Datadog's instrumented-pods list
-pup fleet instrumented-pods list <CLUSTER_NAME>
+# Pod confirmed instrumented — init containers in pod spec
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
 
-# Tracer active and reporting
-pup fleet tracers list --filter "service:<SERVICE_NAME>"
-
-# Service visible in APM
-pup apm services list --env <ENV>
+# Service visible and traced in APM
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 
 # Traces arriving in the last hour
-pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
 ```
 
 ---

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: dd-apm-k8s-troubleshoot-ssi
+description: Diagnose and fix APM SSI issues on Kubernetes. Uses hypothesis-driven investigation — triage, form hypotheses, investigate iteratively, reflect, fix, verify.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,troubleshooting,instrumentation
+  alwaysApply: "false"
+---
+
+# Troubleshoot APM SSI on Kubernetes
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Debug why a pod is not being instrumented
+- Investigate why traces are not appearing in Datadog
+- Diagnose admission webhook or init container injection failures
+- Follow up on failed checks from `verify-ssi`
+- Report that a specific service or pod has no traces
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `enable-ssi` first
+
+---
+
+## Prerequisites
+
+- [ ] kubectl configured to target cluster — `kubectl config current-context`
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status`. If no browser available: `export DD_APP_KEY=<your-app-key>`.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Namespace where Datadog Agent is installed |
+| `APP_NAMESPACE` | Namespace of the application with missing traces |
+| `CLUSTER_NAME` | `kubectl config current-context` or `spec.global.clusterName` in `datadog-agent.yaml` |
+| `SERVICE_NAME` | `tags.datadoghq.com/service` label on the Deployment, or ask the user |
+| `ENV` | `tags.datadoghq.com/env` label on the Deployment, or ask the user |
+| `POD_NAME` | `kubectl get pods -n <APP_NAMESPACE>` — use the specific pod the user mentioned |
+| `DEPLOYMENT_NAME` | Check `metadata.name` in the Deployment manifest, or ask the user |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+
+---
+
+## How SSI Works — Domain Knowledge
+
+Read this before investigating. It gives you the mental model to reason about novel failures, not just known ones.
+
+**Injection chain:**
+1. Admission webhook (registered by Cluster Agent) intercepts pod creation
+2. Webhook mutates the pod spec — adds a `datadog-lib-<language>-init` init container
+3. Init container downloads the tracer library onto a shared volume
+4. `LD_PRELOAD` env var is set pointing to the library `.so` file
+5. Application process loads the library automatically on startup via `LD_PRELOAD`
+
+**What each diagnostic layer can see:**
+- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no instrumented pods, the problem is in the cluster.
+- **kubectl** — sees cluster state. Blind to whether data reached Datadog. If kubectl shows the init container but pup shows no traces, the problem is post-injection.
+
+**What healthy looks like:**
+- `pup fleet instrumented-pods list` shows the pod with correct language/version
+- `pup fleet tracers list` shows the service as active
+- `kubectl get pod -o jsonpath='{.spec.initContainers[*].name}'` includes `datadog-lib-<language>-init`
+
+**Known silent failures — SSI produces no error when these occur:**
+- **Alpine/musl libc** — `LD_PRELOAD` fails silently. SSI's `.so` is compiled against glibc; musl (Alpine Linux) is ABI-incompatible
+- **Existing ddtrace or OTel instrumentation** — SSI detects it and silently disables itself
+- **Unsupported runtime version** — silently skipped
+- **`admission.datadoghq.com/enabled: "false"` annotation** — webhook skips the pod entirely
+- **Pod not restarted after SSI enabled** — injection happens at startup; existing pods keep running uninstrumented
+- **Pod in Agent namespace** — SSI never instruments its own namespace
+
+**Reasoning shortcuts:**
+- No init container → webhook didn't fire → check: namespace targeting, pod-selector, opt-out annotation, webhook registration, pod not restarted
+- Init container present + no traces → injection attempted but failed or tracer not reporting → check: libc compatibility, existing ddtrace, runtime version, Agent connectivity, DD_SITE mismatch
+
+---
+
+## Step 1: Triage
+
+Run all four simultaneously. Everything after this is driven by what you find here.
+
+### Claude runs
+
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+pup fleet instrumented-pods list <CLUSTER_NAME>
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> \
+  -o jsonpath='{.spec.initContainers[*].name}'
+kubectl describe pod <POD_NAME> -n <APP_NAMESPACE> | grep -A 10 "Events:"
+```
+
+---
+
+## Step 2: State Your Hypotheses
+
+Before investigating, explicitly state your ranked hypotheses based on triage output. Do not skip this step.
+
+| Triage signal | Strong hypothesis |
+|---|---|
+| Traces arriving + pod in instrumented list | Not a real problem — likely a UI filter or time window. Tell the user and stop |
+| No traces + pod NOT in instrumented list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
+| No traces + pod NOT in instrumented list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
+| No traces + pod in instrumented list + init container present | Tracer injected but not reporting — investigate: connectivity, DD_SITE, API key |
+| Pod events show CrashLoopBackOff or init container errors | Init container failure — check libc (Alpine/musl), existing ddtrace, runtime version |
+| Traces arriving but wrong service/env | UST labels missing or misconfigured on the Deployment |
+
+State your top 1-3 hypotheses explicitly: *"Based on triage, I think the most likely cause is X because Y."*
+
+---
+
+## Step 3: Investigate
+
+Use only the tools relevant to your hypotheses. Each observation informs your next action.
+
+---
+
+### Cluster-side investigation tools
+
+**Is the pod in the Agent namespace?**
+SSI never instruments pods in the same namespace as the Datadog Agent.
+```bash
+kubectl get pods -n <AGENT_NAMESPACE>
+```
+
+**Were pods restarted after SSI was enabled?**
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+**Is namespace targeting filtering the pod out?**
+```bash
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> -o yaml | grep -A 15 instrumentation
+```
+Fix: update `enabledNamespaces` in `datadog-agent.yaml`.
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+```
+
+**Is a `podSelector` target filtering the pod out?**
+If `targets` with `podSelector` is configured, only pods whose labels match the selector are instrumented. Check whether the app pod's labels match any target:
+```bash
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> -o yaml | grep -A 20 targets
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> --show-labels
+```
+Fix: add a matching label to the pod template, or broaden the `podSelector`, then apply and restart.
+
+**Is a pod annotation opting it out?**
+`admission.datadoghq.com/enabled: "false"` tells the webhook to skip this pod.
+```bash
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> -o yaml | grep -A 5 annotations
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> --show-labels
+```
+Fix: remove the annotation from the Deployment pod template, then apply and restart.
+
+### Claude runs
+
+```bash
+kubectl apply -f <your-app-deployment.yaml>
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+```
+
+**Does the app have existing custom instrumentation?**
+SSI silently disables itself when it detects existing tracer code. Scan source files for:
+- Python: `import ddtrace`, `ddtrace.patch_all()`
+- Node.js: `require('dd-trace')`, `DD.init()`
+- Java: `GlobalTracer.register(`, `dd-java-agent`
+- .NET: `Tracer.Instance`, `DD.Trace`
+- Ruby: `require 'ddtrace'`, `Datadog.configure`
+- PHP: `DDTrace\`
+
+Also check dependency manifests: `requirements.txt`, `package.json`, `Gemfile`, `pom.xml`.
+
+Fix: remove the import/package, rebuild image, reload into cluster, restart pod.
+
+**Is the base image Alpine (musl libc)?**
+SSI's injected library requires glibc. Alpine uses musl — ABI-incompatible, fails silently.
+```bash
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "ldd --version 2>&1 | head -1"
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "cat /etc/os-release | grep -i 'ID\|NAME' | head -3"
+```
+Fix: rebuild with a glibc-based image (`python:3.x-slim`, `node:x-bookworm`, `eclipse-temurin`).
+
+**Is the runtime version supported?**
+```bash
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- python --version
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- node --version
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- java -version
+```
+Verify against [SSI compatibility matrix](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/).
+
+**Is the admission webhook registered?**
+```bash
+kubectl get mutatingwebhookconfigurations | grep datadog
+kubectl get pods -n <AGENT_NAMESPACE> -l app=datadog-cluster-agent
+kubectl logs -n <AGENT_NAMESPACE> -l app=datadog-cluster-agent --tail=100
+```
+
+**Did injection produce errors?**
+Get the node hostname first, then query Datadog for injection errors:
+```bash
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> -o jsonpath='{.spec.nodeName}'
+pup apm troubleshooting list --hostname <NODE_HOSTNAME> --timeframe 1h
+```
+
+**Is the Agent sending data to Datadog?**
+```bash
+kubectl exec -n <AGENT_NAMESPACE> \
+  $(kubectl get pod -n <AGENT_NAMESPACE> -l app=datadog-agent -o name | head -1) \
+  -- agent status | grep -A 5 "APM Agent"
+```
+
+---
+
+### Datadog-side investigation tools
+
+**Is the tracer reporting?**
+```bash
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
+```
+
+**Does APM recognise the service?**
+```bash
+pup apm services list --env <ENV>
+```
+
+**Are traces arriving?**
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 10
+```
+
+**Which agent is the tracer connected to?**
+Use if connectivity between tracer and Agent is suspected.
+```bash
+pup fleet agents list --filter "hostname:<NODE_HOSTNAME>"
+pup fleet agents tracers <AGENT_KEY> --filter "service:<SERVICE_NAME>"
+```
+
+---
+
+## Step 4: Reflect Before Concluding
+
+Before applying any fix, answer:
+1. What evidence confirms my hypothesis?
+2. What evidence would contradict it — and have I checked?
+3. Is there a simpler explanation I haven't considered?
+
+If the conclusion doesn't hold up, return to Step 2 with new hypotheses. Keep iterating until you can defend the conclusion against all three questions.
+
+---
+
+## Step 5: Fix
+
+Apply the fix for the confirmed root cause. If the fix requires a code or Dockerfile change, rebuild and reload:
+
+### Claude runs
+
+```bash
+docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
+```
+
+[DECISION: cluster type]
+- kind (local): load the image into the cluster
+
+### Claude runs
+
+```bash
+kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
+```
+
+- Registry-based: skip — image will be pulled on next deployment
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
+```
+
+---
+
+## Step 6: Verify
+
+Re-run triage to confirm the fix worked:
+
+### Claude runs
+
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+✅ Traces arriving + pod in instrumented list — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+❌ Still not resolved — return to Step 2 with the new triage data and form updated hypotheses.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never run `kubectl delete` without user confirmation
+- Never modify `admissionController` settings directly
+- `docker push` to a registry always requires user confirmation

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: dd-apm-k8s-verify-ssi
+description: Verify APM SSI is working end-to-end on Kubernetes. Confirms pod instrumentation, tracer telemetry, and tracer config using pup fleet and pup apm commands.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,verification,instrumentation
+  alwaysApply: "false"
+---
+
+# Verify APM SSI on Kubernetes
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Confirm SSI is working after enabling APM
+- Check whether pods are being instrumented
+- Verify the tracer is running and reporting telemetry
+- Confirm tracer config is applied correctly
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `enable-ssi` first
+- Pods are not being instrumented at all — use `troubleshoot-ssi`
+
+---
+
+## Prerequisites
+
+- [ ] `enable-ssi` is complete
+- [ ] Application pods have been restarted since SSI was enabled
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status`.
+
+✅ Valid token — proceed.
+❌ No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `CLUSTER_NAME` | Check `spec.global.clusterName` in `datadog-agent.yaml`, or `kubectl config current-context` |
+| `ENV` | Check `tags.datadoghq.com/env` label on the application Deployment |
+| `SERVICE_NAME` | Check `tags.datadoghq.com/service` label on the application Deployment |
+
+---
+
+## Step 1: Confirm Pods are Instrumented
+
+### Claude runs
+
+```bash
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+✅ Target pods appear with injected SDK language and version.
+
+❌ Expected pod missing — go to `troubleshoot-ssi`. Common causes: pod in Agent namespace, namespace targeting filtering it out, pod not restarted after SSI enabled.
+
+---
+
+## Step 2: Confirm the Tracer is Reporting Telemetry
+
+### Claude runs
+
+```bash
+pup fleet tracers list --filter "env:<ENV>"
+```
+
+✅ One or more tracer entries visible with service name, language, SDK version, and active status.
+
+❌ Service missing — tracer may still be initializing. Wait and retry:
+
+### Claude runs
+
+```bash
+sleep 120 && pup fleet tracers list --filter "env:<ENV>"
+```
+
+❌ Still missing after retry — go to `troubleshoot-ssi`.
+
+---
+
+## Step 3: Confirm Tracer Configuration
+
+**Only run this step if `ddTraceConfigs` was explicitly configured in `enable-ssi`** (e.g. profiling, AppSec, Data Streams). If basic SSI was set up without `ddTraceConfigs`, skip this step — an empty response here is expected and not a failure.
+
+### Claude runs
+
+```bash
+pup apm service-library-config get \
+  --service-name <SERVICE_NAME> \
+  --env <ENV>
+```
+
+✅ Output shows expected environment variables matching what was configured in `ddTraceConfigs`.
+
+✅ Empty output and `ddTraceConfigs` was not configured — expected, not a failure.
+
+❌ Config missing but `ddTraceConfigs` was configured — check it is present in the `DatadogAgent` manifest under the correct target, and that pods were restarted after the config change.
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Step 1: target pods appear in `instrumented-pods list`
+- [ ] Step 2: service appears in `tracers list` with active status
+- [ ] Step 3: tracer config matches what was set in `DatadogAgent`
+
+If any check fails, go to `troubleshoot-ssi`.
+
+When all steps pass, automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never run `kubectl delete` without user confirmation

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -51,7 +51,7 @@ brew install pup
 
 Check auth:
 ```bash
-pup auth status
+pup auth status --site <DD_SITE>
 ```
 
 If not authenticated:
@@ -59,7 +59,7 @@ If not authenticated:
 ### What you need to do in a terminal
 
 ```bash
-pup auth login
+pup auth login --site <DD_SITE>
 ```
 
 Confirm with `pup auth status`.
@@ -84,12 +84,13 @@ Confirm with `pup auth status`.
 ### Claude runs
 
 ```bash
-pup fleet instrumented-pods list <CLUSTER_NAME>
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
 ```
 
-✅ Target pods appear with injected SDK language and version.
+✅ Output includes `datadog-lib-<language>-init` and `datadog-init-apm-inject` — SSI init containers injected.
 
-❌ Expected pod missing — go to `troubleshoot-ssi`. Common causes: pod in Agent namespace, namespace targeting filtering it out, pod not restarted after SSI enabled.
+❌ Init containers missing — pod was not restarted after SSI was enabled, or namespace targeting is not matching. Restart the pod and recheck.
 
 ---
 
@@ -98,20 +99,24 @@ pup fleet instrumented-pods list <CLUSTER_NAME>
 ### Claude runs
 
 ```bash
-pup fleet tracers list --filter "env:<ENV>"
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 ```
 
-✅ One or more tracer entries visible with service name, language, SDK version, and active status.
+✅ `<SERVICE_NAME>` appears in the services list with `isTraced: true`.
 
-❌ Service missing — tracer may still be initializing. Wait and retry:
+❌ Service missing — send some traffic to the app first, then retry:
 
 ### Claude runs
 
 ```bash
-sleep 120 && pup fleet tracers list --filter "env:<ENV>"
+# Port-forward and send test traffic
+kubectl port-forward deployment/<DEPLOYMENT_NAME> 8099:8000 -n <APP_NAMESPACE> &
+sleep 2 && for i in $(seq 1 10); do curl -s -o /dev/null http://localhost:8099/; done
+sleep 30 && kill %1 2>/dev/null
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 10m
 ```
 
-❌ Still missing after retry — go to `troubleshoot-ssi`.
+❌ Still missing after traffic — check the agent's trace receiver: `kubectl exec -n <AGENT_NAMESPACE> <AGENT_POD> -c agent -- agent status | grep -A 10 "Receiver (previous minute)"`. If receiver shows 0 traces, go to `troubleshoot-ssi`.
 
 ---
 


### PR DESCRIPTION
- Five skills covering agent install, enable SSI, verify SSI, troubleshoot SSI, and onboarding summary for Kubernetes APM via Single Step Instrumentation.
- [Jira ticket](https://datadoghq.atlassian.net/browse/INPLAT-1072)