### PR TITLE
migrate control plane skill to agent-skills

### DIFF
--- a/dd-instrumentation/SKILL.md
+++ b/dd-instrumentation/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: dd-onboarding-apm
+description: >
+  Onboard and troubleshoot Datadog APM on Linux hosts and Kubernetes clusters
+  using Single Step Instrumentation (SSI). Use when the user wants to set up APM,
+  instrument services, enable tracing, or diagnose why traces aren't appearing.
+  Trigger on: "set up APM", "instrument my hosts", "install datadog agent",
+  "onboard to APM", "set up tracing", "troubleshoot instrumentation",
+  "why isn't APM working", "no traces", "missing services", SSI, injection errors.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: apm, onboarding, ssi, instrumentation, troubleshooting, kubernetes, linux
+  globs: "**/datadog*.yaml,**/ddtrace*,**/helm*"
+  alwaysApply: "false"
+---
+
+# Datadog APM Onboarding & Troubleshooting
+
+Determine what the user needs, then read ONLY the relevant file:
+
+## Onboarding
+The user wants to **set up** Datadog APM on their infrastructure (install agent, enable SSI, instrument services).
+→ Read [onboarding.md](onboarding.md) for full instructions.
+
+## Troubleshooting
+The user has APM set up but something **isn't working** (no traces, missing services, injection errors, wrong service names).
+→ Read [troubleshooting.md](troubleshooting.md) for diagnostic tools and system model.
+
+**Do not read both files.** Pick the one that matches the user's intent.

--- a/dd-instrumentation/onboarding.md
+++ b/dd-instrumentation/onboarding.md
@@ -1,0 +1,395 @@
+---
+name: apm-onboarding
+description: >
+  Onboard a user's Linux hosts to Datadog APM using pup. Use this skill when the user wants to
+  instrument their infrastructure with Datadog APM, set up SSI (Single Step Instrumentation),
+  install the Datadog agent on hosts, or troubleshoot APM instrumentation issues. Trigger when
+  the user says things like "set up APM", "instrument my hosts", "install datadog agent",
+  "onboard to APM", "set up tracing", "troubleshoot instrumentation", or "why isn't APM working".
+  Also trigger when the user mentions SSI, auto-instrumentation, or injection errors.
+---
+
+# APM Onboarding (Linux Hosts)
+
+Guide the user through installing the Datadog agent with APM Single Step Instrumentation on their Linux hosts, then verify that instrumentation is working.
+
+
+## Phase 1: Gather Infrastructure Info
+
+Ask the user:
+1. **What hosts** do you want to instrument? Get a list of IPs or hostnames.
+2. **How do I SSH to them?** Get the SSH user, key path, and any jump host/bastion configuration.
+3. **Do any hosts already have the Datadog agent installed?** If so, we can skip install and go straight to SSI verification.
+
+Verify SSH access works by running a quick `ssh <host> "hostname"` for each host before proceeding.
+
+Once you have the host list and SSH details confirmed, **present a plan to the user and wait for their go-ahead before proceeding.** For example:
+
+```
+Here's what I'm going to do:
+  1. Check pup authentication and detect your Datadog site
+  2. Install the Datadog agent with SSI on: <host1>, <host2>, ...
+  3. Wait for each agent to appear in Datadog
+  4. Discover listening services on each host and tell you what needs restarting
+  5. After you restart services, verify instrumentation and traces
+
+Ready to proceed?
+```
+
+Don't start Phase 2 until the user confirms.
+
+## Phase 2: Authenticate pup and Detect Site
+
+### Step 1 — Ensure pup is authenticated
+
+Run `pup auth status` and check the JSON response:
+
+```bash
+pup auth status
+```
+
+- If `"authenticated": true` — extract `site` from the response and proceed to Step 3.
+- If not authenticated — proceed to Step 2.
+
+### Step 2 — Log in (no questions needed)
+
+Just run it. The browser will open and the user completes the OAuth flow:
+
+```bash
+pup auth login
+```
+
+After the user completes the browser flow, run `pup auth status` again and extract `site` from the response.
+
+**Multiple sessions:** If `pup auth list` shows more than one session, show the list and ask the user which org to use. That is the only question to ask — do not ask about the site itself.
+
+### Step 3 — Detect the site automatically
+
+The `site` field in `pup auth status` output is the Datadog site for this session. Use it for all subsequent pup calls and for the agent install script. Do not ask the user what site they're on.
+
+### Step 4 — Get an API key
+
+The agent install script requires an API key (OAuth tokens cannot be used for agent auth).
+
+1. Try `pup api-keys list` — may return 403 or 503 in some orgs, that's okay.
+2. If unavailable, ask the user to provide one from the web app: /organization-settings/api-keys
+
+Confirm the key with the user before using it. The API key must belong to the same org as the pup session — the site detected in Step 3 confirms they match.
+
+Store for use throughout the session:
+```bash
+export DD_API_KEY="<key>"
+export DD_SITE="<site from pup auth status>"
+```
+
+## Phase 3: Install Agent with APM
+
+For each host that doesn't already have the agent, SSH in and run the install script with SSI enabled:
+
+```bash
+ssh <user>@<host> "DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+Key environment variables for the install script:
+- `DD_API_KEY` — required
+- `DD_SITE` — required (defaults to datadoghq.com if not set)
+- `DD_APM_INSTRUMENTATION_ENABLED=host` — enables SSI for host-level instrumentation
+
+**If the install fails**, check:
+- Does the host have internet access? Can it reach `install.datadoghq.com`?
+- Does the SSH user have sudo access? The install script requires root.
+- Is there a proxy? Set `DD_PROXY` if needed.
+
+## Phase 4: Wait for Agents to Report
+
+For each host, poll until the agent appears in Datadog. Fleet agents list gives you the Datadog-reported hostname and agent status in one call:
+
+```bash
+pup fleet agents list --filter "<hostname_or_ip>"
+```
+
+Check every 30-60 seconds. Agents typically take 1-2 minutes to appear after install.
+
+When each agent appears, record:
+- `hostname` field — the Datadog-reported hostname (may differ from the SSH hostname on cloud instances)
+- `rc_status` — should be `connected`
+- `instrumentation_status` — initial value; will update after services are restarted
+
+**If `pup fleet agents list` errors**, fall back to:
+```bash
+pup infrastructure hosts list --filter "<hostname_or_ip>"
+# And get the DD hostname via SSH:
+ssh <user>@<host> "sudo datadog-agent hostname"
+```
+
+**If a host's agent doesn't appear after 5 minutes:**
+1. SSH to the host: `sudo systemctl status datadog-agent`
+2. Check logs: `sudo journalctl -u datadog-agent --no-pager -n 50`
+3. Verify API key: `sudo datadog-agent configcheck 2>&1 | head -20`
+4. Check connectivity: `sudo datadog-agent diagnose --include connectivity-datadog-core-endpoints`
+
+**Important:** If you corrected a wrong API key after initial install, update `/etc/datadog-agent/datadog.yaml` and restart the agent on each affected host. Then restart all application services so injection telemetry is sent to the correct org.
+
+## Phase 5: Discover Listening Services
+
+SSI only injects into processes at startup — existing processes are not affected. Before verification can happen, the user's services need to be restarted. This phase discovers what's running on each host so the user knows what to restart.
+
+### Step 1 — Find listening network services
+
+```bash
+ssh <user>@<host> "sudo ss -lntp"
+```
+
+This shows all listening TCP services with their ports and PIDs. Filter out well-known system services (sshd, systemd, chronyd, etc.) and focus on application-level listeners.
+
+### Step 2 — Determine how each service is managed
+
+For each application PID found, gather context without being invasive:
+
+```bash
+ssh <user>@<host> "
+# Command line of the process
+sudo cat /proc/<pid>/cmdline | tr '\0' ' '
+
+# Check if it's a systemd service
+sudo systemctl status <pid> 2>/dev/null | head -3
+
+# Parent process (to detect supervisord, screen, tmux, etc.)
+PPID=\$(sudo cat /proc/<pid>/status | grep PPid | awk '{print \$2}')
+sudo cat /proc/\$PPID/cmdline | tr '\0' ' '
+"
+```
+
+**Common management patterns:**
+- **systemd** — `systemctl status <pid>` shows a unit name. Note the unit name for the user.
+- **supervisord** — parent process is `supervisord`. Config typically in `/etc/supervisor/` or `/etc/supervisord.conf`.
+- **Docker** — parent is `containerd-shim` or `docker`. SSI host-mode does not inject into containers — skip these.
+- **screen/tmux** — parent is a multiplexer. Process was started manually in a session.
+- **Direct/ad-hoc** — parent is a shell (`bash`, `sh`, `zsh`). Started manually with no automatic restart mechanism.
+
+### Step 3 — Present findings and hand off to the user
+
+Present a clear summary of what was found on each host. For example:
+
+```
+I found the following application services listening on network ports on <host>:
+
+  Port 8080 — PID 1234 — /usr/bin/python3 /home/ec2-user/app.py
+    Managed by: systemd unit flask-app.service
+
+  Port 3000 — PID 5678 — node /app/server.js
+    Managed by: supervisord (config likely in /etc/supervisor/)
+
+  Port 8443 — PID 9012 — java -jar /opt/myapp/app.jar
+    Managed by: started directly from a shell session (no automatic restart)
+
+These services need to be restarted for Datadog SSI to inject into them.
+Restart them however is appropriate for your environment, then let me know
+and I'll verify the instrumentation.
+```
+
+**Do not offer to restart services. Do not restart services unless the user explicitly asks.** If they do ask, make sure they understand: restarting a production service causes a brief outage, and any service started ad-hoc from a shell session will need to be re-launched manually.
+
+## Phase 6: Verify APM Instrumentation
+
+Once the user has restarted their services, verify injection worked on each host.
+
+**How SSI works:** SSI uses `/etc/ld.so.preload` to load the launcher into every process at startup. The launcher then loads the appropriate language tracer. Injection happens at process startup only — existing processes are not affected.
+
+### Step 1 — Confirm the injector loaded into each process
+
+Check `/proc` directly for the services that were restarted:
+
+```bash
+ssh <user>@<host> "sudo cat /proc/<pid>/maps | grep -E 'launcher|apm-library'"
+```
+
+- **Launcher present + language library present** — injection succeeded for that process. The tracer is running.
+- **Launcher present, no language library** — the launcher ran but couldn't inject. Check the troubleshooting endpoint for the failure reason.
+- **Nothing** — `/etc/ld.so.preload` may not be set. Check with `cat /etc/ld.so.preload`.
+
+### Step 2 — Check the agent for reporting services and trace activity
+
+```bash
+ssh <user>@<host> "sudo datadog-agent status"
+```
+
+Look at the **APM Agent** section:
+- `feature_auto_instrumentation_enabled: true` — SSI is active on the agent
+- `Receiver (previous minute)` — shows whether any traces have arrived at the agent
+- `Endpoints` — confirms where traces are being forwarded
+
+If the receiver is getting traces, the tracer is running and connected.
+
+### Step 3 — Check for injection failures
+
+The troubleshooting endpoint **only reports failures** — successful injections do not appear here. Use it to catch problems, not to confirm success.
+
+```bash
+pup apm troubleshooting list --hostname <dd_hostname>
+pup apm troubleshooting list --hostname <dd_hostname> --timeframe 4h
+```
+
+**Results with `result: error`:**
+- `result_reason` contains a customer-facing explanation.
+- `result_class` categorizes the failure:
+  - `incorrect_installation` — a required file is missing or the package directory is empty/corrupt. **Do not trust `datadog-installer status` here** — it reflects DB registration, not whether files are actually present. Check the directory under `/opt/datadog-packages/datadog-apm-library-<lang>/` manually. If empty or missing, use `sudo datadog-installer remove datadog-apm-library-<lang>` first, then re-run the install script (see Remediation below).
+  - `already_instrumented` — process was already instrumented (usually fine).
+  - Import/load errors — tracer library couldn't be loaded. Check language compatibility.
+
+**Results with `result: abort`:**
+- Injection was intentionally skipped. `result_reason` explains why.
+- Common: process matched an exclusion rule, or the language wasn't detected.
+
+### Step 4 — Determine the service name
+
+With SSI, `DD_SERVICE` is never set in the process environment — the tracer determines the service name itself. To find what name it registered, read the tracer's memfd directly from the process.
+
+Each injected process has two anonymous memory files (memfds) accessible via `/proc/<pid>/fd/`:
+
+- **`/memfd:dd_inject_info`** — written by the injector (JSON): `language_name`, `language_version`, `runtime_id`
+- **`/memfd:datadog-tracer-info-*`** — written by the tracer (MessagePack): `service_name`, `service_env`, `service_version`, `hostname`, `tracer_version`
+
+To read the service name:
+
+```bash
+# Find the tracer memfd fd number
+sudo ls -la /proc/<pid>/fd/ | grep "datadog-tracer-info"
+
+# Decode it (msgpack is available since the tracer is running)
+sudo cat /proc/<pid>/fd/<fd_num> | python3 -c "import sys,msgpack; d=msgpack.unpackb(sys.stdin.buffer.read()); print(d)"
+```
+
+The `service_name` field in the decoded output is what the tracer registered with Datadog.
+
+**Alternative — discover via metrics without SSH:**
+
+If you don't want to SSH in, query the trace metrics grouped by service to discover the name:
+
+```bash
+pup metrics query --query "sum:trace.*.request.hits{host:<dd_hostname>} by {service}.as_count()" --from 5m
+```
+
+The `scope` field on each returned series will show `host:<dd_hostname>,service:<service_name>`.
+
+### Step 5 — Generate traffic and wait
+
+Traces only appear when requests hit the service. Before generating any traffic, ask the user:
+
+> "To verify tracing is working, I need some requests to hit your services. Is it OK for me to send a small amount of test traffic, or would you prefer to generate it yourself? If it's a production service, generating it yourself might be safer — just let me know when you've sent some requests."
+
+If they give the go-ahead, generate a small number of requests:
+
+```bash
+ssh <user>@<host> "for i in \$(seq 1 20); do curl -s http://localhost:<port>/ > /dev/null; done"
+```
+
+If they prefer to generate traffic themselves, wait for their confirmation before proceeding.
+
+**After traffic is generated, wait at least 30 seconds before checking anything.** The pipeline has multiple stages:
+- Tracer flushes to the trace-agent every ~1 second
+- The trace-agent batches and forwards to the backend over the next few seconds
+- Trace metrics (`trace.*.hits`) are on a ~10-second stats flush cycle
+- Backend indexing adds another 15-30 seconds before `pup traces search` returns results
+
+Do not check immediately after generating traffic. Run a `sleep 30` first.
+
+### Step 6 — Verify activity using trace metrics
+
+Trace metrics appear faster than indexed traces. Check them first:
+
+```bash
+pup metrics list --filter "trace." | grep "\.hits"
+pup metrics query --query "sum:trace.<operation>.hits{host:<dd_hostname>,service:<service_name>}.as_count()" --from 5m
+```
+
+If the query returns data points, the tracer on that host is running and emitting. The `host:` + `service:` combination scopes precisely to this host.
+
+Common operation names: `trace.flask.request`, `trace.django.request`, `trace.servlet.request` (Java), `trace.express.request` (Node), `trace.sinatra.request` (Ruby).
+
+**If metrics are still empty after 30 seconds**, wait another 30 seconds and retry before concluding there's a problem.
+
+### Step 7 — Confirm with trace search
+
+Once metrics show data, verify traces are searchable:
+
+```bash
+pup traces search --query "host:<dd_hostname>" --from 5m
+```
+
+The `service` field should match what you found in the tracer memfd.
+
+**If metrics have data but traces search returns nothing**, it's still indexing — wait another 30 seconds and retry. Do not start debugging until at least 60 seconds have passed since traffic was generated.
+
+**If the agent receiver shows traffic but metrics are empty after a minute**, the tracer may not be connecting to the agent socket. Enable debug logging by adding `DD_TRACE_DEBUG=true` and `DD_APM_INSTRUMENTATION_DEBUG=true` to the service environment, restart, and check `sudo journalctl -u <service> -n 50` for the agent URL and any connection errors.
+
+### Remediation: Reinstalling a Broken APM Package
+
+**Important caveat about `datadog-installer status`:** The status command reflects what's registered in `packages.db`, not whether the package files are actually present or intact. A package can show as installed while its directory is empty or corrupted. Don't rely on `status` alone to confirm a package is healthy.
+
+**If re-running the install script doesn't fix it**, the package may be registered in `packages.db` but broken on disk (empty directory, partial install, etc.). In that case the installer skips the download because it sees the package as already registered — and reports success misleadingly. The fix is to remove the registration first:
+
+```bash
+# Remove the broken package registration
+ssh <user>@<host> "sudo datadog-installer remove datadog-apm-library-<lang>"
+
+# Then re-run the install script — now it will properly download and extract
+ssh <user>@<host> "sudo DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+If the package is healthy, just re-running the install script is sufficient (it's idempotent). Only use `remove` first if the install script reports success but the problem persists.
+
+Note: `datadog-installer install <oci-url>` is not a viable manual repair path — package URLs come from Remote Config and can't be guessed or constructed from public registries.
+
+**APM packages managed by the installer** (all under `/opt/datadog-packages/`):
+- `datadog-apm-inject` — the launcher (`/etc/ld.so.preload` hook)
+- `datadog-apm-library-python`
+- `datadog-apm-library-java`
+- `datadog-apm-library-ruby`
+- `datadog-apm-library-js`
+- `datadog-apm-library-dotnet`
+- `datadog-apm-library-php`
+
+Check registered packages: `sudo datadog-installer status` (registration only — verify actual files exist under `/opt/datadog-packages/<package>/` if something looks wrong)
+
+### Remediation Loop
+
+If there are errors:
+1. Explain what the errors mean based on `result_reason` and `result_class`.
+2. Suggest fixes (re-run install script, check language support).
+3. Tell the user which services need to be restarted after the fix.
+4. After restarts, re-check: `pup apm troubleshooting list --hostname <dd_hostname> --timeframe 15m`
+5. Repeat until the user is satisfied.
+
+## Summary Checklist
+
+At the end, present the user with a summary:
+
+```
+Host Status:
+  <ssh_host_1> (<dd_hostname_1>): Agent ✓ | SSI ✓ | Instrumentation: <status>
+    Services instrumented: <list of services/ports>
+  <ssh_host_2> (<dd_hostname_2>): Agent ✓ | SSI ✓ | Instrumentation: <status>
+    Services instrumented: <list of services/ports>
+  ...
+```
+
+For each instrumented service, provide a direct link to its APM page:
+
+```
+https://app.<site>/apm/services/<service_name>
+```
+
+Where `<site>` comes from `pup auth status` and `<service_name>` was determined in Phase 6 Step 4. If the service has an env tag, append `?env=<env>`.
+
+Suggest next steps:
+- View traces: `pup traces search --query "service:<service_name>" --from 1h`
+- View APM services: `pup apm services list --env <env> --from 1h`
+- Set up monitors for the new services
+
+## Troubleshooting: pup Commands That May Return Errors
+
+Some `pup` commands may return errors depending on org configuration:
+- `pup fleet agents list` — always use `--filter "<hostname>"`. Without a filter it will time out (504). If it errors with a filter, fall back to `pup infrastructure hosts list --filter "<hostname>"`.
+- `pup api-keys list` — may return 403 or 503 in some orgs; direct the user to the web UI at /organization-settings/api-keys.
+- `pup apm services list` — may lag behind trace ingestion; empty results don't mean instrumentation failed. Use `pup traces search` for immediate confirmation.

--- a/dd-instrumentation/troubleshooting.md
+++ b/dd-instrumentation/troubleshooting.md
@@ -1,0 +1,288 @@
+# APM Troubleshooting — System Model & Tools
+
+When a user reports an APM issue, diagnose it using the tools and knowledge below. Do not assume the problem — outline diagnostic steps and gather evidence before concluding.
+
+**Critical: You do NOT need SSH access or kubectl access to start troubleshooting.** The `pup` CLI queries Datadog's backend directly over the API. Start with pup commands immediately using the information the user already gave you (hostname, service name, environment).
+
+**Your troubleshooting approach — always follow this order:**
+
+**Step 1: pup commands (no SSH/kubectl needed — do this FIRST):**
+- `pup apm troubleshooting list --hostname <hostname>` — check for SSI injection errors. Always run this first.
+- `pup apm service-library-config get --service-name <service>` — check the full SDK config. Look at `apm_enabled`, `trace_agent_url`, `site`, and the `source` of each config value.
+- `pup fleet tracers list --filter "hostname:<hostname>"` — see what tracers are running and their telemetry service names. If the user's service name doesn't match, this reveals the telemetry name to use.
+- `pup traces search --query "service:<service>" --from 15m` — check if traces exist.
+- `pup metrics query --query "sum:trace.*.request.hits{host:<hostname>,service:<service>}.as_count()" --from 15m` — check trace metrics (appear faster than indexed traces).
+- For K8s: `pup fleet instrumented-pods list <cluster-name>` — check if pods were targeted for injection.
+
+**Step 2: SSH (Linux) or kubectl (K8s) — only if pup didn't reveal the cause:**
+- SSH: check `/proc/<pid>/maps`, `datadog-agent status`, process environment
+- kubectl: check namespace labels, pod annotations, init containers, pod env vars
+
+**Step 3: Diagnose and remediate:**
+- Analyze what you found. Identify the specific failure.
+- Suggest a targeted fix based on the evidence.
+- After the fix, recommend re-running the pup diagnostic commands to verify.
+
+The `pup` program is included in this skill's directory.
+
+## How APM Works (What a Working Configuration Requires)
+
+A working APM setup is a pipeline with four components that must all be healthy:
+
+```
+Datadog Backend  <──>  Agent  <──>  Application (with SDK/Tracer)
+                         │
+                    Host / Node
+```
+
+**On Linux hosts (SSI):**
+- The Datadog Agent runs on the host and listens for traces (default: `localhost:8126`)
+- SSI uses `/etc/ld.so.preload` to load a launcher into every process at startup
+- The launcher detects the process language and loads the appropriate tracer library
+- The tracer sends spans to the Agent, which forwards them to the Datadog backend
+
+**On Kubernetes (SSI):**
+- The Admission Controller (a MutatingAdmissionWebhook) mutates pods at scheduling time
+- It injects init containers that install the tracer library and sets DD_ environment variables
+- The tracer in the pod sends traces to the Agent (running as a DaemonSet or sidecar)
+- The Agent forwards to the Datadog backend
+
+**For traces to appear in Datadog, every link in this chain must work:**
+1. Agent is running and connected to the backend
+2. Application is instrumented (tracer injected and loaded)
+3. Tracer is configured correctly (APM enabled, correct agent URL, correct site)
+4. Tracer can reach the Agent
+5. Application is receiving traffic (traces only appear when requests are processed)
+
+## Tools for Inspecting the Pipeline
+
+### pup — Datadog CLI (requires auth)
+
+**Authentication:**
+```bash
+pup auth status              # Check if authenticated; extract site field
+pup auth login               # OAuth login via browser
+```
+
+**Injection errors** (failures only — successful injections don't appear here):
+```bash
+pup apm troubleshooting list --hostname <dd_hostname>
+pup apm troubleshooting list --hostname <dd_hostname> --timeframe 4h
+```
+Returns `result` (error/abort), `result_class`, and `result_reason` per injection attempt.
+
+Common result_class values and what they mean:
+- `incorrect_installation` — required file missing or package directory empty/corrupt on disk. Note: `datadog-installer status` reflects DB registration, not actual file presence. Always verify files exist under `/opt/datadog-packages/<package>/`.
+- `already_instrumented` — process was already instrumented (usually benign)
+- Import/load errors — tracer library couldn't be loaded. Language compatibility issue or corrupt package.
+- Abort with "exclusion rule" — process matched DD_APM_INSTRUMENTATION_LIBRARIES_EXCLUDE or similar
+- Abort with "language not detected" — expected for non-application processes
+
+**SDK configuration** (what the tracer is actually configured to do):
+```bash
+# All tracer configs for a service
+pup apm service-library-config get --service-name <service>
+
+# Filter by env and language
+pup apm service-library-config get --service-name <service> --env <env> --language <lang>
+
+# Only show configs where instances disagree (config drift)
+pup apm service-library-config get --service-name <service> --mixed
+```
+Returns every config key grouped by service instance. Each entry has:
+- `name` — config key (e.g., `apm_enabled`, `service`, `trace_agent_url`, `env`, `site`)
+- `value` — current value
+- `source` — origin: `env_var`, `remote_config`, `code`, or `default`
+
+Config source priority: `code` > `env_var` > `remote_config` > `default`. A common issue is one source silently overriding another.
+
+**Important note on service identity:** The `service_name`, `service_env`, and `language_name` values in this endpoint come from the **SDK telemetry pipeline** — they reflect what the tracer itself reports based on its runtime configuration. These values may not match what appears in the Service Catalog, which can aggregate data from multiple sources (APM spans, USM, infrastructure tags, manual service definitions). The telemetry values are determined by:
+- **service_name**: `DD_SERVICE` env var, or code-level configuration, or auto-detected by the tracer from the process/framework (SSI default). On K8s, the Admission Controller may inject `DD_SERVICE` into the pod env. On Linux SSI, it's typically auto-detected from the process name.
+- **service_env**: `DD_ENV` env var, or code-level configuration. On K8s, often injected by the Admission Controller. On Linux, set system-wide or per-service.
+- **language_name**: Detected by the injector/launcher at injection time based on the process runtime. Not user-configurable.
+
+When troubleshooting "service not appearing" issues, check whether the telemetry-reported name matches what the user expects — the Service Catalog may show a different name than what the tracer is actually sending.
+
+**Known per-language name divergence (telemetry name vs span name):**
+- **JVM**: Telemetry reports jar artifact name with version (e.g., `inventory-service-1.0.0`), spans use the base name (`inventory-service`). Happens when `DD_SERVICE` is not set.
+- **Python**: Telemetry reports the `DD_SERVICE` value or inferred name (e.g., `order-service`), but spans may use the framework name (`fastapi`, `django`). Same process, different names — verified via runtime-id correlation.
+- **Node.js**: Names typically match between telemetry and spans.
+
+If a config lookup returns empty, use `pup fleet tracers list --filter "hostname:<host>"` to discover the telemetry names, then use those for `service-library-config get`.
+
+Key configs to understand:
+- `apm_enabled` — if false, tracer won't send traces. Check source to understand who disabled it.
+- `trace_agent_url` — where the tracer sends spans. Should be `http://localhost:8126` or a Unix socket on Linux, or the Agent service address on K8s.
+- `site` — must match the Datadog site from `pup auth status`. Mismatch = traces going to wrong org.
+- `service` — with SSI, `source: default` is expected (tracer auto-detects). May not match user expectations. See identity note above.
+- `env` — if unset, traces won't appear under the expected environment in Datadog UI.
+
+**Service config** (broader view of where a service is running):
+```bash
+pup apm service-config get --service-name <service> --env <env>
+```
+Returns service instances, config IDs, and hostnames.
+
+**Trace metrics** (fastest way to confirm traces are flowing):
+```bash
+pup metrics query --query "sum:trace.*.request.hits{host:<dd_hostname>,service:<service_name>}.as_count()" --from 15m
+```
+Trace metrics appear faster than indexed traces. Common operation names: `trace.flask.request`, `trace.django.request`, `trace.servlet.request`, `trace.express.request`.
+
+**Trace search:**
+```bash
+pup traces search --query "service:<service_name>" --from 15m
+pup traces search --query "host:<dd_hostname>" --from 15m
+```
+May lag behind metrics by 30-60 seconds due to indexing.
+
+**Fleet / infrastructure:**
+```bash
+pup fleet agents list --filter "<hostname>"     # Agent status, RC status, instrumentation status
+pup infrastructure hosts list --filter "<hostname>"  # Fallback if fleet errors
+```
+Always use `--filter` — without it, these commands timeout (504).
+
+**Fleet tracers** (telemetry-derived service names — needed to bridge the name mismatch):
+```bash
+# List tracers by hostname — returns telemetry service name, language, tracer version, runtime_ids
+pup fleet tracers list --filter "hostname:<hostname>"
+
+# List tracers by environment
+pup fleet tracers list --filter "env:<env>"
+```
+Use this when `service-library-config get` returns empty — the service name the user gave you may be the span name, not the telemetry name. Fleet tracers shows the telemetry names you need for config queries.
+
+**Instrumented pods** (K8s — confirms Admission Controller injected into pods):
+```bash
+pup fleet instrumented-pods list <cluster-name>
+```
+Returns which pods were targeted for injection by the Admission Controller. Use this as the first check for K8s troubleshooting — if a pod isn't listed here, it was never targeted.
+
+### SSH — Direct host inspection (Linux)
+
+**Agent status:**
+```bash
+ssh <user>@<host> "sudo datadog-agent status"
+```
+APM Agent section shows: `feature_auto_instrumentation_enabled`, `Receiver (previous minute)` (trace count), `Endpoints` (where traces are forwarded).
+
+**Agent connectivity diagnostics:**
+```bash
+ssh <user>@<host> "sudo datadog-agent diagnose --include connectivity-datadog-core-endpoints"
+```
+
+**Verify injection at process level:**
+```bash
+ssh <user>@<host> "sudo cat /proc/<pid>/maps | grep -E 'launcher|apm-library'"
+```
+- Launcher + language library present → injection succeeded
+- Launcher only, no library → launcher ran but injection failed
+- Nothing → `/etc/ld.so.preload` not set. Check with `cat /etc/ld.so.preload`
+
+**Read tracer's registered service name** (SSI doesn't set DD_SERVICE — tracer auto-detects):
+```bash
+# Find the tracer memfd
+sudo ls -la /proc/<pid>/fd/ | grep "datadog-tracer-info"
+# Decode it (MessagePack)
+sudo cat /proc/<pid>/fd/<fd_num> | python3 -c "import sys,msgpack; d=msgpack.unpackb(sys.stdin.buffer.read()); print(d)"
+```
+Returns `service_name`, `service_env`, `service_version`, `tracer_version`.
+
+**Check process environment for DD_ variables:**
+```bash
+ssh <user>@<host> "sudo cat /proc/<pid>/environ | tr '\0' '\n' | grep DD_"
+```
+
+**Discover listening services on a host:**
+```bash
+ssh <user>@<host> "sudo ss -lntp"
+```
+
+**Check installed APM packages:**
+```bash
+ssh <user>@<host> "sudo datadog-installer status"      # Registration only — verify files exist too
+ssh <user>@<host> "ls /opt/datadog-packages/"           # Actual packages on disk
+```
+
+APM packages managed by the installer (all under `/opt/datadog-packages/`):
+- `datadog-apm-inject` — the launcher (`/etc/ld.so.preload` hook)
+- `datadog-apm-library-python`, `-java`, `-ruby`, `-js`, `-dotnet`, `-php`
+
+### K8s SSI Verification Workflow (pup + kubectl)
+
+1. `pup fleet instrumented-pods list <cluster-name>` → confirms Admission Controller injected into pods
+2. `pup fleet tracers list --filter "env:<env>"` → confirms tracer is running and reporting telemetry
+3. `pup apm service-library-config get --service-name <name> --env <env>` → confirms tracer config is correct
+
+If step 1 shows the pod but step 2 doesn't show a tracer, the init containers may have failed. If step 2 shows a tracer but step 3 returns empty, there's a service name mismatch (see identity note above).
+
+### kubectl — Kubernetes inspection
+
+**Admission Controller running?**
+```bash
+kubectl get mutatingwebhookconfigurations | grep datadog
+```
+If missing, SSI won't work on K8s.
+
+**Namespace targeting** (SSI only mutates pods in labeled namespaces):
+```bash
+kubectl get namespaces --show-labels | grep admission.datadoghq.com
+```
+Look for `admission.datadoghq.com/mutate-pods: "true"`.
+
+**Pod mutation** (did the Admission Controller inject into this pod?):
+```bash
+kubectl get pod <pod> -n <ns> -o jsonpath='{.metadata.annotations}' | python3 -m json.tool
+```
+Look for `admission.datadoghq.com` annotations. If absent, pod was not mutated.
+
+**Init containers** (did SSI injection containers run?):
+```bash
+kubectl get pod <pod> -n <ns> -o jsonpath='{.status.initContainerStatuses[*].name}'
+kubectl get pod <pod> -n <ns> -o jsonpath='{.status.initContainerStatuses}'
+```
+Check if Datadog init containers are present and terminated successfully.
+
+**Pod environment** (what DD_ vars did the Admission Controller inject?):
+```bash
+kubectl exec <pod> -n <ns> -- env | grep DD_
+```
+Key: `DD_TRACE_AGENT_URL` or `DD_AGENT_HOST`, `DD_SERVICE`, `DD_ENV`, `DD_VERSION`.
+
+**Agent DaemonSet running?**
+```bash
+kubectl get pods -l app=datadog-agent --all-namespaces
+```
+
+## Remediation: Reinstalling a Broken APM Package (Linux)
+
+`datadog-installer status` reflects what's registered in `packages.db`, not whether files actually exist on disk. If injection fails with `incorrect_installation` but the installer says the package is installed, the registration is stale:
+
+```bash
+# Remove the stale registration
+ssh <user>@<host> "sudo datadog-installer remove datadog-apm-library-<lang>"
+
+# Re-run install — now it will actually download
+ssh <user>@<host> "sudo DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+After any remediation, affected services must be restarted for SSI to re-inject.
+
+## Known Limitations
+
+- `pup apm service-library-config get` — backed by **unstable endpoint**. May change or be unavailable. Fallback: check config via SSH process environ.
+- `pup apm troubleshooting list` — requires `--hostname`. Reports failures only, not successes. Data has 7-day TTL, 4h default window.
+- SDK config data freshness — no TTL on UKV storage, data dies out between deployments. App-extended-heartbeat implementation in progress across SDKs.
+- No direct API for "which services are SSI vs manual" — span tag inference (`svc.auto`, `entrypoint.*`) is unreliable.
+- No aggregated API for pod mutation status — Admission Controller logs at DEBUG level only.
+- `pup fleet agents list` — always use `--filter`. Without it, times out (504).
+
+## Common Troubleshooting Error Types (Linux SSI)
+
+These are the error types reported by `pup apm troubleshooting list`. Each has a `result_reason` field with a customer-facing explanation:
+
+- **Wrong Python version** — SSI requires a compatible Python version. Check `result_reason` for specifics.
+- **ddtrace already installed in app** — Application has its own ddtrace install that conflicts with the SSI-injected one. The `already_instrumented` result_class covers this.
+- **Package directory empty/corrupt** — `incorrect_installation` class. Use the remediation flow above.
+- **Language not supported** — Launcher couldn't find a matching tracer library for the detected language.


### PR DESCRIPTION
This PR adds a new "dd-instrumentation" skill, initially targeted at a few use cases:

* Datadog onboarding, currently with a specific focus on APM
* Datadog APM troubleshooting

This skill relies on the [`pup`](https://github.com/datadog-labs/pup) tool to communicate with Datadog.