### PR TITLE
[RFC] feat(dd-llmo): eval pipeline — classify → RCA → bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,35 +57,41 @@ npx skills add datadog-labs/agent-skills \
 
 ### LLM Observability (LLMO)
 
-The `dd-llmo` directory contains three skills for working with LLM Observability data:
+The `dd-llmo` directory contains five skills for working with LLM Observability data:
 
 | Skill | Purpose |
 |-------|---------|
 | `experiment-analyzer` | Analyze and compare offline LLM experiments |
-| `eval-trace-rca` | Root-cause production failures using eval judge signal |
-| `eval-bootstrap` | Generate evaluator code from traces, optionally seeded by RCA output |
+| `eval-session-classify` | Label production traces with pass/fail verdicts and failure modes |
+| `eval-trace-rca` | Root-cause production failures using eval signal (or classification output) |
+| `eval-bootstrap` | Generate evaluator code or a JSON spec from traces, optionally seeded by RCA |
+| `eval-pipeline` | End-to-end: classify traces → RCA → bootstrap, starting from just an ml_app |
 
 **Eval pipeline flow:**
 
 ```
-eval-trace-rca → eval-bootstrap
- (diagnose why)   (build evals)
+eval-session-classify → eval-trace-rca → eval-bootstrap
+  (label traces)         (diagnose why)   (build evals)
 ```
 
-Run `eval-trace-rca` to understand why an app is failing by analyzing eval judge verdicts across production traces. Then run `eval-bootstrap` to generate evaluator code that captures those failure patterns. Pass the RCA output directly to `eval-bootstrap` to seed it with the discovered failure taxonomy.
+Run `eval-session-classify` to label a sample of production traces with verdicts. That output feeds directly into `eval-trace-rca` for root cause analysis. Then `eval-bootstrap` turns the RCA output into evaluator code. Or run `eval-pipeline` to do all three in one guided flow.
+
+No pre-existing evaluators or labeled datasets required — the pipeline bootstraps from raw traces.
 
 #### Install
 
 ```bash
 # Claude Code — copy any or all skills
 cp -r dd-llmo/experiment-analyzer ~/.claude/skills
+cp -r dd-llmo/eval-session-classify ~/.claude/skills
 cp -r dd-llmo/eval-trace-rca ~/.claude/skills
 cp -r dd-llmo/eval-bootstrap ~/.claude/skills
+cp -r dd-llmo/eval-pipeline ~/.claude/skills
 ```
 
 #### MCP Requirements
 
-All three skills require the LLMO toolset:
+All skills require the LLMO toolset:
 
 ```bash
 claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'
@@ -106,7 +112,13 @@ experiment-analyzer <baseline_id> <candidate_id>            # compare two experi
 experiment-analyzer <id(s)> <question>                      # ask a specific question
 experiment-analyzer <id(s)> [question] --output notebook    # export to Datadog notebook
 
-# Root-cause why an app is failing
+# Full pipeline: raw traces → evaluator suite
+/eval-pipeline <ml_app>                                     # guided end-to-end
+/eval-pipeline <ml_app> --data-only                         # output JSON spec instead of Python
+
+# Or run steps individually:
+/eval-session-classify <ml_app>                             # label traces
+# (eval-trace-rca detects classify output automatically)
 What's wrong with <ml_app> based on its evals over the last 24h
 Analyze eval failures for <eval_name> over the last week
 

--- a/dd-llmo/eval-pipeline/SKILL.md
+++ b/dd-llmo/eval-pipeline/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: eval-pipeline
+description: End-to-end pipeline from unlabeled ml_app traces to a bootstrapped evaluator suite. Runs trace classification → root cause analysis → eval bootstrap in sequence with user checkpoints. Use when user says "run the eval pipeline", "go from traces to evals", "bootstrap evals end to end", "classify then RCA then bootstrap", "build an eval set from scratch", or wants a guided walkthrough from production data to evaluator code.
+---
+
+# Eval Pipeline — Classify → RCA → Bootstrap
+
+Walks from unlabeled production LLM trace data to a ready-to-use evaluator suite in three phases, with user checkpoints between each. No pre-existing evals or labeled data required.
+
+```
+eval-session-classify (ml_app mode)
+         ↓
+   eval-trace-rca (from classifications)
+         ↓
+   eval-bootstrap (from RCA output)
+```
+
+## Usage
+
+```
+/eval-pipeline <ml_app> [--timeframe <window>] [--trace-limit <N>] [--data-only]
+```
+
+Arguments: $ARGUMENTS
+
+### Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `ml_app` | Yes | — | LLM app to analyze end to end |
+| `--timeframe` | No | `now-7d` | Lookback window for trace sampling and RCA |
+| `--trace-limit` | No | `20` | Max traces to classify in Phase 1 |
+| `--data-only` | No | off | Pass through to eval-bootstrap: emit JSON spec instead of Python SDK code |
+
+If `ml_app` is not provided, ask the user before proceeding.
+
+---
+
+## Phase 1: Trace Classification
+
+Follow the **eval-session-classify** skill in **ml_app mode**, using:
+- `ml_app` = the provided ml_app
+- `timeframe` = the provided timeframe
+- `trace_limit` = the provided trace_limit
+
+Run the complete ml_app mode workflow as defined in that skill (Steps M1 through M4):
+sample traces → read content → classify each → emit per-trace blocks → emit summary.
+
+**Output the full classification output**, including all `## Trace: <id>` blocks and the final
+`# Session Classification Summary` section. Do not summarize or truncate this output —
+the downstream phase detection depends on the full text being present in context.
+
+---
+
+### CHECKPOINT 1
+
+After the `# Session Classification Summary` is output, pause and present:
+
+```
+## Phase 1 Complete
+
+[verdict distribution table]
+[failure mode frequency table]
+
+Before I continue to root cause analysis:
+- Do these failure patterns look right?
+- Any traces you'd like to exclude from the RCA?
+- Any failure modes to focus on or ignore?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+**Wait for explicit user confirmation before proceeding.**
+
+If the user excludes specific traces: remove them from the failure bucket by noting "excluded by user" — do NOT re-classify.
+If the user asks to re-run with different parameters: re-run Phase 1 with the new parameters.
+If Phase 1 yielded zero failures: surface this explicitly and offer to retry with a wider timeframe or stop.
+
+---
+
+## Phase 2: Root Cause Analysis
+
+Follow the **eval-trace-rca** skill in **"from classifications"** mode.
+
+The `# Session Classification Summary` from Phase 1 is in context. The skill detects it
+automatically via its Phase 0 check and enters Step 0S (failure bucket extraction).
+Run the full workflow through Phase 6 (the compiled RCA report).
+
+**Output the full RCA report** as defined in eval-trace-rca's Output Format section.
+Do not summarize — the full report must be in context for Phase 3's detection to work.
+
+---
+
+### CHECKPOINT 2
+
+After the RCA report is output, pause and present:
+
+```
+## Phase 2 Complete
+
+[the Phase 6 RCA report is above]
+
+Before I generate evaluators:
+- Do these root causes look accurate?
+- Any failure modes to add, remove, or reframe?
+- Which root causes should the evaluators target?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+**Wait for explicit user confirmation before proceeding.**
+
+If the user adjusts the taxonomy: note the changes and apply them before continuing.
+
+---
+
+## Phase 3: Eval Bootstrap
+
+Follow the **eval-bootstrap** skill in **"from RCA"** mode.
+
+The RCA report from Phase 2 is in context. The skill detects the `Failure Taxonomy` heading
+automatically and enters its "from RCA" path in Phase 0.
+
+If `--data-only` was specified: pass it through — the skill will emit a JSON spec instead
+of Python SDK code.
+
+**The eval-bootstrap skill has its own mandatory proposal checkpoint** (the evaluator suite
+proposal before code generation). Honor it — do not skip or auto-confirm it.
+
+---
+
+## Final Summary
+
+After Phase 3 completes, present:
+
+```markdown
+# Eval Pipeline Complete
+
+**App**: `<ml_app>`  |  **Timeframe**: <timeframe>
+
+| Phase | Output |
+|-------|--------|
+| 1. Classification | <N> traces sampled, <F> failures identified |
+| 2. Root Cause Analysis | <K> failure modes, <M> root causes diagnosed |
+| 3. Eval Bootstrap | <J> evaluators → `<output_path>` |
+
+## Key findings
+
+[3–5 bullets: most important failure patterns and what the evaluators capture]
+
+## Next steps
+
+1. Review the generated evaluators at `<output_path>`
+2. Run an offline experiment to validate eval quality
+3. Once validated, configure as production evals in Datadog
+```
+
+---
+
+## Orchestration Rules
+
+- **Always checkpoint before advancing** between phases. Never auto-proceed.
+- **Never truncate sub-skill outputs** — downstream phase detection depends on the full text being in context.
+- **Phase isolation**: if the user wants to re-run a single phase, re-run only that phase and its downstream phases.
+- **Carry context forward**: the output of each phase is the input for the next. Present the full output of each sub-skill before showing the checkpoint prompt.

--- a/dd-llmo/eval-session-classify/SKILL.md
+++ b/dd-llmo/eval-session-classify/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: eval-session-classify
+description: Classify a sample of LLM Obs traces from an ml_app to produce labeled verdicts (yes/partial/no) for downstream RCA and eval bootstrap. Use when user says "classify traces", "label traces", "classify sessions", "generate eval signal", "classify my app", or wants to produce verdict signal from production data before running eval-trace-rca or eval-pipeline.
+---
+
+# Skill: eval-session-classify
+
+Given an `ml_app`, samples production traces from LLM Observability and classifies each one: did the app accomplish the user's intent? Produces labeled verdicts that feed directly into `eval-trace-rca` and `eval-pipeline`.
+
+No pre-existing evaluators required. Classification is based on reading span content (input/output/messages) and any eval scores already on the span.
+
+---
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `ml_app` | Yes | — | LLM app to sample traces from |
+| `timeframe` | No | `now-7d` | How far back to sample |
+| `trace_limit` | No | `20` | Number of traces to classify (cap: 50) |
+
+If `ml_app` is not provided, ask the user.
+
+---
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `search_llmobs_spans` | Sample root spans from an ml_app |
+| `get_llmobs_span_details` | Get content_info map and any existing eval scores |
+| `get_llmobs_span_content` | Read span input, output, messages, documents, metadata |
+| `get_llmobs_agent_loop` | Full agent execution timeline for agent apps |
+
+---
+
+## Workflow
+
+### Step M1 — Sample traces
+
+```
+search_llmobs_spans(
+  ml_app          = "<ml_app>",
+  root_spans_only = true,
+  from            = "<timeframe>",
+  to              = "now",
+  limit           = 100,
+  query           = "@status:ok"
+)
+```
+
+From the results, randomly sample up to `trace_limit`. Then fetch span details in parallel — one call per trace:
+
+```
+get_llmobs_span_details(trace_id=<id>, span_ids=[<root_span_id>])
+```
+
+From `content_info`, determine **app type**:
+
+| Signal | App type |
+|--------|----------|
+| `content_info` has `messages` | LLM/chat |
+| `content_info` has `documents` | RAG |
+| Spans include `agent` kind | Agent |
+
+Note any existing eval scores in the `evaluations` map — these are additional signal for classification.
+
+If no spans found → stop, report `no_traces_found` and suggest checking the `ml_app` name and timeframe.
+
+### Step M2 — Read trace content (parallel)
+
+For each sampled trace, fetch content based on app type. Issue all calls in a single message.
+
+| App type | Calls to make |
+|----------|--------------|
+| LLM/chat | `get_llmobs_span_content(field="messages", path="$.messages[-1]")` — final response; `path="$.messages[0]"` — system prompt |
+| RAG | `get_llmobs_span_content(field="documents")` + `field="output"` |
+| Agent | `get_llmobs_agent_loop(trace_id, root_span_id)` |
+
+Also fetch `field="metadata"` if `content_info` shows it present — may contain task type, user segment, feature flags, or prompt versions.
+
+### Step M3 — Classify each trace
+
+For each trace, determine:
+
+1. **What the task was** — from the span input (user query, task description, or first user message)
+2. **What the app produced** — from span output or final assistant message
+3. **Whether it succeeded** — using the criteria below
+
+**Satisfaction criteria:**
+- `yes`: Output directly and completely addresses the task. No errors, truncation, or refusals. Content is coherent and accurate.
+- `partial`: Output addresses part of the task, is correct but incomplete, or shows evidence of degraded quality (vague answers, partial completions, excessive hedging).
+- `no`: Output fails to address the task — contains hallucinations, errors, empty responses, wrong tool use, or the task was structurally unachievable.
+
+If existing eval scores are present: treat low scores (bottom quartile or failed assessment) as additional evidence for `partial` or `no`.
+
+**Failure mode codes:**
+
+| Code | Meaning |
+|------|---------|
+| `wrong_answer` | Factually incorrect claim |
+| `incomplete_answer` | Correct but missed important paths |
+| `hallucination` | Invented facts, IDs, or URLs not in the data |
+| `wrong_tool_use` | Called wrong tool or with wrong parameters |
+| `excessive_turns` | Goal achieved but took too many round-trips |
+| `context_loss` | Forgot earlier context or repeated mistakes |
+| `broke_existing_state` | Damaged something the user had |
+| `other: <describe>` | |
+
+### Step M4 — Emit per-trace blocks and summary
+
+Emit a compact block for each trace as it is classified (do not wait for all to finish):
+
+```markdown
+## Trace: <trace_id>
+
+- **Span ID:** <root_span_id>
+- **Verdict:** yes | partial | no
+- **Failure mode:** <code> | none
+- **Failure mode detail:** <one sentence>
+- **App type:** LLM | RAG | Agent
+- **Signal:** content-only | content+evals
+```
+
+After all traces are classified, emit the summary. The `# Session Classification Summary` header is the **detection sentinel** for downstream skills (`eval-trace-rca`, `eval-pipeline`) — emit it exactly as shown:
+
+```markdown
+# Session Classification Summary
+
+**App:** `<ml_app>`  |  **Timeframe:** <from> → now  |  **Traces sampled:** <N>
+
+## Verdict Distribution
+
+| Verdict | Count | % |
+|---------|------:|:-:|
+| yes     | N     | % |
+| partial | N     | % |
+| no      | N     | % |
+
+## Failure Mode Frequency
+
+| Failure Mode | Count | % of failures |
+|-------------|------:|:-------------:|
+| <mode>      | N     | %             |
+
+## Per-Trace Details
+
+| Trace ID | Verdict | Failure Mode | Signal | Link |
+|----------|---------|-------------|--------|------|
+| <id_short> | yes | none | content-only | [link](https://app.datadoghq.com/llm/traces?query=trace_id:<full_id>) |
+```

--- a/dd-llmo/eval-trace-rca/SKILL.md
+++ b/dd-llmo/eval-trace-rca/SKILL.md
@@ -92,6 +92,53 @@ Additional filters combine with space (AND): `@evaluations.custom.<name>:* @stat
 
 ### Phase 0: Resolve Inputs
 
+**First: check for classification context.** Scan the conversation for a `# Session Classification Summary` header OR three or more `## Trace:` / `## Session:` blocks each containing a `**Verdict:**` line. If found → **"from classifications" path**: enter Step 0S below and skip steps 1–5.
+
+#### Step 0S — Extract Failure Bucket from Classification Output
+
+For each `## Trace: <id>` or `## Session: <id>` block in the conversation, extract:
+
+| Field | Source line |
+|-------|-------------|
+| `trace_id` | `## Trace: <trace_id>` header, or `**Trace ID:**` line |
+| `span_id` | `**Span ID:**` or `**Agent span ID:**` line |
+| `verdict` | `**Verdict:**` line |
+| `failure_mode` | `**Failure mode:**` line |
+| `reasoning_text` | `**Failure mode detail:**` line (construct as "verdict=no, failure_mode=X" if absent) |
+| `app_type` | `**App type:**` line (if present; default to `LLM` if absent) |
+
+**Failure bucket** = all traces/sessions where verdict is `no` or `partial` (exclude `yes` and `error`).
+
+If failure bucket has < 5 entries → note low confidence, proceed anyway.
+If failure bucket is empty → report "No failures found in the provided classification output" and stop.
+
+Synthesize and present this overview before continuing:
+
+```
+## Classification Overview (from eval-session-classify)
+
+**Source**: eval-session-classify  |  **ml_app**: <from summary header if present>
+**Traces/sessions classified**: N  |  **Failures (no+partial)**: F  |  **Pass rate**: X%
+
+Failure modes in failure bucket:
+| Mode | Count |
+...
+
+Proceeding to Phase 2 (open coding) using F failure traces as the corpus.
+No eval judge configured — classification verdict is the signal.
+```
+
+After presenting, **skip Phase 1 entirely and jump to Phase 2.**
+
+Carry forward:
+- **For Phase 2**: failure bucket = `[(trace_id, span_id, reasoning_text)]` tuples — identical structure to Step 1b output.
+- **For Phase 4**: evaluated span is the root span. If `app_type: Agent` is visible in any trace block, use `get_agent_loop` + child-span investigation; otherwise treat as `llm` span.
+- **Phases 2–7**: all run unchanged — the failure bucket structure is the same regardless of origin.
+
+---
+
+**Standard resolution (no classification context):**
+
 1. If neither `ml_app` nor `eval_name` provided → ask the user.
 2. If `timeframe` not provided → default to `now-24h`.
 3. **ml_app entry point**: If `ml_app` provided without `eval_name`, call `list_llmobs_evals(ml_app)` to discover all configured evals. Then call `get_llmobs_eval_aggregate_stats` for each eval (in parallel) to get a quick health snapshot. Present the overview to the user and proceed to analyze ALL evals with issues (don't ask the user to pick one).
@@ -101,6 +148,8 @@ Additional filters combine with space (AND): `@evaluations.custom.<name>:* @stat
 ---
 
 ### Phase 1: Gather Context & Collect Evidence
+
+> **Skip this entire phase if entering from the "from classifications" path (Step 0S).** Jump directly to Phase 2.
 
 **Goal**: Get the big picture, sample failure spans, and determine the app profile.
 
@@ -367,6 +416,21 @@ Write the full report following the Output Format below. **This is the primary d
 | Eval | Type | Total | Pass Rate | Status |
 |------|------|------:|:---------:|--------|
 | ... | ... | ... | ... | ... |
+}
+
+{If from classifications (Step 0S path):
+## Classification Signal Summary
+
+**Source**: eval-session-classify output (not eval judges)
+
+| Metric | Value |
+|--------|-------|
+| Traces/sessions classified | N |
+| Failures in RCA corpus (no+partial) | F |
+| Failure modes present | list |
+| Classification signal | content-only / content+evals / trace+rum |
+
+Note: Root cause analysis is based on per-trace classification verdicts, not automated eval judge reasoning.
 }
 
 {If custom eval:


### PR DESCRIPTION
> [!CAUTION]
> **RFC — DO NOT MERGE**
> This PR is open for review and discussion. Do not merge until the workflow has been validated end-to-end against a real ml_app.

## Overview

This PR adds an end-to-end eval pipeline that lets a user go from **unlabeled production LLM trace data** to a **bootstrapped evaluator suite** by pointing at a single `ml_app` — no pre-existing evals, no labeled datasets, no Datadog Evals SDK required to get started.

```
eval-session-classify → eval-trace-rca → eval-bootstrap
  (label traces)         (diagnose why)   (build evals)
```

---

## The problem this solves

The existing skills work well individually but can't be chained:

- `eval-trace-rca` needs evaluators already configured on spans to have something to analyze
- `eval-bootstrap` already supports RCA-seeded generation, but there's no path to get an RCA without pre-existing evals

For teams with a new or unevaluated LLM app, there was no starting point. This PR creates one.

---

## What's in this PR

### `eval-session-classify` (new)

Samples production root spans from an `ml_app` and classifies each one: did the app accomplish the user's intent? Classification is based on reading span content (input/output/messages) and any existing eval scores — no pre-existing evaluators required.

Outputs a structured `# Session Classification Summary` block with per-trace verdicts (`yes`/`partial`/`no`) and failure mode codes. This is the **detection sentinel** that `eval-trace-rca` uses to know classification output is in context.

> **Note on naming**: The skill is named `eval-session-classify` for future compatibility with a session concept for external apps. For now it operates on individual traces.

### `eval-trace-rca` (updated)

Phase 0 now checks for classification context before doing anything else. If `eval-session-classify` output is in context, it:

1. Extracts `(trace_id, span_id, verdict, failure_mode, detail)` from each classified trace
2. Builds a failure bucket from `no`/`partial` verdicts
3. Skips eval discovery entirely — no Datadog evaluators needed
4. Jumps directly to open coding, using the classification details as the signal

Phases 2–7 (open coding → axial coding → RCA → recommendations → report) are **completely unchanged** — the failure bucket structure is identical regardless of whether it came from eval judges or trace classifications.

### `eval-pipeline` (new)

A thin orchestrator that runs all three skills in sequence with user checkpoints:

```
Phase 1: eval-session-classify (ml_app mode)
         ↓  [CHECKPOINT: review failure patterns, exclude traces, adjust]
Phase 2: eval-trace-rca (from classifications path)
         ↓  [CHECKPOINT: review root causes, adjust taxonomy]
Phase 3: eval-bootstrap (from RCA output)
         ↓
  evaluator suite or JSON spec (--data-only)
```

Both checkpoints require explicit user confirmation. The orchestrator delegates fully to each sub-skill by reference — it adds only sequencing and checkpointing.

---

## How the pieces connect

The three skills are wired together by two detection contracts:

| Sentinel | Produced by | Consumed by |
|----------|-------------|-------------|
| `# Session Classification Summary` header | `eval-session-classify` | `eval-trace-rca` Phase 0 |
| `## Failure Taxonomy` heading | `eval-trace-rca` Phase 6 report | `eval-bootstrap` Phase 0 |

The second contract (`Failure Taxonomy` → `eval-bootstrap`) already existed. This PR adds the first.

---

## Proposed usage

```bash
# Full guided pipeline
/eval-pipeline my-llm-app

# Or manually, step by step:
/eval-session-classify my-llm-app --timeframe now-14d --trace-limit 30
# review the verdict table, then:
What's wrong with my-llm-app  # eval-trace-rca detects classify output automatically
# review the RCA report, then:
/eval-bootstrap my-llm-app    # eval-bootstrap detects RCA output automatically

# For teams not using the Datadog Evals SDK:
/eval-pipeline my-llm-app --data-only  # outputs framework-agnostic JSON spec
```

---

## RFC questions

- **Classification quality**: ml_app mode classifies purely from content. Is this signal good enough to seed a useful RCA, or do we need a minimum trace count / confidence threshold?
- **Failure mode taxonomy**: Does the current set (`wrong_answer`, `hallucination`, `wrong_tool_use`, etc.) translate well across different LLM app types? These codes were originally designed for an agent/chat context and are likely too specific — a RAG app or a simple LLM completion app may need a different taxonomy. Will need to generalize before this is broadly usable.
- **eval-session-classify naming**: The name anticipates a future session concept for external apps. Does that make sense as a forward-looking name, or is it confusing now?

## Test plan

- [ ] Run `/eval-session-classify <ml_app>` and verify `# Session Classification Summary` is emitted with correct per-trace blocks
- [ ] Run `eval-trace-rca` immediately after and verify Phase 0S fires (look for `## Classification Overview` in output, not `## Eval Overview`)
- [ ] Run `/eval-bootstrap` after the RCA and verify it enters "from RCA" mode (proposal table shown before code generation)
- [ ] Run `/eval-pipeline <ml_app>` end-to-end and verify both checkpoints pause for user input
- [ ] Run `/eval-pipeline <ml_app> --data-only` and verify JSON spec output from Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)