### PR TITLE
improvements to dd-apm skills

### DIFF
--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -81,6 +81,8 @@ tags.datadoghq.com/version: "1.0.0"
 
 ### Step 4: Restart app pods and verify SSI init containers
 
+> **Confirm with the user before restarting.** Tell the user: "I need to restart `<name>` in `<namespace>` for SSI to inject into the pods. This will cause a brief outage. Ready to proceed?" Wait for confirmation.
+
 ```bash
 kubectl rollout restart deployment/<name> -n <namespace>
 kubectl get pods -A -o json | grep -o '"datadog-lib[^"]*"' | sort -u

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -1,18 +1,100 @@
 ---
 name: dd-apm
-description: APM - traces, services, dependencies, performance analysis.
+description: APM - install, onboard, instrument, enable, set up, configure, traces, services, dependencies, performance analysis. Use for any request involving Datadog APM setup, instrumentation (SSI, ddtrace, agent install), or analysis.
+alwaysApply: true
 metadata:
   version: "1.0.1"
   author: datadog-labs
   repository: https://github.com/datadog-labs/agent-skills
-  tags: datadog,apm,tracing,performance,distributed-tracing,dd-apm
+  tags: datadog,apm,tracing,performance,distributed-tracing,dd-apm,install,onboarding,instrumentation,ssi,agent
   globs: "**/ddtrace*,**/datadog*.yaml,**/*trace*"
-  alwaysApply: "false"
 ---
 
 # Datadog APM
 
 Distributed tracing, service maps, and performance analysis.
+
+## Routing — Read This First
+
+**For Kubernetes APM install / instrument / onboard tasks — follow this procedure exactly:**
+
+> ⚠️ **Common wrong approaches that LOOK like they work but silently fail:**
+> - `helm install datadog datadog/datadog` — the standard chart does NOT support SSI via DatadogAgent CR. Do NOT use it.
+> - Adding `ddtrace` imports or `ddtrace-run` to the app — SSI auto-instruments WITHOUT any code changes.
+> - `admission.datadoghq.com/enabled` annotations — this is admission controller config injection, not SSI init container injection.
+
+### Step 0: Pre-flight checks (MANDATORY — run before installing anything)
+
+```bash
+# Check for ddtrace/otel — even without imports it SILENTLY DISABLES SSI at runtime
+grep -rn "ddtrace\|dd-trace\|opentelemetry" requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null || echo "No tracer dependency found"
+```
+
+If ddtrace found → remove that line entirely from the dependency file, rebuild image, reload into cluster, restart pod.
+
+### Step 1: Install the Datadog Operator (NOT `datadog/datadog`)
+
+```bash
+helm repo add datadog https://helm.datadoghq.com && helm repo update
+helm upgrade --install datadog-operator datadog/datadog-operator \
+  --namespace datadog --create-namespace
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=datadog-operator -n datadog --timeout=120s
+
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=$DD_API_KEY -n datadog
+```
+
+### Step 2: Create DatadogAgent CR with SSI enabled
+
+Save as `datadog-agent.yaml`, then `kubectl apply -f datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  namespace: datadog
+spec:
+  global:
+    site: <DD_SITE>
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+    kubelet:
+      tlsVerify: false  # required for kind/minikube; omit for cloud clusters
+  features:
+    apm:
+      instrumentation:
+        enabled: true
+```
+
+### Step 3: Apply Unified Service Tags to the application Deployment
+
+Add to **both** `metadata.labels` and `spec.template.metadata.labels`:
+```yaml
+tags.datadoghq.com/env: "dev"
+tags.datadoghq.com/service: "<service-name>"
+tags.datadoghq.com/version: "1.0.0"
+```
+
+### Step 4: Restart app pods and verify SSI init containers
+
+```bash
+kubectl rollout restart deployment/<name> -n <namespace>
+kubectl get pods -A -o json | grep -o '"datadog-lib[^"]*"' | sort -u
+```
+
+Expected: `"datadog-lib-python-init"` (or the language-appropriate init container).
+
+For full details read: `.claude/skills/k8s-ssi/agent-install/SKILL.md` then `.claude/skills/k8s-ssi/enable-ssi/SKILL.md`
+
+---
+
+**For Linux APM install/instrument tasks:** Read `.claude/skills/linux-ssi/agent-install/SKILL.md` then enable-ssi then verify-ssi.
+
+**For trace search, service analysis, metrics:** Continue below.
 
 ## Requirements
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -16,8 +16,6 @@ metadata:
 
 ## Phase 0: Load Credentials
 
-### Claude runs
-
 ```bash
 [ -f environment ] && source environment
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 ## Phase 0: Load Credentials
 
+> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
+
 ### Claude runs
 
 ```bash
@@ -38,17 +40,16 @@ Do not proceed until `helm` is available.
 
 **If `DD_API_KEY` is already set** — proceed to Prerequisites.
 
-**If `DD_API_KEY` is not set** — ask the user to create an `environment` file in this directory:
+**If `DD_API_KEY` is not set** — tell the user:
 
-```bash
-# environment  (this file is git-ignored — never commit it)
-export DD_API_KEY='your-api-key-here'
-export DD_SITE='datadoghq.com'   # change to your site
-```
+> "Please create an `environment` file in this directory (it's git-ignored and never committed):
+> ```bash
+> export DD_API_KEY='your-api-key-here'
+> export DD_SITE='datadoghq.com'
+> ```
+> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
 
-Tell the user: *"Create an `environment` file in this directory with your credentials (see above), then type `! source environment` to load it into our shared session. I'll wait."*
-
-Once created, run `source environment` and verify `DD_API_KEY` is set before continuing.
+Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
 
 > **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -16,12 +16,10 @@ metadata:
 
 ## Phase 0: Load Credentials
 
-> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
-
 ### Claude runs
 
 ```bash
-[ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
+[ -f environment ] && source environment
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
 echo "DD_SITE: ${DD_SITE:-not set}"
 echo "helm: $(helm version --short 2>/dev/null || echo NOT FOUND)"
@@ -42,16 +40,13 @@ Do not proceed until `helm` is available.
 
 **If `DD_API_KEY` is not set** — tell the user:
 
-> "Please create an `environment` file in this directory (it's git-ignored and never committed):
-> ```bash
-> export DD_API_KEY='your-api-key-here'
-> export DD_SITE='datadoghq.com'
+> Please run the following in this chat to set your credentials (the `!` prefix executes it in this session):
 > ```
-> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
+> ! export DD_API_KEY=your-api-key-here
+> ! export DD_SITE=datadoghq.com
+> ```
 
-Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
-
-> **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
+Once set, re-run the check above to confirm before continuing.
 
 ---
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -1,30 +1,18 @@
 ---
 name: dd-apm-k8s-agent-install
-description: Install the Datadog Agent on Kubernetes using the Datadog Operator. Covers Operator install, API key setup, DatadogAgent CR deployment, and key verification.
+description: Install the Datadog Agent on Kubernetes using the Datadog Operator — required before enabling Single Step Instrumentation (SSI), which automatically instruments applications for APM without code changes. Only use if no Datadog Agent is deployed on the cluster yet.
 metadata:
   version: "1.0.0"
   author: datadog-labs
   repository: https://github.com/datadog-labs/agent-skills
   tags: datadog,apm,kubernetes,agent,operator,install
   alwaysApply: "false"
+  tools: helm,kubectl,curl,pup
 ---
 
 # Install the Datadog Agent on Kubernetes
 
 > **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
-
-## Triggers
-
-Invoke this skill when the user expresses intent to:
-- Install or set up the Datadog Agent on a Kubernetes cluster
-- Deploy the Datadog Operator or a `DatadogAgent` custom resource
-- Get Datadog running on Kubernetes before enabling any product
-
-Do NOT invoke this skill if:
-- The Agent is already deployed — confirm with Step 1 first
-- The user only wants APM and the Agent is confirmed healthy — use `enable-ssi`
-
----
 
 ## Phase 0: Load Credentials
 
@@ -34,7 +22,19 @@ Do NOT invoke this skill if:
 [ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
 echo "DD_SITE: ${DD_SITE:-not set}"
+echo "helm: $(helm version --short 2>/dev/null || echo NOT FOUND)"
 ```
+
+**If `helm` is not found** — tell the user:
+
+> `helm` is required for this skill. Install it with:
+> ```bash
+> brew install helm        # macOS
+> # or see https://helm.sh/docs/intro/install/ for other platforms
+> ```
+> Once installed, let me know and I'll continue.
+
+Do not proceed until `helm` is available.
 
 **If `DD_API_KEY` is already set** — proceed to Prerequisites.
 
@@ -68,7 +68,7 @@ Once created, run `source environment` and verify `DD_API_KEY` is set before con
 | Variable | How to resolve |
 |---|---|
 | `CLUSTER_NAME` | Check repo IaC, scripts, or `kubectl config current-context` |
-| `DD_SITE` | Ask the user. Default: `datadoghq.com`. Options: `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com` |
+| `DD_SITE` | Ask the user. Default: `datadoghq.com`. Common options: `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`. Full list: https://docs.datadoghq.com/getting_started/site/ |
 | `AGENT_NAMESPACE` | Use `datadog` unless the repo already uses `datadog-agent` consistently |
 | `CHART_VERSION` | Run `helm search repo datadog/datadog-operator --versions \| head -5` and use the latest stable |
 
@@ -82,9 +82,9 @@ Once created, run `source environment` and verify `DD_API_KEY` is set before con
 helm list -A | grep -i datadog
 ```
 
-✅ A release shows `deployed` — Agent already installed. Skip to Step 5 to confirm health, then exit.
+If a release shows `deployed` — Agent already installed. Skip to Step 5 to confirm health, then exit.
 
-✅ No output — no existing install. Continue to Step 2.
+If there is no output — no existing install. Continue to Step 2.
 
 ---
 
@@ -107,9 +107,9 @@ kubectl wait --for=condition=Ready pod \
   --timeout=120s
 ```
 
-✅ Operator pod is Running.
+If the Operator pod is Running — continue to Step 3.
 
-❌ Pod not ready after 120s — check image pull: `kubectl describe pod -l app.kubernetes.io/name=datadog-operator -n <AGENT_NAMESPACE>`.
+ERROR: Pod not ready after 120s — check image pull: `kubectl describe pod -l app.kubernetes.io/name=datadog-operator -n <AGENT_NAMESPACE>`.
 
 ---
 
@@ -125,9 +125,9 @@ kubectl create secret generic datadog-secret \
   --namespace <AGENT_NAMESPACE>
 ```
 
-✅ `secret/datadog-secret created`
+If `secret/datadog-secret created` — continue to Step 4.
 
-❌ `AlreadyExists` — confirm which key it holds via Step 5 before deciding whether to recreate.
+ERROR: `AlreadyExists` — confirm which key it holds via Step 5 before deciding whether to recreate.
 
 ---
 
@@ -195,21 +195,27 @@ kubectl logs -l app.kubernetes.io/component=agent \
   || echo "No authentication errors found"
 ```
 
-✅ `No authentication errors found` — key is accepted.
+If `No authentication errors found` — key is accepted.
 
-❌ Authentication errors found — validate the key directly:
+ERROR: Authentication errors found — validate credentials directly:
 
 ### Claude runs
 
 ```bash
-RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X GET "https://api.<DD_SITE>/api/v1/validate" \
-  -H "DD-API-KEY: $DD_API_KEY")
-
-if [ "$RESPONSE" = "200" ]; then
-  echo "✅ API key is valid for <DD_SITE>"
+# Prefer pup (OAuth) — fall back to curl with API key
+if pup auth status 2>/dev/null | grep -q "Logged in"; then
+  echo "pup OAuth authenticated"
+elif [ -n "${DD_API_KEY:-}" ]; then
+  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X GET "https://api.<DD_SITE>/api/v1/validate" \
+    -H "DD-API-KEY: $DD_API_KEY")
+  if [ "$RESPONSE" = "200" ]; then
+    echo "API key is valid for <DD_SITE>"
+  else
+    echo "ERROR: Validation failed (HTTP $RESPONSE) — check key and site alignment"
+  fi
 else
-  echo "❌ Validation failed (HTTP $RESPONSE) — check key and site alignment"
+  echo "ERROR: No credentials available — run 'pup auth login' or set DD_API_KEY"
 fi
 ```
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: dd-apm-k8s-agent-install
+description: Install the Datadog Agent on Kubernetes using the Datadog Operator. Covers Operator install, API key setup, DatadogAgent CR deployment, and key verification.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,agent,operator,install
+  alwaysApply: "false"
+---
+
+# Install the Datadog Agent on Kubernetes
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Install or set up the Datadog Agent on a Kubernetes cluster
+- Deploy the Datadog Operator or a `DatadogAgent` custom resource
+- Get Datadog running on Kubernetes before enabling any product
+
+Do NOT invoke this skill if:
+- The Agent is already deployed — confirm with Step 1 first
+- The user only wants APM and the Agent is confirmed healthy — use `enable-ssi`
+
+---
+
+## Prerequisites
+
+- [ ] Kubernetes v1.20+ — `kubectl version`
+- [ ] helm v3+ — `helm version`
+- [ ] kubectl configured to target cluster — `kubectl config current-context`
+- [ ] User has a Datadog API key for the correct org and site
+- [ ] pup-cli installed — check with `pup --version`; if missing, install with `brew tap datadog-labs/pack && brew install pup`
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `CLUSTER_NAME` | Check repo IaC, scripts, or `kubectl config current-context` |
+| `DD_SITE` | Ask the user. Default: `datadoghq.com`. Options: `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com` |
+| `AGENT_NAMESPACE` | Use `datadog` unless the repo already uses `datadog-agent` consistently |
+| `CHART_VERSION` | Run `helm search repo datadog/datadog-operator --versions \| head -5` and use the latest stable |
+
+---
+
+## Step 1: Check for an Existing Agent Installation
+
+### Claude runs
+
+```bash
+helm list -A | grep -i datadog
+```
+
+✅ A release shows `deployed` — Agent already installed. Skip to Step 5 to confirm health, then exit.
+
+✅ No output — no existing install. Continue to Step 2.
+
+---
+
+## Step 2: Install the Datadog Operator
+
+### Claude runs
+
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm upgrade --install datadog-operator datadog/datadog-operator \
+  --namespace <AGENT_NAMESPACE> \
+  --create-namespace \
+  --version <CHART_VERSION>
+
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=datadog-operator \
+  -n <AGENT_NAMESPACE> \
+  --timeout=120s
+```
+
+✅ Operator pod is Running.
+
+❌ Pod not ready after 120s — check image pull: `kubectl describe pod -l app.kubernetes.io/name=datadog-operator -n <AGENT_NAMESPACE>`.
+
+---
+
+## Step 3: Create the API Key Secret
+
+### What you need to do in a terminal
+
+```bash
+export DD_API_KEY=<your-api-key>
+
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=$DD_API_KEY \
+  --namespace <AGENT_NAMESPACE>
+```
+
+✅ `secret/datadog-secret created`
+
+❌ `AlreadyExists` — confirm which key it holds via Step 5 before deciding whether to recreate.
+
+---
+
+## Step 4: Deploy the DatadogAgent Resource
+
+[DECISION: cluster type]
+- Self-hosted (minikube, kind): include `kubelet.tlsVerify: false` inside `spec.global`
+- Managed (GKE, EKS, AKS): omit `kubelet.tlsVerify` entirely
+
+[DECISION: APM/SSI also being enabled in this session]
+- If yes: do not create a separate `DatadogAgent` for APM — extend this same manifest with `features.apm` per `enable-ssi`. One manifest, not two.
+- If no: use the manifest below as-is.
+
+Save the following as `datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  namespace: <AGENT_NAMESPACE>
+spec:
+  global:
+    clusterName: <CLUSTER_NAME>
+    site: <DD_SITE>
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+    # Self-hosted clusters only (minikube, kind):
+    # kubelet:
+    #   tlsVerify: false
+  features:
+    orchestratorExplorer:
+      enabled: true
+    clusterChecks:
+      enabled: true
+    logCollection:
+      enabled: true
+      containerCollectAll: false
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/component=agent \
+  -n <AGENT_NAMESPACE> \
+  --timeout=120s 2>/dev/null || true
+```
+
+---
+
+## Step 5: Verify the API Key
+
+### Claude runs
+
+```bash
+kubectl logs -l app.kubernetes.io/component=agent \
+  -n <AGENT_NAMESPACE> \
+  --tail=50 2>/dev/null \
+  | grep -iE "invalid.*api\.?key|api\.?key.*invalid" \
+  || echo "No authentication errors found"
+```
+
+✅ `No authentication errors found` — key is accepted.
+
+❌ Authentication errors found — validate the key directly:
+
+### Claude runs
+
+```bash
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X GET "https://api.<DD_SITE>/api/v1/validate" \
+  -H "DD-API-KEY: $DD_API_KEY")
+
+if [ "$RESPONSE" = "200" ]; then
+  echo "✅ API key is valid for <DD_SITE>"
+else
+  echo "❌ Validation failed (HTTP $RESPONSE) — check key and site alignment"
+fi
+```
+
+If key is invalid:
+
+### What you need to do in a terminal
+
+```bash
+export DD_API_KEY=<new-api-key>
+
+kubectl delete secret datadog-secret -n <AGENT_NAMESPACE>
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=$DD_API_KEY \
+  -n <AGENT_NAMESPACE>
+
+kubectl rollout restart daemonset datadog-agent -n <AGENT_NAMESPACE>
+kubectl rollout restart deployment datadog-cluster-agent -n <AGENT_NAMESPACE>
+```
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Datadog Operator pod is Running in `AGENT_NAMESPACE`
+- [ ] `datadog-secret` exists in `AGENT_NAMESPACE`
+- [ ] Agent DaemonSet pods are Running
+- [ ] Step 5 returns no authentication errors
+
+Automatically proceed to `enable-ssi` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file, YAML block, or chat message — always use `$DD_API_KEY`
+- Never create a Kubernetes Secret manifest file — always use `kubectl create secret` imperatively
+- Never use `apiKey:` directly in `DatadogAgent` spec — always use `apiSecret:` with a secret reference
+- Never use `--set datadog.apiKey=...` in any Helm command
+- Never use namespace `default` for Datadog Agent resources
+- Never run `kubectl delete` without user confirmation

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -16,8 +16,6 @@ metadata:
 
 ## Phase 0: Load Credentials
 
-> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
-
 ### Claude runs
 
 ```bash
@@ -29,12 +27,7 @@ echo "helm: $(helm version --short 2>/dev/null || echo NOT FOUND)"
 
 **If `helm` is not found** — tell the user:
 
-> `helm` is required for this skill. Install it with:
-> ```bash
-> brew install helm        # macOS
-> # or see https://helm.sh/docs/intro/install/ for other platforms
-> ```
-> Once installed, let me know and I'll continue.
+> `helm` is required. Install it with `brew install helm` (macOS) or see https://helm.sh/docs/intro/install/. Let me know when it's ready.
 
 Do not proceed until `helm` is available.
 
@@ -42,16 +35,13 @@ Do not proceed until `helm` is available.
 
 **If `DD_API_KEY` is not set** — tell the user:
 
-> "Please create an `environment` file in this directory (it's git-ignored and never committed):
-> ```bash
-> export DD_API_KEY='your-api-key-here'
-> export DD_SITE='datadoghq.com'
-> ```
-> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
+> Your `DD_API_KEY` is not set. To avoid exposing it in chat history, create a temporary credentials file:
+> 1. Copy `environment.template` to `environment` and fill in your API key and site
+> 2. Run `! source environment` — the `!` prefix loads it into this shell session
+>
+> Once you've done that, I'll continue.
 
-Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
-
-> **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
+Wait. Once the user runs `! source environment`, re-run the bash check above to confirm `DD_API_KEY` is now set, then proceed.
 
 ---
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-k8s-agent-install
+name: agent-install
 description: Install the Datadog Agent on Kubernetes using the Datadog Operator — required before enabling Single Step Instrumentation (SSI), which automatically instruments applications for APM without code changes. Only use if no Datadog Agent is deployed on the cluster yet.
 metadata:
   version: "1.0.0"

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -26,12 +26,39 @@ Do NOT invoke this skill if:
 
 ---
 
+## Phase 0: Load Credentials
+
+### Claude runs
+
+```bash
+[ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
+echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
+echo "DD_SITE: ${DD_SITE:-not set}"
+```
+
+**If `DD_API_KEY` is already set** — proceed to Prerequisites.
+
+**If `DD_API_KEY` is not set** — ask the user to create an `environment` file in this directory:
+
+```bash
+# environment  (this file is git-ignored — never commit it)
+export DD_API_KEY='your-api-key-here'
+export DD_SITE='datadoghq.com'   # change to your site
+```
+
+Tell the user: *"Create an `environment` file in this directory with your credentials (see above), then type `! source environment` to load it into our shared session. I'll wait."*
+
+Once created, run `source environment` and verify `DD_API_KEY` is set before continuing.
+
+> **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
+
+---
+
 ## Prerequisites
 
 - [ ] Kubernetes v1.20+ — `kubectl version`
 - [ ] helm v3+ — `helm version`
 - [ ] kubectl configured to target cluster — `kubectl config current-context`
-- [ ] User has a Datadog API key for the correct org and site
 - [ ] pup-cli installed — check with `pup --version`; if missing, install with `brew tap datadog-labs/pack && brew install pup`
 
 ---

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -46,7 +46,7 @@ Do not proceed until `helm` is available.
 > ! export DD_SITE=datadoghq.com
 > ```
 
-Once set, re-run the check above to confirm before continuing.
+Wait for the user to run the commands, then re-run the check above before continuing.
 
 ---
 

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: dd-apm-k8s-enable-ssi
+description: Enable APM on Kubernetes via Single Step Instrumentation (SSI). Configures the DatadogAgent CR, adds Unified Service Tags, restarts pods, and triggers verification.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,instrumentation,single-step
+  alwaysApply: "false"
+---
+
+# Enable APM on Kubernetes via Single Step Instrumentation
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 0 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Enable APM on a Kubernetes cluster
+- Instrument Kubernetes applications with Datadog tracing
+- Set up Single Step Instrumentation (SSI)
+
+Do NOT invoke this skill if:
+- The Datadog Agent is not yet installed — run `agent-install` first
+- The user wants to verify SSI after setup — use `verify-ssi`
+- The user wants to enable Profiler, AppSec, or Data Streams — use `dd-apm-k8s-sdk-features`
+
+---
+
+## Prerequisites
+
+**Environment**
+- [ ] Datadog Agent is installed and healthy — `agent-install` complete
+- [ ] Kubernetes v1.20+
+- [ ] Linux node pools only — Windows pods require explicit namespace exclusion
+- [ ] Cluster is not ECS Fargate — unsupported
+- [ ] Not a hardened SELinux environment — unsupported
+- [ ] Not a very small VM instance (e.g. t2.micro) — SSI can hit init timeouts
+- [ ] No PodSecurity baseline or restricted policy enforced
+- [ ] Application container is **not Alpine Linux** — SSI requires glibc; Alpine uses musl libc which is ABI-incompatible. Use `python:3.x-slim`, `node:x-bookworm`, or any Debian/Ubuntu-based image
+
+**Language and runtime**
+- [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
+- [ ] Runtime version is within SSI's supported range — verify against the [SSI compatibility matrix](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/)
+- [ ] Node.js app is not using ESM — SSI does not support ESM
+- [ ] Java app is not already using a `-javaagent` JVM flag
+
+**Existing instrumentation**
+- [ ] Application has no existing `ddtrace` imports, OTel SDK calls, or custom `tracer.trace()` calls — SSI silently disables itself when detected; complete Step 0 first
+- [ ] `ddtrace` is not listed in the app's dependency manifest (`requirements.txt`, `package.json`, `Gemfile`, etc.) — SSI installs the tracer automatically
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Same namespace used in `agent-install` (e.g. `datadog`) |
+| `APP_NAMESPACE` | Ask the user which namespace their application runs in |
+| `TARGET_LANGUAGES` | Identify from repo — check Dockerfiles, package manifests, or ask the user |
+| `DEPLOYMENT_NAME` | Identify from repo or ask the user |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+| `CLUSTER_NAME` | Check `spec.global.clusterName` in `datadog-agent.yaml`, or `kubectl config current-context` — needed for kind clusters in Step 0 |
+
+---
+
+## Step 0 (Only if existing instrumentation detected): Remove Manual Instrumentation
+
+Scan all source files for: `import ddtrace`, `from ddtrace`, `require 'ddtrace'`, `require("dd-trace")`, `opentelemetry`, `tracer.trace(`
+
+Also check dependency manifests for `ddtrace` / `dd-trace` / OTel SDK packages.
+
+If found — remove the import/package, then rebuild and reload:
+
+### Claude runs
+
+```bash
+docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
+```
+
+[DECISION: cluster type]
+- kind (local): load the image into the cluster
+
+### Claude runs
+
+```bash
+kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
+```
+
+- Registry-based: skip — image will be pulled on next deployment
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod \
+  -l app=<APP_LABEL> \
+  -n <APP_NAMESPACE> \
+  --timeout=120s
+```
+
+---
+
+## Step 1: Extend the DatadogAgent Manifest with APM
+
+SSI is configured on the existing `DatadogAgent` resource — do not create a separate manifest.
+
+[DECISION: targeting scope — ask the user if unclear]
+- Cluster-wide: `enabled: true` with no `targets` or `enabledNamespaces`
+- Specific namespaces: `enabledNamespaces`
+- Specific pods: `targets` with `podSelector`
+- Excluding namespaces: `disabledNamespaces`
+
+Recommended `ddTraceVersions`: `java: "1"`, `python: "2"`, `js: "5"`, `dotnet: "3"`, `ruby: "2"`, `php: "1"`
+
+**Option A — Target specific workloads (recommended for production):**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      targets:
+        - name: <TARGET_NAME>
+          namespaceSelector:
+            matchNames:
+              - <APP_NAMESPACE>
+          ddTraceVersions:
+            <LANGUAGE>: "<MAJOR_VERSION>"
+```
+
+**Option B — Specific namespaces only:**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      enabledNamespaces:
+        - <APP_NAMESPACE>
+```
+
+**Option C — Cluster-wide with exclusions:**
+```yaml
+features:
+  apm:
+    instrumentation:
+      enabled: true
+      disabledNamespaces:
+        - jenkins
+        - kube-system
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+```
+
+✅ `datadogagent.datadoghq.com/datadog configured`
+
+❌ Validation error — check YAML. `enabledNamespaces` and `disabledNamespaces` cannot both be set.
+
+---
+
+## Step 2: Configure Unified Service Tags on Application Workloads
+
+Add UST labels to the Deployment under both `metadata.labels` and `spec.template.metadata.labels`:
+
+```yaml
+metadata:
+  labels:
+    tags.datadoghq.com/env: "<ENV>"
+    tags.datadoghq.com/service: "<SERVICE_NAME>"
+    tags.datadoghq.com/version: "<VERSION>"
+spec:
+  template:
+    metadata:
+      labels:
+        tags.datadoghq.com/env: "<ENV>"
+        tags.datadoghq.com/service: "<SERVICE_NAME>"
+        tags.datadoghq.com/version: "<VERSION>"
+```
+
+### Claude runs
+
+```bash
+kubectl apply -f <your-app-deployment.yaml>
+```
+
+---
+
+## Step 3: Restart Application Pods
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+
+kubectl wait --for=condition=Ready pod \
+  -l app=<APP_LABEL> \
+  -n <APP_NAMESPACE> \
+  --timeout=120s
+```
+
+✅ Pods restart cleanly. Init containers named `datadog-lib-<language>-init` visible in pod spec.
+
+❌ Pods crash-looping — check for existing custom instrumentation. See `troubleshoot-ssi`.
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] `features.apm.instrumentation` is present in the applied `DatadogAgent` manifest
+- [ ] Application pods have been restarted and are Running
+- [ ] UST labels are present on the Deployment and pod template
+- [ ] Scope confirmed: which workloads are instrumented, which were skipped and why
+
+Automatically proceed to `verify-ssi` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never use namespace `default` for Datadog resources
+- Never modify `admissionController` settings directly — SSI manages this via the Operator
+- Do not add APM config to application manifests — configure only via `DatadogAgent`
+- Exception: UST labels (`tags.datadoghq.com/*`) on application Deployments are required and intentional
+- Never run `kubectl delete` without user confirmation
+- `docker push` to a registry always requires user confirmation

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-k8s-enable-ssi
+name: enable-ssi
 description: Enable Single Step Instrumentation (SSI) on Kubernetes — automatically instruments applications for APM without code changes. Only use if the Datadog Agent is already running on the cluster — if not, use agent-install first.
 metadata:
   version: "1.0.0"

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -29,6 +29,8 @@ Do NOT invoke this skill if:
 
 ## Prerequisites
 
+> **These are not a reading exercise — actively verify each one before proceeding.**
+
 **Environment**
 - [ ] Datadog Agent is installed and healthy — `agent-install` complete
 - [ ] Kubernetes v1.20+
@@ -37,7 +39,18 @@ Do NOT invoke this skill if:
 - [ ] Not a hardened SELinux environment — unsupported
 - [ ] Not a very small VM instance (e.g. t2.micro) — SSI can hit init timeouts
 - [ ] No PodSecurity baseline or restricted policy enforced
-- [ ] Application container is **not Alpine Linux** — SSI requires glibc; Alpine uses musl libc which is ABI-incompatible. Use `python:3.x-slim`, `node:x-bookworm`, or any Debian/Ubuntu-based image
+
+**Base image — verify before proceeding:**
+
+### Claude runs
+
+```bash
+kubectl exec -n <APP_NAMESPACE> -l app=<APP_LABEL> -- ldd --version 2>&1 | head -1
+```
+
+✅ Output contains `glibc` or `GLIBC` or `GNU libc` — proceed.
+
+❌ Output contains `musl` — **stop**. SSI's injector requires glibc and is ABI-incompatible with musl libc. The injector will load but silently abort injection, and no traces will be sent. Switch the base image to a glibc-based equivalent (e.g. `python:X-slim`, `node:X-bookworm-slim`, any Debian/Ubuntu/UBI image), then rebuild, reload, restart the pod, and rerun this check before continuing.
 
 **Language and runtime**
 - [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
@@ -45,9 +58,21 @@ Do NOT invoke this skill if:
 - [ ] Node.js app is not using ESM — SSI does not support ESM
 - [ ] Java app is not already using a `-javaagent` JVM flag
 
-**Existing instrumentation**
-- [ ] Application has no existing `ddtrace` imports, OTel SDK calls, or custom `tracer.trace()` calls — SSI silently disables itself when detected; complete Step 0 first
-- [ ] `ddtrace` is not listed in the app's dependency manifest (`requirements.txt`, `package.json`, `Gemfile`, etc.) — SSI installs the tracer automatically
+**Existing instrumentation — verify before proceeding:**
+
+### Claude runs
+
+```bash
+# Check source files for manual tracer imports
+grep -r "import ddtrace\|from ddtrace\|require 'ddtrace'\|require(\"dd-trace\")\|opentelemetry\|tracer\.trace(" <SOURCE_DIR> 2>/dev/null || echo "No manual instrumentation found"
+
+# Check dependency manifests
+grep -rE "ddtrace|dd-trace|opentelemetry" requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null || echo "No tracer dependency found"
+```
+
+❌ Any match found — remove the import/package before continuing (see Step 0). SSI silently disables itself when existing instrumentation is detected.
+
+✅ No matches — proceed.
 
 ---
 
@@ -78,14 +103,19 @@ If found — remove the import/package, then rebuild and reload:
 docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
 ```
 
-[DECISION: cluster type]
-- kind (local): load the image into the cluster
+[DECISION: how does this cluster get local images?]
 
-### Claude runs
+Check the repo's setup script (e.g. `create.sh`, `Makefile`, `justfile`) for how images are loaded — do not guess from the cluster name or context. Common patterns:
 
-```bash
-kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
-```
+| What you find in the setup script | Load command |
+|---|---|
+| `minikube image load` or `minikube cache add` | `minikube -p <PROFILE> image load <IMAGE_NAME>` — profile is the `-p` flag value in the script, NOT necessarily the kubectl context name |
+| `kind load docker-image` | `kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>` |
+| `docker push` to a registry | Push the new image; the cluster will pull on restart — skip local load |
+| `k3d image import` | `k3d image import <IMAGE_NAME> -c <CLUSTER_NAME>` |
+| No image load step (cloud cluster, always pulls from registry) | Skip — image will be pulled on next deployment |
+
+If the setup script is ambiguous, run the load command it uses exactly as written.
 
 - Registry-based: skip — image will be pulled on next deployment
 

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -60,18 +60,6 @@ Do NOT invoke this skill if:
 - [ ] Not a very small VM instance (e.g. t2.micro) — SSI can hit init timeouts
 - [ ] No PodSecurity baseline or restricted policy enforced
 
-**Base image — verify before proceeding:**
-
-### Claude runs
-
-```bash
-kubectl exec -n <APP_NAMESPACE> -l app=<APP_LABEL> -- ldd --version 2>&1 | head -1
-```
-
-If the output contains `glibc` or `GLIBC` or `GNU libc` — proceed.
-
-ERROR: Output contains `musl` — **stop**. SSI's injector requires glibc and is ABI-incompatible with musl libc. The injector will load but silently abort injection, and no traces will be sent. Switch the base image to a glibc-based equivalent (e.g. `python:X-slim`, `node:X-bookworm-slim`, any Debian/Ubuntu/UBI image), then rebuild, reload, restart the pod, and rerun this check before continuing.
-
 **Language and runtime**
 - [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
 - [ ] Runtime version is within SSI's supported range — verify against the [SSI compatibility matrix](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/)

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -13,6 +13,26 @@ metadata:
 
 > **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 0 until every variable has a concrete value.
 
+---
+
+> **Silent failure — check this before any other step:**
+>
+> If the application has `ddtrace`, `dd-trace`, or any OpenTelemetry SDK in its **dependency manifest** (`requirements.txt`, `package.json`, `Gemfile`, `go.mod`, `pom.xml`) — even with no import statements in code — SSI will silently disable itself at runtime.
+>
+> The failure is invisible: init containers run and complete, the pod starts healthy, no errors appear in `kubectl` or `pup`, but no traces arrive. The injector detects the user-installed tracer and exits cleanly without logging anything.
+>
+> ### Claude runs
+>
+> ```bash
+> grep -rE "ddtrace|dd-trace|opentelemetry" \
+>   requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null \
+>   || echo "No tracer dependency found"
+> ```
+>
+> If any match — **stop**. Remove the package entirely (not just the import), rebuild the image, reload it into the cluster, and restart the pod before continuing. A package present in the manifest is enough to trigger this even if it is never imported.
+
+---
+
 ## Triggers
 
 Invoke this skill when the user expresses intent to:
@@ -58,21 +78,7 @@ ERROR: Output contains `musl` — **stop**. SSI's injector requires glibc and is
 - [ ] Node.js app is not using ESM — SSI does not support ESM
 - [ ] Java app is not already using a `-javaagent` JVM flag
 
-**Existing instrumentation — verify before proceeding:**
-
-### Claude runs
-
-```bash
-# Check source files for manual tracer imports
-grep -r "import ddtrace\|from ddtrace\|require 'ddtrace'\|require(\"dd-trace\")\|opentelemetry\|tracer\.trace(" <SOURCE_DIR> 2>/dev/null || echo "No manual instrumentation found"
-
-# Check dependency manifests
-grep -rE "ddtrace|dd-trace|opentelemetry" requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null || echo "No tracer dependency found"
-```
-
-ERROR: Any match found — remove the import/package before continuing (see Step 0). SSI silently disables itself when existing instrumentation is detected.
-
-If no matches — proceed.
+**Existing instrumentation** — confirmed clean by the check at the top of this skill. If you skipped that check, go back and run it now.
 
 ---
 

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -125,6 +125,8 @@ If the setup script is ambiguous, run the load command it uses exactly as writte
 
 - Registry-based: skip — image will be pulled on next deployment
 
+> **Confirm with the user before restarting.** Tell the user: "I need to restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>` to pick up the rebuilt image. Ready to proceed?" Wait for confirmation.
+
 ### Claude runs
 
 ```bash
@@ -225,6 +227,8 @@ kubectl apply -f <your-app-deployment.yaml>
 ---
 
 ## Step 3: Restart Application Pods
+
+> **Confirm with the user before restarting.** Tell the user: "I need to restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>` for SSI to inject into the pods. This will cause a brief outage. Ready to proceed?" Wait for confirmation.
 
 ### Claude runs
 

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-k8s-enable-ssi
-description: Enable APM on Kubernetes via Single Step Instrumentation (SSI). Configures the DatadogAgent CR, adds Unified Service Tags, restarts pods, and triggers verification.
+description: Enable Single Step Instrumentation (SSI) on Kubernetes — automatically instruments applications for APM without code changes. Only use if the Datadog Agent is already running on the cluster — if not, use agent-install first.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -48,9 +48,9 @@ Do NOT invoke this skill if:
 kubectl exec -n <APP_NAMESPACE> -l app=<APP_LABEL> -- ldd --version 2>&1 | head -1
 ```
 
-✅ Output contains `glibc` or `GLIBC` or `GNU libc` — proceed.
+If the output contains `glibc` or `GLIBC` or `GNU libc` — proceed.
 
-❌ Output contains `musl` — **stop**. SSI's injector requires glibc and is ABI-incompatible with musl libc. The injector will load but silently abort injection, and no traces will be sent. Switch the base image to a glibc-based equivalent (e.g. `python:X-slim`, `node:X-bookworm-slim`, any Debian/Ubuntu/UBI image), then rebuild, reload, restart the pod, and rerun this check before continuing.
+ERROR: Output contains `musl` — **stop**. SSI's injector requires glibc and is ABI-incompatible with musl libc. The injector will load but silently abort injection, and no traces will be sent. Switch the base image to a glibc-based equivalent (e.g. `python:X-slim`, `node:X-bookworm-slim`, any Debian/Ubuntu/UBI image), then rebuild, reload, restart the pod, and rerun this check before continuing.
 
 **Language and runtime**
 - [ ] Application language is one of: Java, Python, Ruby, Node.js, .NET, PHP
@@ -70,9 +70,9 @@ grep -r "import ddtrace\|from ddtrace\|require 'ddtrace'\|require(\"dd-trace\")\
 grep -rE "ddtrace|dd-trace|opentelemetry" requirements.txt package.json Gemfile go.mod pom.xml 2>/dev/null || echo "No tracer dependency found"
 ```
 
-❌ Any match found — remove the import/package before continuing (see Step 0). SSI silently disables itself when existing instrumentation is detected.
+ERROR: Any match found — remove the import/package before continuing (see Step 0). SSI silently disables itself when existing instrumentation is detected.
 
-✅ No matches — proceed.
+If no matches — proceed.
 
 ---
 
@@ -185,9 +185,9 @@ features:
 kubectl apply -f datadog-agent.yaml
 ```
 
-✅ `datadogagent.datadoghq.com/datadog configured`
+If `datadogagent.datadoghq.com/datadog configured` — continue to Step 2.
 
-❌ Validation error — check YAML. `enabledNamespaces` and `disabledNamespaces` cannot both be set.
+ERROR: Validation error — check YAML. `enabledNamespaces` and `disabledNamespaces` cannot both be set.
 
 ---
 
@@ -231,9 +231,9 @@ kubectl wait --for=condition=Ready pod \
   --timeout=120s
 ```
 
-✅ Pods restart cleanly. Init containers named `datadog-lib-<language>-init` visible in pod spec.
+If pods restart cleanly, init containers named `datadog-lib-<language>-init` will be visible in the pod spec.
 
-❌ Pods crash-looping — check for existing custom instrumentation. See `troubleshoot-ssi`.
+ERROR: Pods crash-looping — check for existing custom instrumentation. See `troubleshoot-ssi`.
 
 ---
 

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: dd-apm-k8s-onboarding-summary
+description: Generate a live APM onboarding confirmation report with deep links into the Datadog UI. Collects real data from the cluster and Datadog backend to confirm everything is working end-to-end.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,summary,verification
+  alwaysApply: "false"
+---
+
+# APM Onboarding Summary
+
+## Triggers
+
+Invoke this skill when:
+- All steps in `verify-ssi` have passed
+- All checks in `troubleshoot-ssi` have been resolved
+- The user asks "is everything working?", "show me the status", or "confirm APM is set up"
+
+Do NOT invoke this skill if any verification or troubleshooting check is still failing — resolve those first.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Namespace where Datadog Agent is installed |
+| `APP_NAMESPACE` | Namespace of the application |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+| `CLUSTER_NAME` | `spec.global.clusterName` in `datadog-agent.yaml` |
+| `SERVICE_NAME` | `tags.datadoghq.com/service` label on the Deployment |
+| `ENV` | `tags.datadoghq.com/env` label on the Deployment |
+| `DD_SITE` | `spec.global.site` in `datadog-agent.yaml` |
+
+---
+
+## Prerequisites
+
+### Claude runs
+
+```bash
+pup auth status
+```
+
+✅ Valid token — proceed.
+
+❌ Not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status` before continuing.
+
+---
+
+## Collect live confirmation data
+
+Run all of the following. Each populates a row in the final report.
+
+### Claude runs
+
+```bash
+# Agent pod count and status
+kubectl get pods -n <AGENT_NAMESPACE> \
+  -l app.kubernetes.io/component=agent \
+  --no-headers
+
+# SSI instrumentation config live in cluster
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> \
+  -o jsonpath='{.spec.features.apm.instrumentation}'
+
+# Init container confirmed in app pod spec
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
+
+# Pod confirmed in Datadog's instrumented-pods list
+pup fleet instrumented-pods list <CLUSTER_NAME>
+
+# Tracer active and reporting
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
+
+# Service visible in APM
+pup apm services list --env <ENV>
+
+# Traces arriving in the last hour
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+```
+
+---
+
+## Present the report
+
+Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row ❌ and link to `troubleshoot-ssi`.
+
+---
+
+**APM onboarding complete**
+
+| Check | Detail | Status |
+|---|---|---|
+| Datadog Agent | `<N>` pod(s) Running in `<AGENT_NAMESPACE>` | ✅ |
+| SSI enabled | Targeting namespace `<APP_NAMESPACE>`, language `<LANGUAGE>` v`<MAJOR_VERSION>` | ✅ |
+| Init container injected | `datadog-lib-<language>-init` present in pod spec | ✅ |
+| Pod instrumented | `<POD_NAME>` in `pup fleet instrumented-pods list` | ✅ |
+| Tracer reporting | Service `<SERVICE_NAME>`, `<LANGUAGE>`, tracer v`<TRACER_VERSION>` | ✅ |
+| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | ✅ |
+| Traces arriving | `<N>` trace(s) found in the last hour | ✅ |
+
+---
+
+**Your service in Datadog — click to open:**
+
+Construct each URL by substituting real values. Do not print placeholder URLs.
+
+| View | URL |
+|---|---|
+| Service overview | `https://app.<DD_SITE>/apm/services/<SERVICE_NAME>?env=<ENV>` |
+| Traces explorer | `https://app.<DD_SITE>/apm/traces?query=service:<SERVICE_NAME>%20env:<ENV>` |
+| Service map | `https://app.<DD_SITE>/apm/map?env=<ENV>&service=<SERVICE_NAME>` |
+| Agent fleet | `https://app.<DD_SITE>/fleet-automation` |
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -41,7 +41,7 @@ Do NOT invoke this skill if any verification or troubleshooting check is still f
 ### Claude runs
 
 ```bash
-pup auth status
+pup auth status --site <DD_SITE>
 ```
 
 ✅ Valid token — proceed.
@@ -51,10 +51,10 @@ pup auth status
 ### What you need to do in a terminal
 
 ```bash
-pup auth login
+pup auth login --site <DD_SITE>
 ```
 
-Confirm with `pup auth status` before continuing.
+Confirm with `pup auth status --site <DD_SITE>` before continuing.
 
 ---
 
@@ -78,17 +78,15 @@ kubectl get datadogagent datadog -n <AGENT_NAMESPACE> \
 kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
   -o jsonpath='{.items[0].spec.initContainers[*].name}'
 
-# Pod confirmed in Datadog's instrumented-pods list
-pup fleet instrumented-pods list <CLUSTER_NAME>
+# Pod confirmed instrumented — init containers in pod spec
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
 
-# Tracer active and reporting
-pup fleet tracers list --filter "service:<SERVICE_NAME>"
-
-# Service visible in APM
-pup apm services list --env <ENV>
+# Service visible and traced in APM
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 
 # Traces arriving in the last hour
-pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
 ```
 
 ---

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -48,13 +48,11 @@ If valid token — proceed.
 
 ERROR: Not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login --site <DD_SITE>
 ```
-
-Confirm with `pup auth status --site <DD_SITE>` before continuing.
 
 ---
 

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -54,6 +54,8 @@ ERROR: Not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 ---
 
 ## Collect live confirmation data

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-k8s-onboarding-summary
+name: onboarding-summary
 description: Generate a live Single Step Instrumentation (SSI) onboarding confirmation report — verifies APM instrumentation is working end-to-end with deep links into the Datadog UI. Only use after agent-install and enable-ssi have both completed successfully.
 metadata:
   version: "1.0.0"

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-k8s-onboarding-summary
-description: Generate a live APM onboarding confirmation report with deep links into the Datadog UI. Collects real data from the cluster and Datadog backend to confirm everything is working end-to-end.
+description: Generate a live Single Step Instrumentation (SSI) onboarding confirmation report — verifies APM instrumentation is working end-to-end with deep links into the Datadog UI. Only use after agent-install and enable-ssi have both completed successfully.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -44,9 +44,9 @@ Do NOT invoke this skill if any verification or troubleshooting check is still f
 pup auth status --site <DD_SITE>
 ```
 
-✅ Valid token — proceed.
+If valid token — proceed.
 
-❌ Not authenticated:
+ERROR: Not authenticated:
 
 ### What you need to do in a terminal
 
@@ -93,7 +93,7 @@ DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 1h -
 
 ## Present the report
 
-Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row ❌ and link to `troubleshoot-ssi`.
+Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row as failed and link to `troubleshoot-ssi`.
 
 ---
 
@@ -101,13 +101,13 @@ Fill in every value from live command output. Do not leave any placeholder unfil
 
 | Check | Detail | Status |
 |---|---|---|
-| Datadog Agent | `<N>` pod(s) Running in `<AGENT_NAMESPACE>` | ✅ |
-| SSI enabled | Targeting namespace `<APP_NAMESPACE>`, language `<LANGUAGE>` v`<MAJOR_VERSION>` | ✅ |
-| Init container injected | `datadog-lib-<language>-init` present in pod spec | ✅ |
-| Pod instrumented | `<POD_NAME>` in `pup fleet instrumented-pods list` | ✅ |
-| Tracer reporting | Service `<SERVICE_NAME>`, `<LANGUAGE>`, tracer v`<TRACER_VERSION>` | ✅ |
-| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | ✅ |
-| Traces arriving | `<N>` trace(s) found in the last hour | ✅ |
+| Datadog Agent | `<N>` pod(s) Running in `<AGENT_NAMESPACE>` | OK |
+| SSI enabled | Targeting namespace `<APP_NAMESPACE>`, language `<LANGUAGE>` v`<MAJOR_VERSION>` | OK |
+| Init container injected | `datadog-lib-<language>-init` present in pod spec | OK |
+| Pod instrumented | `<POD_NAME>` in `pup fleet instrumented-pods list` | OK |
+| Tracer reporting | Service `<SERVICE_NAME>`, `<LANGUAGE>`, tracer v`<TRACER_VERSION>` | OK |
+| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | OK |
+| Traces arriving | `<N>` trace(s) found in the last hour | OK |
 
 ---
 

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -119,8 +119,6 @@ Construct each URL by substituting real values. Do not print placeholder URLs.
 |---|---|
 | Service overview | `https://app.<DD_SITE>/apm/services/<SERVICE_NAME>?env=<ENV>` |
 | Traces explorer | `https://app.<DD_SITE>/apm/traces?query=service:<SERVICE_NAME>%20env:<ENV>` |
-| Service map | `https://app.<DD_SITE>/apm/map?env=<ENV>&service=<SERVICE_NAME>` |
-| Agent fleet | `https://app.<DD_SITE>/fleet-automation` |
 
 ---
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -53,13 +53,13 @@ pup auth status
 
 If not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login
 ```
 
-Confirm with `pup auth status`. If no browser available: `export DD_APP_KEY=<your-app-key>`.
+If no browser available: `export DD_APP_KEY=<your-app-key>`.
 
 ---
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -59,6 +59,8 @@ If not authenticated:
 pup auth login
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 If no browser available: `export DD_APP_KEY=<your-app-key>`.
 
 ---
@@ -165,6 +167,9 @@ kubectl get pods -n <AGENT_NAMESPACE>
 ```bash
 kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
 kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
+```
+
+```bash
 pup fleet instrumented-pods list <CLUSTER_NAME>
 ```
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-k8s-troubleshoot-ssi
-description: Diagnose and fix APM SSI issues on Kubernetes. Uses hypothesis-driven investigation — triage, form hypotheses, investigate iteratively, reflect, fix, verify.
+description: Diagnose and fix Single Step Instrumentation (SSI) issues on Kubernetes — SSI automatically instruments applications for APM without code changes. Only use if the agent and SSI are already configured but traces are missing or instrumentation is not working.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -331,9 +331,9 @@ pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
 pup fleet instrumented-pods list <CLUSTER_NAME>
 ```
 
-✅ Traces arriving + pod in instrumented list — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+If traces are arriving and the pod is in the instrumented list — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
 
-❌ Still not resolved — return to Step 2 with the new triage data and form updated hypotheses.
+ERROR: Still not resolved — return to Step 2 with the new triage data and form updated hypotheses.
 
 ---
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: dd-apm-k8s-troubleshoot-ssi
+description: Diagnose and fix APM SSI issues on Kubernetes. Uses hypothesis-driven investigation — triage, form hypotheses, investigate iteratively, reflect, fix, verify.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,troubleshooting,instrumentation
+  alwaysApply: "false"
+---
+
+# Troubleshoot APM SSI on Kubernetes
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Debug why a pod is not being instrumented
+- Investigate why traces are not appearing in Datadog
+- Diagnose admission webhook or init container injection failures
+- Follow up on failed checks from `verify-ssi`
+- Report that a specific service or pod has no traces
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `enable-ssi` first
+
+---
+
+## Prerequisites
+
+- [ ] kubectl configured to target cluster — `kubectl config current-context`
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status`. If no browser available: `export DD_APP_KEY=<your-app-key>`.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `AGENT_NAMESPACE` | Namespace where Datadog Agent is installed |
+| `APP_NAMESPACE` | Namespace of the application with missing traces |
+| `CLUSTER_NAME` | `kubectl config current-context` or `spec.global.clusterName` in `datadog-agent.yaml` |
+| `SERVICE_NAME` | `tags.datadoghq.com/service` label on the Deployment, or ask the user |
+| `ENV` | `tags.datadoghq.com/env` label on the Deployment, or ask the user |
+| `POD_NAME` | `kubectl get pods -n <APP_NAMESPACE>` — use the specific pod the user mentioned |
+| `DEPLOYMENT_NAME` | Check `metadata.name` in the Deployment manifest, or ask the user |
+| `APP_LABEL` | Check `spec.selector.matchLabels.app` in the Deployment manifest |
+
+---
+
+## How SSI Works — Domain Knowledge
+
+Read this before investigating. It gives you the mental model to reason about novel failures, not just known ones.
+
+**Injection chain:**
+1. Admission webhook (registered by Cluster Agent) intercepts pod creation
+2. Webhook mutates the pod spec — adds a `datadog-lib-<language>-init` init container
+3. Init container downloads the tracer library onto a shared volume
+4. `LD_PRELOAD` env var is set pointing to the library `.so` file
+5. Application process loads the library automatically on startup via `LD_PRELOAD`
+
+**What each diagnostic layer can see:**
+- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no instrumented pods, the problem is in the cluster.
+- **kubectl** — sees cluster state. Blind to whether data reached Datadog. If kubectl shows the init container but pup shows no traces, the problem is post-injection.
+
+**What healthy looks like:**
+- `pup fleet instrumented-pods list` shows the pod with correct language/version
+- `pup fleet tracers list` shows the service as active
+- `kubectl get pod -o jsonpath='{.spec.initContainers[*].name}'` includes `datadog-lib-<language>-init`
+
+**Known silent failures — SSI produces no error when these occur:**
+- **Alpine/musl libc** — `LD_PRELOAD` fails silently. SSI's `.so` is compiled against glibc; musl (Alpine Linux) is ABI-incompatible
+- **Existing ddtrace or OTel instrumentation** — SSI detects it and silently disables itself
+- **Unsupported runtime version** — silently skipped
+- **`admission.datadoghq.com/enabled: "false"` annotation** — webhook skips the pod entirely
+- **Pod not restarted after SSI enabled** — injection happens at startup; existing pods keep running uninstrumented
+- **Pod in Agent namespace** — SSI never instruments its own namespace
+
+**Reasoning shortcuts:**
+- No init container → webhook didn't fire → check: namespace targeting, pod-selector, opt-out annotation, webhook registration, pod not restarted
+- Init container present + no traces → injection attempted but failed or tracer not reporting → check: libc compatibility, existing ddtrace, runtime version, Agent connectivity, DD_SITE mismatch
+
+---
+
+## Step 1: Triage
+
+Run all four simultaneously. Everything after this is driven by what you find here.
+
+### Claude runs
+
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+pup fleet instrumented-pods list <CLUSTER_NAME>
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> \
+  -o jsonpath='{.spec.initContainers[*].name}'
+kubectl describe pod <POD_NAME> -n <APP_NAMESPACE> | grep -A 10 "Events:"
+```
+
+---
+
+## Step 2: State Your Hypotheses
+
+Before investigating, explicitly state your ranked hypotheses based on triage output. Do not skip this step.
+
+| Triage signal | Strong hypothesis |
+|---|---|
+| Traces arriving + pod in instrumented list | Not a real problem — likely a UI filter or time window. Tell the user and stop |
+| No traces + pod NOT in instrumented list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
+| No traces + pod NOT in instrumented list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
+| No traces + pod in instrumented list + init container present | Tracer injected but not reporting — investigate: connectivity, DD_SITE, API key |
+| Pod events show CrashLoopBackOff or init container errors | Init container failure — check libc (Alpine/musl), existing ddtrace, runtime version |
+| Traces arriving but wrong service/env | UST labels missing or misconfigured on the Deployment |
+
+State your top 1-3 hypotheses explicitly: *"Based on triage, I think the most likely cause is X because Y."*
+
+---
+
+## Step 3: Investigate
+
+Use only the tools relevant to your hypotheses. Each observation informs your next action.
+
+---
+
+### Cluster-side investigation tools
+
+**Is the pod in the Agent namespace?**
+SSI never instruments pods in the same namespace as the Datadog Agent.
+```bash
+kubectl get pods -n <AGENT_NAMESPACE>
+```
+
+**Were pods restarted after SSI was enabled?**
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+**Is namespace targeting filtering the pod out?**
+```bash
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> -o yaml | grep -A 15 instrumentation
+```
+Fix: update `enabledNamespaces` in `datadog-agent.yaml`.
+
+### Claude runs
+
+```bash
+kubectl apply -f datadog-agent.yaml
+```
+
+**Is a `podSelector` target filtering the pod out?**
+If `targets` with `podSelector` is configured, only pods whose labels match the selector are instrumented. Check whether the app pod's labels match any target:
+```bash
+kubectl get datadogagent datadog -n <AGENT_NAMESPACE> -o yaml | grep -A 20 targets
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> --show-labels
+```
+Fix: add a matching label to the pod template, or broaden the `podSelector`, then apply and restart.
+
+**Is a pod annotation opting it out?**
+`admission.datadoghq.com/enabled: "false"` tells the webhook to skip this pod.
+```bash
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> -o yaml | grep -A 5 annotations
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> --show-labels
+```
+Fix: remove the annotation from the Deployment pod template, then apply and restart.
+
+### Claude runs
+
+```bash
+kubectl apply -f <your-app-deployment.yaml>
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+```
+
+**Does the app have existing custom instrumentation?**
+SSI silently disables itself when it detects existing tracer code. Scan source files for:
+- Python: `import ddtrace`, `ddtrace.patch_all()`
+- Node.js: `require('dd-trace')`, `DD.init()`
+- Java: `GlobalTracer.register(`, `dd-java-agent`
+- .NET: `Tracer.Instance`, `DD.Trace`
+- Ruby: `require 'ddtrace'`, `Datadog.configure`
+- PHP: `DDTrace\`
+
+Also check dependency manifests: `requirements.txt`, `package.json`, `Gemfile`, `pom.xml`.
+
+Fix: remove the import/package, rebuild image, reload into cluster, restart pod.
+
+**Is the base image Alpine (musl libc)?**
+SSI's injected library requires glibc. Alpine uses musl — ABI-incompatible, fails silently.
+```bash
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "ldd --version 2>&1 | head -1"
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "cat /etc/os-release | grep -i 'ID\|NAME' | head -3"
+```
+Fix: rebuild with a glibc-based image (`python:3.x-slim`, `node:x-bookworm`, `eclipse-temurin`).
+
+**Is the runtime version supported?**
+```bash
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- python --version
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- node --version
+kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- java -version
+```
+Verify against [SSI compatibility matrix](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/).
+
+**Is the admission webhook registered?**
+```bash
+kubectl get mutatingwebhookconfigurations | grep datadog
+kubectl get pods -n <AGENT_NAMESPACE> -l app=datadog-cluster-agent
+kubectl logs -n <AGENT_NAMESPACE> -l app=datadog-cluster-agent --tail=100
+```
+
+**Did injection produce errors?**
+Get the node hostname first, then query Datadog for injection errors:
+```bash
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> -o jsonpath='{.spec.nodeName}'
+pup apm troubleshooting list --hostname <NODE_HOSTNAME> --timeframe 1h
+```
+
+**Is the Agent sending data to Datadog?**
+```bash
+kubectl exec -n <AGENT_NAMESPACE> \
+  $(kubectl get pod -n <AGENT_NAMESPACE> -l app=datadog-agent -o name | head -1) \
+  -- agent status | grep -A 5 "APM Agent"
+```
+
+---
+
+### Datadog-side investigation tools
+
+**Is the tracer reporting?**
+```bash
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
+```
+
+**Does APM recognise the service?**
+```bash
+pup apm services list --env <ENV>
+```
+
+**Are traces arriving?**
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 10
+```
+
+**Which agent is the tracer connected to?**
+Use if connectivity between tracer and Agent is suspected.
+```bash
+pup fleet agents list --filter "hostname:<NODE_HOSTNAME>"
+pup fleet agents tracers <AGENT_KEY> --filter "service:<SERVICE_NAME>"
+```
+
+---
+
+## Step 4: Reflect Before Concluding
+
+Before applying any fix, answer:
+1. What evidence confirms my hypothesis?
+2. What evidence would contradict it — and have I checked?
+3. Is there a simpler explanation I haven't considered?
+
+If the conclusion doesn't hold up, return to Step 2 with new hypotheses. Keep iterating until you can defend the conclusion against all three questions.
+
+---
+
+## Step 5: Fix
+
+Apply the fix for the confirmed root cause. If the fix requires a code or Dockerfile change, rebuild and reload:
+
+### Claude runs
+
+```bash
+docker build -f <DOCKERFILE_PATH> -t <IMAGE_NAME> <BUILD_CONTEXT>
+```
+
+[DECISION: cluster type]
+- kind (local): load the image into the cluster
+
+### Claude runs
+
+```bash
+kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
+```
+
+- Registry-based: skip — image will be pulled on next deployment
+
+### Claude runs
+
+```bash
+kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
+kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
+```
+
+---
+
+## Step 6: Verify
+
+Re-run triage to confirm the fix worked:
+
+### Claude runs
+
+```bash
+pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+✅ Traces arriving + pod in instrumented list — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+❌ Still not resolved — return to Step 2 with the new triage data and form updated hypotheses.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never run `kubectl delete` without user confirmation
+- Never modify `admissionController` settings directly
+- `docker push` to a registry always requires user confirmation

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-k8s-troubleshoot-ssi
+name: troubleshoot-ssi
 description: Diagnose and fix Single Step Instrumentation (SSI) issues on Kubernetes — SSI automatically instruments applications for APM without code changes. Only use if the agent and SSI are already configured but traces are missing or instrumentation is not working.
 metadata:
   version: "1.0.0"

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -99,7 +99,6 @@ Read this before investigating. It gives you the mental model to reason about no
 - `kubectl get pod -o jsonpath='{.spec.initContainers[*].name}'` includes `datadog-lib-<language>-init`
 
 **Known silent failures — SSI produces no error when these occur:**
-- **Alpine/musl libc** — `LD_PRELOAD` fails silently. SSI's `.so` is compiled against glibc; musl (Alpine Linux) is ABI-incompatible
 - **Existing ddtrace or OTel instrumentation** — SSI detects it and silently disables itself
 - **Unsupported runtime version** — silently skipped
 - **`admission.datadoghq.com/enabled: "false"` annotation** — webhook skips the pod entirely
@@ -138,7 +137,7 @@ Before investigating, explicitly state your ranked hypotheses based on triage ou
 | No traces + pod NOT in instrumented list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
 | No traces + pod NOT in instrumented list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
 | No traces + pod in instrumented list + init container present | Tracer injected but not reporting — investigate: connectivity, DD_SITE, API key |
-| Pod events show CrashLoopBackOff or init container errors | Init container failure — check libc (Alpine/musl), existing ddtrace, runtime version |
+| Pod events show CrashLoopBackOff or init container errors | Init container failure — check existing ddtrace, runtime version |
 | Traces arriving but wrong service/env | UST labels missing or misconfigured on the Deployment |
 
 State your top 1-3 hypotheses explicitly: *"Based on triage, I think the most likely cause is X because Y."*
@@ -225,12 +224,7 @@ Also check dependency manifests: `requirements.txt`, `package.json`, `Gemfile`, 
 Fix: remove the import/package, rebuild image, reload into cluster, restart pod.
 
 **Is the base image Alpine (musl libc)?**
-SSI's injected library requires glibc. Alpine uses musl — ABI-incompatible, fails silently.
-```bash
-kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "ldd --version 2>&1 | head -1"
-kubectl exec -n <APP_NAMESPACE> <POD_NAME> -- sh -c "cat /etc/os-release | grep -i 'ID\|NAME' | head -3"
-```
-Fix: rebuild with a glibc-based image (`python:3.x-slim`, `node:x-bookworm`, `eclipse-temurin`).
+K8s SSI injects `LD_PRELOAD` as an environment variable into the pod — it does not rely on `/etc/ld.so.preload`, so musl/Alpine images are supported. This is not a blocker for Kubernetes SSI.
 
 **Is the runtime version supported?**
 ```bash

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -160,6 +160,9 @@ kubectl get pods -n <AGENT_NAMESPACE>
 ```
 
 **Were pods restarted after SSI was enabled?**
+
+> **Confirm with the user before restarting.** Tell the user: "Pods must be restarted for SSI to inject into them. I'll restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>`. Ready to proceed?" Wait for confirmation.
+
 ```bash
 kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
 kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
@@ -198,6 +201,13 @@ Fix: remove the annotation from the Deployment pod template, then apply and rest
 
 ```bash
 kubectl apply -f <your-app-deployment.yaml>
+```
+
+> **Confirm with the user before restarting.** Tell the user: "I need to restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>` for this change to take effect. Ready to proceed?" Wait for confirmation.
+
+### Claude runs
+
+```bash
 kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
 ```
 
@@ -310,6 +320,8 @@ kind load docker-image <IMAGE_NAME> --name <CLUSTER_NAME>
 ```
 
 - Registry-based: skip — image will be pulled on next deployment
+
+> **Confirm with the user before restarting.** Tell the user: "I need to restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>` to apply the fix. Ready to proceed?" Wait for confirmation.
 
 ### Claude runs
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -109,7 +109,7 @@ Read this before investigating. It gives you the mental model to reason about no
 
 **Reasoning shortcuts:**
 - No init container → webhook didn't fire → check: namespace targeting, pod-selector, opt-out annotation, webhook registration, pod not restarted
-- Init container present + no traces → injection attempted but failed or tracer not reporting → check: libc compatibility, existing ddtrace, runtime version, Agent connectivity, DD_SITE mismatch
+- Init container present + no traces → injection attempted but failed or tracer not reporting → check: existing ddtrace, runtime version, Agent connectivity, DD_SITE mismatch
 
 ---
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -164,10 +164,14 @@ kubectl get pods -n <AGENT_NAMESPACE>
 
 > **Confirm with the user before restarting.** Tell the user: "Pods must be restarted for SSI to inject into them. I'll restart `<DEPLOYMENT_NAME>` in `<APP_NAMESPACE>`. Ready to proceed?" Wait for confirmation.
 
+### Claude runs
+
 ```bash
 kubectl rollout restart deployment/<DEPLOYMENT_NAME> -n <APP_NAMESPACE>
 kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --timeout=120s
 ```
+
+### Claude runs
 
 ```bash
 pup fleet instrumented-pods list <CLUSTER_NAME>

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-k8s-verify-ssi
-description: Verify APM SSI is working end-to-end on Kubernetes. Confirms pod instrumentation, tracer telemetry, and tracer config using pup fleet and pup apm commands.
+description: Verify Single Step Instrumentation (SSI) is working end-to-end on Kubernetes — SSI automatically instruments applications for APM without code changes. Only use after enable-ssi has run.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -64,8 +64,8 @@ pup auth login --site <DD_SITE>
 
 Confirm with `pup auth status`.
 
-✅ Valid token — proceed.
-❌ No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`
+If valid token — proceed.
+ERROR: No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`
 
 ---
 
@@ -88,9 +88,9 @@ kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
   -o jsonpath='{.items[0].spec.initContainers[*].name}'
 ```
 
-✅ Output includes `datadog-lib-<language>-init` and `datadog-init-apm-inject` — SSI init containers injected.
+If the output includes `datadog-lib-<language>-init` and `datadog-init-apm-inject` — SSI init containers are injected.
 
-❌ Init containers missing — pod was not restarted after SSI was enabled, or namespace targeting is not matching. Restart the pod and recheck.
+ERROR: Init containers missing — pod was not restarted after SSI was enabled, or namespace targeting is not matching. Restart the pod and recheck.
 
 ---
 
@@ -102,9 +102,9 @@ kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
 DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 ```
 
-✅ `<SERVICE_NAME>` appears in the services list with `isTraced: true`.
+If `<SERVICE_NAME>` appears in the services list with `isTraced: true` — continue to Step 3.
 
-❌ Service missing — send some traffic to the app first, then retry:
+ERROR: Service missing — send some traffic to the app first, then retry:
 
 ### Claude runs
 
@@ -116,7 +116,7 @@ sleep 30 && kill %1 2>/dev/null
 DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 10m
 ```
 
-❌ Still missing after traffic — check the agent's trace receiver: `kubectl exec -n <AGENT_NAMESPACE> <AGENT_POD> -c agent -- agent status | grep -A 10 "Receiver (previous minute)"`. If receiver shows 0 traces, go to `troubleshoot-ssi`.
+ERROR: Still missing after traffic — check the agent's trace receiver: `kubectl exec -n <AGENT_NAMESPACE> <AGENT_POD> -c agent -- agent status | grep -A 10 "Receiver (previous minute)"`. If receiver shows 0 traces, go to `troubleshoot-ssi`.
 
 ---
 
@@ -132,11 +132,11 @@ pup apm service-library-config get \
   --env <ENV>
 ```
 
-✅ Output shows expected environment variables matching what was configured in `ddTraceConfigs`.
+If the output shows expected environment variables matching what was configured in `ddTraceConfigs` — done.
 
-✅ Empty output and `ddTraceConfigs` was not configured — expected, not a failure.
+If the output is empty and `ddTraceConfigs` was not configured — expected, not a failure.
 
-❌ Config missing but `ddTraceConfigs` was configured — check it is present in the `DatadogAgent` manifest under the correct target, and that pods were restarted after the config change.
+ERROR: Config missing but `ddTraceConfigs` was configured — check it is present in the `DatadogAgent` manifest under the correct target, and that pods were restarted after the config change.
 
 ---
 

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-k8s-verify-ssi
+name: verify-ssi
 description: Verify Single Step Instrumentation (SSI) is working end-to-end on Kubernetes — SSI automatically instruments applications for APM without code changes. Only use after enable-ssi has run.
 metadata:
   version: "1.0.0"

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -56,13 +56,11 @@ pup auth status --site <DD_SITE>
 
 If not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login --site <DD_SITE>
 ```
-
-Confirm with `pup auth status`.
 
 If valid token — proceed.
 ERROR: No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: dd-apm-k8s-verify-ssi
+description: Verify APM SSI is working end-to-end on Kubernetes. Confirms pod instrumentation, tracer telemetry, and tracer config using pup fleet and pup apm commands.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,kubernetes,ssi,verification,instrumentation
+  alwaysApply: "false"
+---
+
+# Verify APM SSI on Kubernetes
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Confirm SSI is working after enabling APM
+- Check whether pods are being instrumented
+- Verify the tracer is running and reporting telemetry
+- Confirm tracer config is applied correctly
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `enable-ssi` first
+- Pods are not being instrumented at all — use `troubleshoot-ssi`
+
+---
+
+## Prerequisites
+
+- [ ] `enable-ssi` is complete
+- [ ] Application pods have been restarted since SSI was enabled
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login
+```
+
+Confirm with `pup auth status`.
+
+✅ Valid token — proceed.
+❌ No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `CLUSTER_NAME` | Check `spec.global.clusterName` in `datadog-agent.yaml`, or `kubectl config current-context` |
+| `ENV` | Check `tags.datadoghq.com/env` label on the application Deployment |
+| `SERVICE_NAME` | Check `tags.datadoghq.com/service` label on the application Deployment |
+
+---
+
+## Step 1: Confirm Pods are Instrumented
+
+### Claude runs
+
+```bash
+pup fleet instrumented-pods list <CLUSTER_NAME>
+```
+
+✅ Target pods appear with injected SDK language and version.
+
+❌ Expected pod missing — go to `troubleshoot-ssi`. Common causes: pod in Agent namespace, namespace targeting filtering it out, pod not restarted after SSI enabled.
+
+---
+
+## Step 2: Confirm the Tracer is Reporting Telemetry
+
+### Claude runs
+
+```bash
+pup fleet tracers list --filter "env:<ENV>"
+```
+
+✅ One or more tracer entries visible with service name, language, SDK version, and active status.
+
+❌ Service missing — tracer may still be initializing. Wait and retry:
+
+### Claude runs
+
+```bash
+sleep 120 && pup fleet tracers list --filter "env:<ENV>"
+```
+
+❌ Still missing after retry — go to `troubleshoot-ssi`.
+
+---
+
+## Step 3: Confirm Tracer Configuration
+
+**Only run this step if `ddTraceConfigs` was explicitly configured in `enable-ssi`** (e.g. profiling, AppSec, Data Streams). If basic SSI was set up without `ddTraceConfigs`, skip this step — an empty response here is expected and not a failure.
+
+### Claude runs
+
+```bash
+pup apm service-library-config get \
+  --service-name <SERVICE_NAME> \
+  --env <ENV>
+```
+
+✅ Output shows expected environment variables matching what was configured in `ddTraceConfigs`.
+
+✅ Empty output and `ddTraceConfigs` was not configured — expected, not a failure.
+
+❌ Config missing but `ddTraceConfigs` was configured — check it is present in the `DatadogAgent` manifest under the correct target, and that pods were restarted after the config change.
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Step 1: target pods appear in `instrumented-pods list`
+- [ ] Step 2: service appears in `tracers list` with active status
+- [ ] Step 3: tracer config matches what was set in `DatadogAgent`
+
+If any check fails, go to `troubleshoot-ssi`.
+
+When all steps pass, automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never run `kubectl delete` without user confirmation

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -62,6 +62,8 @@ If not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 If valid token — proceed.
 ERROR: No browser available — use API key fallback: `export DD_APP_KEY=<your-app-key>`
 

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -51,7 +51,7 @@ brew install pup
 
 Check auth:
 ```bash
-pup auth status
+pup auth status --site <DD_SITE>
 ```
 
 If not authenticated:
@@ -59,7 +59,7 @@ If not authenticated:
 ### What you need to do in a terminal
 
 ```bash
-pup auth login
+pup auth login --site <DD_SITE>
 ```
 
 Confirm with `pup auth status`.
@@ -84,12 +84,13 @@ Confirm with `pup auth status`.
 ### Claude runs
 
 ```bash
-pup fleet instrumented-pods list <CLUSTER_NAME>
+kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}'
 ```
 
-✅ Target pods appear with injected SDK language and version.
+✅ Output includes `datadog-lib-<language>-init` and `datadog-init-apm-inject` — SSI init containers injected.
 
-❌ Expected pod missing — go to `troubleshoot-ssi`. Common causes: pod in Agent namespace, namespace targeting filtering it out, pod not restarted after SSI enabled.
+❌ Init containers missing — pod was not restarted after SSI was enabled, or namespace targeting is not matching. Restart the pod and recheck.
 
 ---
 
@@ -98,20 +99,24 @@ pup fleet instrumented-pods list <CLUSTER_NAME>
 ### Claude runs
 
 ```bash
-pup fleet tracers list --filter "env:<ENV>"
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 ```
 
-✅ One or more tracer entries visible with service name, language, SDK version, and active status.
+✅ `<SERVICE_NAME>` appears in the services list with `isTraced: true`.
 
-❌ Service missing — tracer may still be initializing. Wait and retry:
+❌ Service missing — send some traffic to the app first, then retry:
 
 ### Claude runs
 
 ```bash
-sleep 120 && pup fleet tracers list --filter "env:<ENV>"
+# Port-forward and send test traffic
+kubectl port-forward deployment/<DEPLOYMENT_NAME> 8099:8000 -n <APP_NAMESPACE> &
+sleep 2 && for i in $(seq 1 10); do curl -s -o /dev/null http://localhost:8099/; done
+sleep 30 && kill %1 2>/dev/null
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 10m
 ```
 
-❌ Still missing after retry — go to `troubleshoot-ssi`.
+❌ Still missing after traffic — check the agent's trace receiver: `kubectl exec -n <AGENT_NAMESPACE> <AGENT_POD> -c agent -- agent status | grep -A 10 "Receiver (previous minute)"`. If receiver shows 0 traces, go to `troubleshoot-ssi`.
 
 ---
 

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -46,7 +46,7 @@ echo "DD_SITE: ${DD_SITE:-not set}"
 > ! export DD_SITE=datadoghq.com
 > ```
 
-Once set, re-run the check above to confirm before continuing.
+Wait for the user to run the commands, then re-run the check above before continuing.
 
 ---
 

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-linux-agent-install
-description: Install the Datadog Agent on Linux hosts via SSH. Gathers host list and SSH details, checks for existing installs, runs one-line install with SSI enabled, verifies agent is healthy.
+description: Install the Datadog Agent on Linux hosts via SSH with Single Step Instrumentation (SSI) enabled — SSI automatically instruments applications for APM without code changes. Only use if no agent is installed yet.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -72,8 +72,8 @@ Verify SSH works for each host before proceeding:
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "hostname"
 ```
 
-✅ Returns a hostname — proceed.
-❌ Connection refused or timeout — resolve connectivity before continuing.
+If it returns a hostname — proceed.
+ERROR: Connection refused or timeout — resolve connectivity before continuing.
 
 Once SSH is confirmed, present a plan to the user before proceeding. For example:
 
@@ -102,9 +102,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "uname -m && cat /etc/os-release | grep -E '^(ID|VERSION_ID|PRETTY_NAME)='"
 ```
 
-✅ Architecture is `x86_64` or `aarch64`, OS is a supported distribution (Ubuntu 16.04+, Debian 9+, RHEL/CentOS 6–9, Amazon Linux 2/2023, SUSE 12+) — proceed.
+If architecture is `x86_64` or `aarch64`, and the OS is a supported distribution (Ubuntu 16.04+, Debian 9+, RHEL/CentOS 6-9, Amazon Linux 2/2023, SUSE 12+) — proceed.
 
-❌ Architecture is `armv7l` (32-bit ARM) or unsupported OS — stop. Datadog Agent 7 and SSI do not support this configuration.
+ERROR: Architecture is `armv7l` (32-bit ARM) or unsupported OS — stop. Datadog Agent 7 and SSI do not support this configuration.
 
 ---
 
@@ -134,17 +134,17 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 
 `DD_APM_INSTRUMENTATION_ENABLED=host` causes the install script to also install `datadog-apm-inject` and language library packages under `/opt/datadog-packages/` in one pass.
 
-✅ Script completes without errors — proceed to Phase 2.
+If the script completes without errors — proceed to Phase 2.
 
-❌ `curl: command not found`:
+ERROR: `curl: command not found`:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "apt-get install -y curl 2>/dev/null || yum install -y curl"
 ```
 
-❌ Permission error — ensure the SSH user has sudo access. The install script requires root.
+ERROR: Permission error — ensure the SSH user has sudo access. The install script requires root.
 
-❌ Script fails with GPG key error — retry; if it persists, check the host's DNS resolution for `keys.datadoghq.com`.
+ERROR: Script fails with GPG key error — retry; if it persists, check the host's DNS resolution for `keys.datadoghq.com`.
 
 ---
 
@@ -157,20 +157,20 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo datadog-agent status 2>&1 | head -40"
 ```
 
-✅ Shows:
+Healthy output shows:
 - `Agent (v7.XX.X)` with `Status: Running`
 - `API Keys status: API Key ending with XXXX: Valid`
 
-❌ `command not found` — installation did not complete. Re-run Phase 1.
+ERROR: `command not found` — installation did not complete. Re-run Phase 1.
 
-❌ `API key invalid` — update and restart:
+ERROR: `API key invalid` — update and restart:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo sed -i 's/^api_key:.*/api_key: <NEW_API_KEY>/' /etc/datadog-agent/datadog.yaml && \
    (sudo systemctl restart datadog-agent 2>/dev/null || sudo service datadog-agent restart)"
 ```
 
-❌ Agent service not running:
+ERROR: Agent service not running:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo systemctl start datadog-agent 2>/dev/null && sudo systemctl enable datadog-agent 2>/dev/null || sudo service datadog-agent start"
@@ -182,9 +182,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "ls /opt/datadog-packages/ && sudo datadog-installer status 2>/dev/null | grep apm | head -10"
 ```
 
-✅ `/opt/datadog-packages/datadog-apm-inject` exists — injection is available.
+If `/opt/datadog-packages/datadog-apm-inject` exists — injection is available.
 
-❌ Directory missing or empty — `datadog-installer status` may show the package as registered while its directory is actually empty (stale registration). Reinstall:
+ERROR: Directory missing or empty — `datadog-installer status` may show the package as registered while its directory is actually empty (stale registration). Reinstall:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo datadog-installer remove datadog-apm-inject && \
@@ -198,9 +198,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo datadog-agent status 2>&1 | grep -iE '^\s+Hostname' | head -3"
 ```
 
-✅ `Hostname: <some-name>` — hostname resolved. Record this as `DD_HOSTNAME` for all subsequent steps.
+If `Hostname: <some-name>` is shown — hostname resolved. Record this as `DD_HOSTNAME` for all subsequent steps.
 
-❌ `Hostname: (none)` or any DNS resolution error — the agent can't resolve its own FQDN. Fix by setting the hostname explicitly in `datadog.yaml`:
+ERROR: `Hostname: (none)` or any DNS resolution error — the agent can't resolve its own FQDN. Fix by setting the hostname explicitly in `datadog.yaml`:
 
 ```bash
 # Read the actual system hostname

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -28,6 +28,8 @@ Do NOT invoke this skill if:
 
 ## Phase 0: Load Credentials
 
+> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
+
 ### Claude runs
 
 ```bash
@@ -39,19 +41,16 @@ echo "DD_SITE: ${DD_SITE:-not set}"
 
 **If `DD_API_KEY` is already set** — proceed directly to gathering infrastructure info.
 
-**If `DD_API_KEY` is not set** — ask the user to create an `environment` file in this directory:
+**If `DD_API_KEY` is not set** — tell the user:
 
-```bash
-# environment  (this file is git-ignored — never commit it)
-export DD_API_KEY='your-api-key-here'
-export DD_SITE='datadoghq.com'   # change to your site
-```
+> "Please create an `environment` file in this directory (it's git-ignored and never committed):
+> ```bash
+> export DD_API_KEY='your-api-key-here'
+> export DD_SITE='datadoghq.com'
+> ```
+> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
 
-Tell the user: *"Create an `environment` file in this directory with your credentials (see above), then type `! source environment` to load it into our shared session. I'll wait."*
-
-Once created, run `source environment` and verify `DD_API_KEY` is now set before continuing.
-
-> **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
+Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
 
 ---
 

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -28,13 +28,10 @@ Do NOT invoke this skill if:
 
 ## Phase 0: Load Credentials
 
-> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
-
 ### Claude runs
 
 ```bash
-# Check for a local environment file
-[ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
+[ -f environment ] && source environment
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
 echo "DD_SITE: ${DD_SITE:-not set}"
 ```
@@ -43,14 +40,13 @@ echo "DD_SITE: ${DD_SITE:-not set}"
 
 **If `DD_API_KEY` is not set** — tell the user:
 
-> "Please create an `environment` file in this directory (it's git-ignored and never committed):
-> ```bash
-> export DD_API_KEY='your-api-key-here'
-> export DD_SITE='datadoghq.com'
+> Please run the following in this chat to set your credentials (the `!` prefix executes it in this session):
 > ```
-> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
+> ! export DD_API_KEY=your-api-key-here
+> ! export DD_SITE=datadoghq.com
+> ```
 
-Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
+Once set, re-run the check above to confirm before continuing.
 
 ---
 

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: dd-apm-linux-agent-install
+description: Install the Datadog Agent on Linux hosts via SSH. Gathers host list and SSH details, checks for existing installs, runs one-line install with SSI enabled, verifies agent is healthy.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,linux,agent,install,ssi,ssh
+  alwaysApply: "false"
+---
+
+# Install Datadog Agent on Linux
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Install the Datadog Agent on Linux hosts or VMs
+- Set up Datadog monitoring on bare-metal or cloud Linux instances
+- Prepare Linux hosts for APM onboarding
+
+Do NOT invoke this skill if:
+- The Agent is already installed on all hosts — check with `datadog-agent status` first
+- The target is a Kubernetes cluster — use `dd-apm-k8s-agent-install` instead
+
+---
+
+## Phase 0: Load Credentials
+
+### Claude runs
+
+```bash
+# Check for a local environment file
+[ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
+echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
+echo "DD_SITE: ${DD_SITE:-not set}"
+```
+
+**If `DD_API_KEY` is already set** — proceed directly to gathering infrastructure info.
+
+**If `DD_API_KEY` is not set** — ask the user to create an `environment` file in this directory:
+
+```bash
+# environment  (this file is git-ignored — never commit it)
+export DD_API_KEY='your-api-key-here'
+export DD_SITE='datadoghq.com'   # change to your site
+```
+
+Tell the user: *"Create an `environment` file in this directory with your credentials (see above), then type `! source environment` to load it into our shared session. I'll wait."*
+
+Once created, run `source environment` and verify `DD_API_KEY` is now set before continuing.
+
+> **Why a file?** Claude's shell session is separate from your terminal — `export` commands in your terminal don't reach here. The `environment` file is the persistent, session-safe way to pass credentials. It is git-ignored so it will never be committed.
+
+---
+
+## Phase 1: Gather Infrastructure Info
+
+Only do this phase if the user hasn't already provided the information. If SSH credentials are known, skip to Phase 2.
+
+Ask the user:
+1. **Which hosts** need the agent? Get a list of IPs or hostnames.
+2. **How do I SSH to them?** Get the SSH user, key path, and any jump host or bastion configuration.
+3. **Do any hosts already have the Datadog Agent installed?** If so, skip install for those hosts and go straight to `verify-ssi`.
+
+### Claude runs
+
+Verify SSH works for each host before proceeding:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "hostname"
+```
+
+✅ Returns a hostname — proceed.
+❌ Connection refused or timeout — resolve connectivity before continuing.
+
+Once SSH is confirmed, present a plan to the user before proceeding. For example:
+
+```
+Here's what I'm going to do:
+  1. Install the Datadog Agent with SSI on: <host1>, <host2>, ...
+  2. Verify each agent is running and healthy
+  3. Discover services on each host that need restarting for SSI to take effect
+  4. After you restart services, verify instrumentation is working
+
+Ready to proceed?
+```
+
+Wait for user confirmation before starting installs.
+
+---
+
+## Prerequisites
+
+**Per host — check before installing:**
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "uname -m && cat /etc/os-release | grep -E '^(ID|VERSION_ID|PRETTY_NAME)='"
+```
+
+✅ Architecture is `x86_64` or `aarch64`, OS is a supported distribution (Ubuntu 16.04+, Debian 9+, RHEL/CentOS 6–9, Amazon Linux 2/2023, SUSE 12+) — proceed.
+
+❌ Architecture is `armv7l` (32-bit ARM) or unsupported OS — stop. Datadog Agent 7 and SSI do not support this configuration.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `DD_API_KEY` | Check `echo $DD_API_KEY` first — if set, use it. Otherwise ask the user for their API key from Datadog UI: Organization Settings → API Keys. Never log or print the key. |
+| `DD_SITE` | Check `echo $DD_SITE` first — if set, use it. Otherwise ask the user. Default: `datadoghq.com`. Options: `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `datadoghq.eu`, `ap1.datadoghq.com` |
+| `SSH_KEY` | Ask the user for the path to their SSH private key, or check `CLAUDE.md` |
+| `SSH_USER` | Ask the user for the SSH username. Default: `root` |
+| `SSH_HOST` | Ask the user for the hostname or IP of the target host |
+| `SSH_PORT` | Ask the user for the SSH port. Default: `22` |
+
+---
+
+## Phase 2: Install the Datadog Agent with SSI
+
+Run for each host that does not already have the agent installed.
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+`DD_APM_INSTRUMENTATION_ENABLED=host` causes the install script to also install `datadog-apm-inject` and language library packages under `/opt/datadog-packages/` in one pass.
+
+✅ Script completes without errors — proceed to Phase 2.
+
+❌ `curl: command not found`:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "apt-get install -y curl 2>/dev/null || yum install -y curl"
+```
+
+❌ Permission error — ensure the SSH user has sudo access. The install script requires root.
+
+❌ Script fails with GPG key error — retry; if it persists, check the host's DNS resolution for `keys.datadoghq.com`.
+
+---
+
+## Phase 3: Verify the Agent is Running and Healthy
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | head -40"
+```
+
+✅ Shows:
+- `Agent (v7.XX.X)` with `Status: Running`
+- `API Keys status: API Key ending with XXXX: Valid`
+
+❌ `command not found` — installation did not complete. Re-run Phase 1.
+
+❌ `API key invalid` — update and restart:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo sed -i 's/^api_key:.*/api_key: <NEW_API_KEY>/' /etc/datadog-agent/datadog.yaml && \
+   (sudo systemctl restart datadog-agent 2>/dev/null || sudo service datadog-agent restart)"
+```
+
+❌ Agent service not running:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo systemctl start datadog-agent 2>/dev/null && sudo systemctl enable datadog-agent 2>/dev/null || sudo service datadog-agent start"
+```
+
+**Verify APM inject packages are present on disk** (not just registered):
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "ls /opt/datadog-packages/ && sudo datadog-installer status 2>/dev/null | grep apm | head -10"
+```
+
+✅ `/opt/datadog-packages/datadog-apm-inject` exists — injection is available.
+
+❌ Directory missing or empty — `datadog-installer status` may show the package as registered while its directory is actually empty (stale registration). Reinstall:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-installer remove datadog-apm-inject && \
+   DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+**Verify hostname registration** — the Agent must resolve and register its hostname for the host to appear in Datadog. DNS lookup failures are common in containers and minimal VMs:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | grep -iE '^\s+Hostname' | head -3"
+```
+
+✅ `Hostname: <some-name>` — hostname resolved. Record this as `DD_HOSTNAME` for all subsequent steps.
+
+❌ `Hostname: (none)` or any DNS resolution error — the agent can't resolve its own FQDN. Fix by setting the hostname explicitly in `datadog.yaml`:
+
+```bash
+# Read the actual system hostname
+ACTUAL_HOSTNAME=$(ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "hostname")
+
+# Append to datadog.yaml only if not already set
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "grep -q '^hostname:' /etc/datadog-agent/datadog.yaml || \
+   echo \"hostname: ${ACTUAL_HOSTNAME}\" | sudo tee -a /etc/datadog-agent/datadog.yaml"
+
+# Restart the Agent
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo systemctl restart datadog-agent 2>/dev/null || sudo service datadog-agent restart"
+
+# Confirm hostname is now registered
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | grep -iE '^\s+Hostname' | head -2"
+```
+
+---
+
+## Phase 4: Discover Services That Need Restarting
+
+SSI only injects into processes at startup. Existing processes keep running uninstrumented until restarted. Discover what's running so the user knows what to restart.
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo ss -lntp 2>/dev/null || sudo netstat -tlnp 2>/dev/null || cat /proc/net/tcp"
+```
+
+For each application-level listener (ignore sshd, systemd, chronyd):
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "
+# Command line of the process
+sudo cat /proc/<PID>/cmdline | tr '\0' ' '
+# Service manager (may not be available in all environments)
+sudo systemctl status <PID> 2>/dev/null | head -3 || true
+# Parent process
+PPID=\$(sudo awk '/PPid/ {print \$2}' /proc/<PID>/status)
+sudo cat /proc/\$PPID/cmdline | tr '\0' ' '
+"
+```
+
+Present findings to the user:
+
+```
+I found the following application services on <host>:
+
+  Port 8080 — PID 1234 — /usr/bin/python3 /app/server.py
+    Managed by: systemd unit flask-app.service
+
+  Port 3000 — PID 5678 — node /app/server.js
+    Managed by: supervisord
+
+These services need to be restarted for Datadog SSI to inject into them.
+Restart them however is appropriate for your environment, then let me know
+and I'll verify the instrumentation.
+```
+
+**Do not offer to restart services. Do not restart services unless the user explicitly asks.**
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Agent running on each target host (`datadog-agent status` shows Running, API key valid)
+- [ ] `/opt/datadog-packages/datadog-apm-inject` exists on disk on each host
+- [ ] User has been informed which services need restarting
+- [ ] User has confirmed they are ready to restart services
+
+Automatically proceed to `enable-ssi` (if services need UST labels configured) or `verify-ssi` (if services have already been restarted) — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never store `DD_API_KEY` in shell history — pass it inline in the SSH command only
+- If the user's API key appears in any output, redact it before displaying
+- Always confirm before restarting production services

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -28,8 +28,6 @@ Do NOT invoke this skill if:
 
 ## Phase 0: Load Credentials
 
-### Claude runs
-
 ```bash
 [ -f environment ] && source environment
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -28,12 +28,9 @@ Do NOT invoke this skill if:
 
 ## Phase 0: Load Credentials
 
-> **NEVER ask the user to type `DD_API_KEY` or any secret in the conversation.** Credentials must come from the `environment` file only. If the key is missing, tell the user to create the file and source it — do not ask for the value in chat.
-
 ### Claude runs
 
 ```bash
-# Check for a local environment file
 [ -f environment ] && source environment && echo "Loaded credentials from ./environment file" || echo "No environment file found"
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
 echo "DD_SITE: ${DD_SITE:-not set}"
@@ -43,14 +40,13 @@ echo "DD_SITE: ${DD_SITE:-not set}"
 
 **If `DD_API_KEY` is not set** — tell the user:
 
-> "Please create an `environment` file in this directory (it's git-ignored and never committed):
-> ```bash
-> export DD_API_KEY='your-api-key-here'
-> export DD_SITE='datadoghq.com'
-> ```
-> Then run `! source environment` in this chat to load it. I'll wait — do not paste the key here."
+> Your `DD_API_KEY` is not set. To avoid exposing it in chat history, create a temporary credentials file:
+> 1. Copy `environment.template` to `environment` and fill in your API key and site
+> 2. Run `! source environment` — the `!` prefix loads it into this shell session
+>
+> Once you've done that, I'll continue.
 
-Once sourced, re-run the check above and verify `DD_API_KEY` is set before continuing.
+Wait. Once the user runs `! source environment`, re-run the bash check above to confirm `DD_API_KEY` is now set, then proceed.
 
 ---
 

--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-linux-agent-install
+name: agent-install
 description: Install the Datadog Agent on Linux hosts via SSH with Single Step Instrumentation (SSI) enabled — SSI automatically instruments applications for APM without code changes. Only use if no agent is installed yet.
 metadata:
   version: "1.0.0"

--- a/dd-apm/linux-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/enable-ssi/SKILL.md
@@ -102,7 +102,7 @@ ERROR: musl — SSI requires glibc. No workaround; must use a glibc-based OS.
 - Ruby: `gem uninstall ddtrace`, remove `require 'ddtrace'`
 - .NET: remove `Datadog.Trace` NuGet and profiler env vars
 
-After removing, restart the service. **Confirm with user before restarting.**
+After removing, restart the service. **Confirm with the user before restarting.** Tell the user: "I need to restart `<SYSTEMD_SERVICE_NAME>` to remove the old instrumentation. This will cause a brief outage. Ready to proceed?" Wait for confirmation.
 
 ---
 
@@ -166,9 +166,7 @@ Reload: `pm2 reload <app>`
 
 ## Step 2: Restart the Service
 
-**Confirm with the user before restarting.** Restarting a production service causes a brief outage.
-
-Once confirmed:
+**Confirm with the user before restarting.** Tell the user: "I need to restart `<SYSTEMD_SERVICE_NAME>` for SSI to inject into it. This will cause a brief outage. Ready to proceed?" Wait for confirmation.
 
 ### Claude runs
 

--- a/dd-apm/linux-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/enable-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-linux-enable-ssi
+name: enable-ssi
 description: Configure Unified Service Tags and verify Single Step Instrumentation (SSI) injection on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use if the Datadog Agent is already installed.
 metadata:
   version: "1.0.0"

--- a/dd-apm/linux-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/enable-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-linux-enable-ssi
-description: Configure Unified Service Tags and verify SSI injection setup on Linux hosts where the agent is already installed. Handles systemd, supervisord, and pm2 service managers.
+description: Configure Unified Service Tags and verify Single Step Instrumentation (SSI) injection on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use if the Datadog Agent is already installed.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -51,9 +51,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "cat /etc/ld.so.preload && ls /opt/datadog-packages/ | grep apm"
 ```
 
-✅ `/etc/ld.so.preload` contains a path to the launcher, and `/opt/datadog-packages/datadog-apm-inject` exists — SSI is armed.
+If `/etc/ld.so.preload` contains a path to the launcher, and `/opt/datadog-packages/datadog-apm-inject` exists — SSI is armed.
 
-❌ Either missing — run `agent-install` first.
+ERROR: Either missing — run `agent-install` first.
 
 **Check for existing manual instrumentation:**
 
@@ -65,7 +65,7 @@ grep -r 'import ddtrace\|from ddtrace\|require .dd-trace.\|opentelemetry' <SOURC
 "
 ```
 
-❌ Manual instrumentation found — SSI silently disables itself when it detects an existing tracer. Remove the manual import/package before proceeding.
+ERROR: Manual instrumentation found — SSI silently disables itself when it detects an existing tracer. Remove the manual import/package before proceeding.
 
 **Check base libc:**
 
@@ -76,7 +76,7 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "ldd --version 2>&1 | head -1"
 ```
 
-❌ musl — SSI requires glibc. No workaround; must use a glibc-based OS.
+ERROR: musl — SSI requires glibc. No workaround; must use a glibc-based OS.
 
 ---
 
@@ -146,7 +146,7 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo systemctl daemon-reload && sudo systemctl show <SYSTEMD_SERVICE_NAME> | grep -E 'DD_SERVICE|DD_ENV|DD_VERSION'"
 ```
 
-✅ UST vars appear in the output — configuration applied.
+If the UST vars appear in the output — configuration applied.
 
 **For supervisord:**
 ```ini
@@ -177,9 +177,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo systemctl restart <SYSTEMD_SERVICE_NAME> && sleep 3 && sudo systemctl is-active <SYSTEMD_SERVICE_NAME>"
 ```
 
-✅ Returns `active` — service is running.
+If `active` is returned — service is running.
 
-❌ Returns `failed` — check logs:
+ERROR: Returns `failed` — check logs:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo journalctl -u <SYSTEMD_SERVICE_NAME> --since '1 minute ago' | tail -30"
@@ -208,9 +208,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo cat /proc/<PID>/environ | tr '\0' '\n' | grep -E 'DD_SERVICE|DD_ENV|DD_VERSION'"
 ```
 
-✅ Both launcher and language library in maps + UST vars in environ — SSI and tagging are fully configured.
+If both the launcher and language library appear in maps, and UST vars are in environ — SSI and tagging are fully configured.
 
-❌ Launcher in maps but no language library — injection attempted but failed. Run:
+ERROR: Launcher in maps but no language library — injection attempted but failed. Run:
 ```bash
 pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 15m
 ```

--- a/dd-apm/linux-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/enable-ssi/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: dd-apm-linux-enable-ssi
+description: Configure Unified Service Tags and verify SSI injection setup on Linux hosts where the agent is already installed. Handles systemd, supervisord, and pm2 service managers.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,linux,ssi,instrumentation,single-step,ld-preload,ust
+  alwaysApply: "false"
+---
+
+# Configure SSI and Unified Service Tags on Linux
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 0 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when:
+- The Datadog Agent is already installed with SSI (`DD_APM_INSTRUMENTATION_ENABLED=host` was used) and you need to configure Unified Service Tags on the application service
+- The user wants to set `DD_SERVICE`, `DD_ENV`, `DD_VERSION` on a running service
+- SSI is installed but `/proc/<pid>/maps` doesn't show the language tracer (launcher-only injection)
+
+Do NOT invoke this skill if:
+- The Datadog Agent is not yet installed — run `agent-install` first
+- SSI packages are missing from `/opt/datadog-packages/` — re-run `agent-install`
+- The target is a Kubernetes cluster — use `dd-apm-k8s-enable-ssi` instead
+
+---
+
+## Background
+
+When the install script runs with `DD_APM_INSTRUMENTATION_ENABLED=host`, it:
+1. Installs `datadog-apm-inject` and language library packages under `/opt/datadog-packages/`
+2. Writes the launcher path into `/etc/ld.so.preload`
+3. SSI is now armed — every new process on the host gets the launcher injected at startup
+
+**What SSI does NOT configure automatically:**
+- `DD_SERVICE`, `DD_ENV`, `DD_VERSION` — these must be set on the application process for traces to be tagged correctly
+- Without `DD_SERVICE`, the tracer auto-detects a service name (often the process name or framework name), which may not match what the user expects
+
+---
+
+## Prerequisites
+
+**Verify SSI is armed:**
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "cat /etc/ld.so.preload && ls /opt/datadog-packages/ | grep apm"
+```
+
+✅ `/etc/ld.so.preload` contains a path to the launcher, and `/opt/datadog-packages/datadog-apm-inject` exists — SSI is armed.
+
+❌ Either missing — run `agent-install` first.
+
+**Check for existing manual instrumentation:**
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "
+grep -r 'import ddtrace\|from ddtrace\|require .dd-trace.\|opentelemetry' <SOURCE_DIR> 2>/dev/null | head -5 || echo 'No manual instrumentation found'
+"
+```
+
+❌ Manual instrumentation found — SSI silently disables itself when it detects an existing tracer. Remove the manual import/package before proceeding.
+
+**Check base libc:**
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "ldd --version 2>&1 | head -1"
+```
+
+❌ musl — SSI requires glibc. No workaround; must use a glibc-based OS.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `SERVICE_NAME` | Ask the user — how the service should appear in Datadog APM (e.g. `payment-api`) |
+| `ENV` | Ask the user — environment name (e.g. `production`, `staging`, `dev`) |
+| `VERSION` | Ask the user or read from the app's version file / git tag |
+| `SYSTEMD_SERVICE_NAME` | From `systemctl list-units --type=service --state=running` on the host — the unit running the app |
+| `SSH_KEY` | Path to SSH private key |
+| `SSH_USER` | SSH username |
+| `SSH_HOST` | Hostname or IP of the target host |
+
+---
+
+## Step 0 (Only if existing instrumentation detected): Remove Manual Instrumentation
+
+- Python: `pip uninstall ddtrace`, remove `import ddtrace` / `ddtrace-run` from CMD
+- Node.js: `npm uninstall dd-trace`, remove `require('dd-trace')` 
+- Java: remove `-javaagent:/path/to/dd-java-agent.jar` JVM flag
+- Ruby: `gem uninstall ddtrace`, remove `require 'ddtrace'`
+- .NET: remove `Datadog.Trace` NuGet and profiler env vars
+
+After removing, restart the service. **Confirm with user before restarting.**
+
+---
+
+## Step 1: Set Unified Service Tags on the Application Process
+
+Without UST, traces arrive with an auto-detected service name that may not match user expectations, and won't be tagged with env or version.
+
+**For systemd-managed services** (most common):
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo systemctl cat <SYSTEMD_SERVICE_NAME>"
+```
+
+Add a drop-in override (preserves the original unit file):
+
+### What you need to do in a terminal
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST>
+sudo systemctl edit <SYSTEMD_SERVICE_NAME>
+```
+
+Add to the editor:
+
+```ini
+[Service]
+Environment="DD_SERVICE=<SERVICE_NAME>"
+Environment="DD_ENV=<ENV>"
+Environment="DD_VERSION=<VERSION>"
+```
+
+Apply:
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo systemctl daemon-reload && sudo systemctl show <SYSTEMD_SERVICE_NAME> | grep -E 'DD_SERVICE|DD_ENV|DD_VERSION'"
+```
+
+✅ UST vars appear in the output — configuration applied.
+
+**For supervisord:**
+```ini
+# In [program:<name>] section of supervisord.conf
+environment=DD_SERVICE="<SERVICE_NAME>",DD_ENV="<ENV>",DD_VERSION="<VERSION>"
+```
+Reload: `sudo supervisorctl reload`
+
+**For pm2:**
+```js
+// ecosystem.config.js
+env: { DD_SERVICE: "<SERVICE_NAME>", DD_ENV: "<ENV>", DD_VERSION: "<VERSION>" }
+```
+Reload: `pm2 reload <app>`
+
+---
+
+## Step 2: Restart the Service
+
+**Confirm with the user before restarting.** Restarting a production service causes a brief outage.
+
+Once confirmed:
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo systemctl restart <SYSTEMD_SERVICE_NAME> && sleep 3 && sudo systemctl is-active <SYSTEMD_SERVICE_NAME>"
+```
+
+✅ Returns `active` — service is running.
+
+❌ Returns `failed` — check logs:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo journalctl -u <SYSTEMD_SERVICE_NAME> --since '1 minute ago' | tail -30"
+```
+
+---
+
+## Step 3: Confirm Injection and UST in the Running Process
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "pgrep -a -f '<SERVICE_NAME>' | head -3"
+```
+
+Use the PID:
+
+```bash
+# Authoritative injection check
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/maps | grep -E 'launcher|apm-library|datadog'"
+
+# UST vars in process environment
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/environ | tr '\0' '\n' | grep -E 'DD_SERVICE|DD_ENV|DD_VERSION'"
+```
+
+✅ Both launcher and language library in maps + UST vars in environ — SSI and tagging are fully configured.
+
+❌ Launcher in maps but no language library — injection attempted but failed. Run:
+```bash
+pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 15m
+```
+
+Go to `troubleshoot-ssi` if errors are present.
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Launcher and language library visible in `/proc/<PID>/maps`
+- [ ] `DD_SERVICE`, `DD_ENV`, `DD_VERSION` present in `/proc/<PID>/environ`
+- [ ] Service is running and healthy
+
+Automatically proceed to `verify-ssi` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Always confirm with the user before restarting production services
+- Do not modify application source code — configure only via environment variables in the service unit

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -55,6 +55,8 @@ ERROR: Not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 ---
 
 ## Collect live confirmation data

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: dd-apm-linux-onboarding-summary
+description: Generate a live APM onboarding confirmation report for Linux hosts with deep links into the Datadog UI. Collects real data from the host and Datadog backend to confirm everything is working end-to-end.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,linux,ssi,summary,verification
+  alwaysApply: "false"
+---
+
+# APM Onboarding Summary — Linux Host
+
+## Triggers
+
+Invoke this skill when:
+- All steps in `verify-ssi` have passed
+- All checks in `troubleshoot-ssi` have been resolved
+- The user asks "is everything working?", "show me the status", or "confirm APM is set up"
+
+Do NOT invoke this skill if any verification or troubleshooting check is still failing — resolve those first.
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `HOSTNAME` | `hostname -f` on the target host |
+| `DD_HOSTNAME` | Hostname as Datadog sees it — from `sudo datadog-agent status` |
+| `SERVICE_NAME` | `DD_SERVICE` value from `/proc/<PID>/environ` or the systemd unit |
+| `ENV` | `DD_ENV` value from `/proc/<PID>/environ` or the systemd unit |
+| `DD_SITE` | `grep "^site:" /etc/datadog-agent/datadog.yaml` |
+| `SSH_KEY` | Path to SSH private key |
+| `SSH_USER` | SSH username |
+| `SSH_HOST` | Hostname or IP of the target host |
+
+---
+
+## Prerequisites
+
+### Claude runs
+
+```bash
+pup auth status --site <DD_SITE>
+```
+
+✅ Valid token — proceed.
+
+❌ Not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login --site <DD_SITE>
+```
+
+Confirm with `pup auth status --site <DD_SITE>` before continuing.
+
+---
+
+## Collect live confirmation data
+
+Run all of the following. Each populates a row in the final report.
+
+### Claude runs
+
+```bash
+# Agent version and status
+sudo datadog-agent status 2>&1 | grep -E "Agent \(v|Status:|API Keys status"
+
+# Inject library armed in ld.so.preload
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "cat /etc/ld.so.preload"
+
+# Process confirmed injected — launcher + language library in /proc/<PID>/maps
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "pgrep -a -f '<SERVICE_NAME>' | head -3"
+```
+
+Use the PID from above:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/maps | grep -E 'launcher|apm-library|datadog'"
+
+# UST vars in process environment
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/environ | tr '\0' '\n' | grep -E 'DD_SERVICE|DD_ENV|DD_VERSION'"
+
+# Agent APM receiver — trace counts
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | grep -A 10 'Receiver (previous minute)'"
+
+# Service visible and traced in APM backend
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
+
+# Traces arriving in the last hour
+DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
+```
+
+---
+
+## Present the report
+
+Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row ❌ and link to `troubleshoot-ssi`.
+
+---
+
+**APM onboarding complete**
+
+| Check | Detail | Status |
+|---|---|---|
+| Datadog Agent | v`<VERSION>` running on `<HOSTNAME>`, API key valid | ✅ |
+| SSI armed | `/etc/ld.so.preload` contains launcher path | ✅ |
+| Process injected | launcher + language library in `/proc/<PID>/maps` for `<SERVICE_NAME>` | ✅ |
+| Unified Service Tags | `DD_SERVICE=<SERVICE_NAME>` `DD_ENV=<ENV>` `DD_VERSION=<VERSION>` | ✅ |
+| Agent receiving traces | `<N>` trace(s)/min in APM receiver | ✅ |
+| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | ✅ |
+| Traces arriving | `<N>` trace(s) found in the last hour | ✅ |
+
+---
+
+**Your service in Datadog — click to open:**
+
+Construct each URL by substituting real values. Do not print placeholder URLs.
+
+| View | URL |
+|---|---|
+| Service overview | `https://app.<DD_SITE>/apm/services/<SERVICE_NAME>?env=<ENV>` |
+| Traces explorer | `https://app.<DD_SITE>/apm/traces?query=service:<SERVICE_NAME>%20env:<ENV>` |
+| Service map | `https://app.<DD_SITE>/apm/map?env=<ENV>&service=<SERVICE_NAME>` |
+| Infrastructure host | `https://app.<DD_SITE>/infrastructure?q=host:<HOSTNAME>` |
+| Agent fleet | `https://app.<DD_SITE>/fleet-automation` |
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -49,13 +49,11 @@ If valid token — proceed.
 
 ERROR: Not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login --site <DD_SITE>
 ```
-
-Confirm with `pup auth status --site <DD_SITE>` before continuing.
 
 ---
 

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -128,9 +128,7 @@ Construct each URL by substituting real values. Do not print placeholder URLs.
 |---|---|
 | Service overview | `https://app.<DD_SITE>/apm/services/<SERVICE_NAME>?env=<ENV>` |
 | Traces explorer | `https://app.<DD_SITE>/apm/traces?query=service:<SERVICE_NAME>%20env:<ENV>` |
-| Service map | `https://app.<DD_SITE>/apm/map?env=<ENV>&service=<SERVICE_NAME>` |
 | Infrastructure host | `https://app.<DD_SITE>/infrastructure?q=host:<HOSTNAME>` |
-| Agent fleet | `https://app.<DD_SITE>/fleet-automation` |
 
 ---
 

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-linux-onboarding-summary
-description: Generate a live APM onboarding confirmation report for Linux hosts with deep links into the Datadog UI. Collects real data from the host and Datadog backend to confirm everything is working end-to-end.
+description: Generate a live Single Step Instrumentation (SSI) onboarding confirmation report for Linux hosts — verifies APM instrumentation is working end-to-end with deep links into the Datadog UI. Only use after agent-install and enable-ssi have both completed.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -45,9 +45,9 @@ Do NOT invoke this skill if any verification or troubleshooting check is still f
 pup auth status --site <DD_SITE>
 ```
 
-✅ Valid token — proceed.
+If valid token — proceed.
 
-❌ Not authenticated:
+ERROR: Not authenticated:
 
 ### What you need to do in a terminal
 
@@ -102,7 +102,7 @@ DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 1h -
 
 ## Present the report
 
-Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row ❌ and link to `troubleshoot-ssi`.
+Fill in every value from live command output. Do not leave any placeholder unfilled. If a value cannot be confirmed, mark that row as failed and link to `troubleshoot-ssi`.
 
 ---
 
@@ -110,13 +110,13 @@ Fill in every value from live command output. Do not leave any placeholder unfil
 
 | Check | Detail | Status |
 |---|---|---|
-| Datadog Agent | v`<VERSION>` running on `<HOSTNAME>`, API key valid | ✅ |
-| SSI armed | `/etc/ld.so.preload` contains launcher path | ✅ |
-| Process injected | launcher + language library in `/proc/<PID>/maps` for `<SERVICE_NAME>` | ✅ |
-| Unified Service Tags | `DD_SERVICE=<SERVICE_NAME>` `DD_ENV=<ENV>` `DD_VERSION=<VERSION>` | ✅ |
-| Agent receiving traces | `<N>` trace(s)/min in APM receiver | ✅ |
-| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | ✅ |
-| Traces arriving | `<N>` trace(s) found in the last hour | ✅ |
+| Datadog Agent | v`<VERSION>` running on `<HOSTNAME>`, API key valid | OK |
+| SSI armed | `/etc/ld.so.preload` contains launcher path | OK |
+| Process injected | launcher + language library in `/proc/<PID>/maps` for `<SERVICE_NAME>` | OK |
+| Unified Service Tags | `DD_SERVICE=<SERVICE_NAME>` `DD_ENV=<ENV>` `DD_VERSION=<VERSION>` | OK |
+| Agent receiving traces | `<N>` trace(s)/min in APM receiver | OK |
+| APM service visible | `<SERVICE_NAME>` in env `<ENV>` | OK |
+| Traces arriving | `<N>` trace(s) found in the last hour | OK |
 
 ---
 

--- a/dd-apm/linux-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/linux-ssi/onboarding-summary/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-linux-onboarding-summary
+name: onboarding-summary
 description: Generate a live Single Step Instrumentation (SSI) onboarding confirmation report for Linux hosts — verifies APM instrumentation is working end-to-end with deep links into the Datadog UI. Only use after agent-install and enable-ssi have both completed.
 metadata:
   version: "1.0.0"

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-linux-troubleshoot-ssi
+name: troubleshoot-ssi
 description: Diagnose and fix Single Step Instrumentation (SSI) issues on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use if the agent and SSI are configured but traces are missing or instrumentation is not working.
 metadata:
   version: "1.0.0"

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: dd-apm-linux-troubleshoot-ssi
+description: Diagnose and fix APM SSI issues on Linux hosts. Uses hypothesis-driven investigation — pup commands first, SSH second. Covers injection errors, tracer config, connectivity, and package remediation.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,linux,ssi,troubleshooting,instrumentation,ld-preload
+  alwaysApply: "false"
+---
+
+# Troubleshoot APM SSI on Linux
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Debug why a Linux process is not being instrumented
+- Investigate why traces are not appearing in Datadog from a Linux host
+- Diagnose SSI injection failures on Linux
+- Follow up on failed checks from `verify-ssi`
+- Report that a specific service or host has no traces
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `enable-ssi` first
+
+---
+
+## Critical: pup First, SSH Second
+
+**You do NOT need SSH access to start troubleshooting.** The `pup` CLI queries Datadog's backend directly. Start with pup commands immediately using information the user already gave you (hostname, service name, env). Only go to SSH if pup doesn't reveal the cause.
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status --site <DD_SITE>
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login --site <DD_SITE>
+```
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `DD_HOSTNAME` | The hostname as Datadog sees it — from `datadog-agent status` output, or ask the user |
+| `SERVICE_NAME` | Ask the user — the service name as they expect it to appear in APM |
+| `ENV` | Ask the user — the environment tag |
+| `DD_SITE` | Ask the user, or `grep "^site:" /etc/datadog-agent/datadog.yaml` via SSH |
+| `SSH_KEY` | Path to SSH private key — from user or `/workspace/.ssh/id_ed25519` |
+| `SSH_USER` | SSH username — from user or `root` |
+| `SSH_HOST` | Hostname or IP of the target host |
+
+---
+
+## How SSI Works on Linux — Domain Knowledge
+
+Read this before investigating. It gives you the mental model to reason about novel failures.
+
+**Injection chain:**
+1. Install script (with `DD_APM_INSTRUMENTATION_ENABLED=host`) installs `datadog-apm-inject` and language library packages under `/opt/datadog-packages/`
+2. The inject package writes its launcher path into `/etc/ld.so.preload`
+3. The Linux dynamic linker pre-loads the launcher into every new process at startup
+4. The launcher detects the process language and loads the appropriate tracer `.so` from `/opt/datadog-packages/datadog-apm-library-<lang>/`
+5. The tracer sends spans to the Agent at `localhost:8126`
+6. The Agent forwards traces to Datadog at `intake.<DD_SITE>`
+
+**Diagnostic layers:**
+- **`pup`** — sees what Datadog's backend received + injection errors reported by the launcher. Start here.
+- **`/proc/<pid>/maps`** — sees the actual shared libraries loaded into a running process. The authoritative check for whether injection succeeded.
+- **`datadog-agent status`** — sees whether the local Agent is receiving traces.
+
+**Known silent failures:**
+- **musl libc (Alpine)** — launcher is glibc-compiled; musl is ABI-incompatible. Linker loads it but injection silently aborts
+- **Existing ddtrace/OTel** — launcher detects user-installed tracer and silently disables itself (`already_instrumented` result class)
+- **Unsupported runtime version** — silently skipped
+- **Process started before SSI was enabled** — `/etc/ld.so.preload` only affects new processes
+- **Static binary / Go** — Go programs link statically and ignore `LD_PRELOAD` entirely
+- **SELinux/AppArmor** — can block `/etc/ld.so.preload` reads for confined processes
+- **Package directory empty/corrupt** — `datadog-installer status` reflects DB registration, not actual files. A package can show as installed while its directory is empty. Always verify files exist under `/opt/datadog-packages/<package>/`
+
+**Service name identity — important:**
+With SSI, `DD_SERVICE` is often not set in the process environment. The tracer auto-detects a service name. The telemetry-reported name (what `pup fleet tracers list` and `service-library-config get` show) may not match what you expect in the APM UI:
+- **JVM**: telemetry reports jar artifact name with version (e.g. `inventory-service-1.0.0`), spans use the base name (`inventory-service`)
+- **Python**: telemetry may report `fastapi` or `django` rather than the app name
+- **Node.js**: names typically match
+
+If `service-library-config get` returns empty, use `pup traces search --query "host:<DD_HOSTNAME>" --from 1h --limit 5` to discover what service names have been sending traces, then retry.
+
+---
+
+## Step 1: Triage with pup (no SSH required)
+
+Run these first. The answers determine everything that follows.
+
+### Claude runs
+
+```bash
+# Check for injection errors (failures only — successful injections don't appear here)
+pup apm troubleshooting list --hostname <DD_HOSTNAME>
+
+# Check full tracer config — look at apm_enabled, trace_agent_url, site
+pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>
+
+# Check what services have sent traces (reveals actual service names visible to backend)
+pup apm services list --from 1h
+
+# Check if traces exist at all
+pup traces search --query "service:<SERVICE_NAME>" --from 15m --limit 5
+
+# Fastest trace confirmation — metrics appear before indexed traces
+pup metrics query --query "sum:trace.*.request.hits{host:<DD_HOSTNAME>,service:<SERVICE_NAME>}.as_count()" --from 15m
+```
+
+---
+
+## Step 2: State Your Hypotheses
+
+Before investigating, explicitly state your ranked hypotheses based on triage output. Do not skip this step.
+
+| Triage signal | Strong hypothesis |
+|---|---|
+| `pup troubleshooting list` shows `result: error`, `result_class: incorrect_installation` | Package directory empty or corrupt — verify files exist under `/opt/datadog-packages/datadog-apm-library-<lang>/`, then use remediation flow |
+| `pup troubleshooting list` shows `result: error`, import/load error | Tracer library couldn't be loaded — check runtime version, libc compatibility |
+| `pup troubleshooting list` shows `result: abort`, reason `already_instrumented` | Manual ddtrace/OTel already in the app — launcher silently disabled itself |
+| `pup troubleshooting list` shows `result: abort`, reason `language not detected` | Expected for non-app processes (e.g., bash, cron). Not a failure. |
+| `pup troubleshooting list` empty | Either no injection attempts yet (process not restarted), or injection succeeded silently |
+| `service-library-config get` shows `apm_enabled: false` | Tracer is loaded but explicitly disabled — check `source` field to see who set it |
+| `service-library-config get` shows `trace_agent_url` pointing to wrong host/port | Tracer can't reach the Agent — fix the URL |
+| `service-library-config get` shows wrong `site` | Traces going to wrong Datadog org |
+| No traces in `pup traces search`, no troubleshooting errors | Process was never injected — check: process not restarted after SSI enabled, `/etc/ld.so.preload` missing, static binary |
+| Unexpected service name in `pup apm services list` results | Service name mismatch — use the actual name from trace data for subsequent config lookups |
+| Traces arriving in pup | Not a real problem — likely a UI filter or time window. Tell the user and stop. |
+
+State your top 1-3 hypotheses explicitly: *"Based on triage, I think the most likely cause is X because Y."*
+
+---
+
+## Step 3: Investigate with pup (deeper)
+
+Use only the tools relevant to your hypotheses.
+
+**Check SDK config in detail:**
+```bash
+# Show all config values with their source (env_var, remote_config, code, default)
+pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>
+
+# Show only configs where instances disagree (config drift)
+pup apm service-library-config get --service-name <SERVICE_NAME> --mixed
+```
+
+Key values to check:
+- `apm_enabled` — if `false`, tracer won't send traces. Check `source` to see who disabled it (`code` > `env_var` > `remote_config` > `default`)
+- `trace_agent_url` — should be `http://localhost:8126` or a Unix socket. Wrong value = tracer can't reach Agent
+- `site` — must match your Datadog org's site. Mismatch = traces going to wrong org
+- `service` — with SSI and no `DD_SERVICE` set, `source: default` is expected
+
+**If `service-library-config get` returns empty** — the service name you're using may not match the actual name in trace data:
+```bash
+pup traces search --query "host:<DD_HOSTNAME>" --from 1h --limit 5
+```
+Use the `service` field from trace results for subsequent config lookups.
+
+**Check injection error details:**
+```bash
+pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 4h
+```
+
+---
+
+## Step 4: Investigate via SSH (if pup didn't reveal the cause)
+
+**Is `/etc/ld.so.preload` set?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "cat /etc/ld.so.preload"
+```
+✅ Contains path ending in `launcher.preload.so` or `libdatadog-apm-inject.so` — launcher is armed for new processes.
+❌ Empty or missing — SSI was not fully set up. Re-run the install script with `DD_APM_INSTRUMENTATION_ENABLED=host`.
+
+**Is the tracer actually loaded into the running process?**
+
+This is the authoritative injection check — use `/proc/<pid>/maps`, not environ:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "pgrep -a -f '<SERVICE_NAME>' | head -3"
+```
+Use the PID:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/maps | grep -E 'launcher|apm-library|datadog'"
+```
+- **Launcher + language library present** — injection succeeded for this process
+- **Launcher only, no language library** — launcher ran but couldn't inject the tracer (check `pup troubleshooting list` for the reason)
+- **Nothing** — `/etc/ld.so.preload` not set, process started before SSI was enabled, or static binary
+
+**Was the process started before SSI was enabled?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "ps -p <PID> -o pid,lstart,cmd; stat /etc/ld.so.preload"
+```
+If process started before `/etc/ld.so.preload` was written, restart the service. **Always confirm with the user before restarting production services.**
+
+**Is the base libc musl?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "ldd --version 2>&1 | head -1 && cat /etc/os-release | grep PRETTY_NAME"
+```
+❌ musl — SSI's launcher requires glibc. No workaround; must migrate to Debian/Ubuntu/RHEL/Amazon Linux.
+
+**Is it a static binary?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "file /proc/<PID>/exe; ldd /proc/<PID>/exe 2>&1"
+```
+❌ `statically linked` — SSI cannot instrument this binary. Manual instrumentation required.
+
+**Are the APM packages actually present on disk?**
+
+`datadog-installer status` reflects only DB registration — a package can show as installed while its directory is empty. Always verify:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "ls /opt/datadog-packages/ && ls /opt/datadog-packages/datadog-apm-library-<LANG>/ | head -5"
+```
+❌ Directory empty or missing — package is registered but broken on disk. Use the remediation flow.
+
+**Does the app have existing manual instrumentation?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "
+sudo cat /proc/<PID>/maps | grep -E 'ddtrace|opentelemetry|dd-trace'
+"
+```
+Also check dependency manifests: `requirements.txt`, `package.json`, `Gemfile`, `pom.xml`.
+❌ Found — SSI silently disabled itself. Remove manual tracer, restart the service.
+
+**Is the Agent APM receiver listening and receiving traces?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | grep -A 15 'APM Agent'"
+```
+- `feature_auto_instrumentation_enabled: true` — SSI is active on the agent
+- `Receiver (previous minute)` — trace count received by the agent
+- `Endpoints` — where traces are forwarded
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo ss -tlnp 2>/dev/null | grep 8126 || sudo netstat -tlnp 2>/dev/null | grep 8126"
+```
+❌ Port 8126 not listening — APM receiver disabled. Check `apm_config.enabled` in `/etc/datadog-agent/datadog.yaml`.
+
+**What service name did the tracer register?**
+
+With SSI, `DD_SERVICE` is often not set. Read the tracer's memfd to find the real service name:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "
+sudo ls -la /proc/<PID>/fd/ | grep 'datadog-tracer-info'
+"
+```
+Use the fd number:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/fd/<FD_NUM> | python3 -c \"import sys,msgpack; d=msgpack.unpackb(sys.stdin.buffer.read()); print(d)\""
+```
+Returns `service_name`, `service_env`, `tracer_version`.
+
+**Is SELinux/AppArmor blocking `/etc/ld.so.preload`?**
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "
+getenforce 2>/dev/null
+ausearch -m AVC -ts recent 2>/dev/null | grep 'ld.so.preload\|datadog' | tail -10
+dmesg | grep -i 'apparmor.*denied.*datadog' | tail -5
+"
+```
+If SELinux/AppArmor is denying access, work with the user's security team. Do not disable SELinux systemwide.
+
+---
+
+## Step 5: Reflect Before Concluding
+
+Before applying any fix, answer:
+1. What evidence confirms my hypothesis?
+2. What evidence would contradict it — and have I checked?
+3. Is there a simpler explanation I haven't considered?
+
+If the conclusion doesn't hold up, return to Step 2 with new hypotheses.
+
+---
+
+## Step 6: Fix
+
+**Remediation: Reinstalling a Broken APM Package**
+
+`datadog-installer status` reflects DB registration, not actual file presence. If `pup troubleshooting list` shows `incorrect_installation` but the installer says the package is installed, the registration is stale:
+
+```bash
+# Remove the stale registration first
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-installer remove datadog-apm-library-<LANG>"
+
+# Re-run install — now it will actually download and extract
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+```
+
+If re-running the install script is sufficient (package files are intact), use `remove` first only if the script reports success but the problem persists.
+
+**After any config change — restart the service** (confirm with user first for production):
+
+The user must restart the affected service for SSI to re-inject. Identify the service manager and present restart instructions — do not restart automatically unless the user explicitly asks.
+
+Common restart commands:
+```bash
+# systemd
+sudo systemctl restart <SERVICE_NAME>
+# supervisord
+sudo supervisorctl restart <PROGRAM_NAME>
+# pm2
+pm2 reload <APP_NAME>
+```
+
+---
+
+## Step 7: Verify
+
+Re-run the pup triage commands to confirm the fix worked:
+
+### Claude runs
+
+```bash
+pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 15m
+pup traces search --query "service:<SERVICE_NAME>" --from 15m --limit 5
+pup metrics query --query "sum:trace.*.request.hits{host:<DD_HOSTNAME>,service:<SERVICE_NAME>}.as_count()" --from 15m
+```
+
+✅ No new injection errors + traces arriving — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+❌ Still failing — return to Step 2 with updated hypotheses.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Never disable SELinux systemwide
+- Always confirm before restarting production services
+- `datadog-installer remove` requires explicit confirmation — confirm with user before running

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -55,9 +55,9 @@ pup auth status --site <DD_SITE>
 
 If authenticated — proceed directly to Step 1.
 
-ERROR: Not authenticated — ask the user to log in:
+ERROR: Not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login --site <DD_SITE>

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-linux-troubleshoot-ssi
-description: Diagnose and fix APM SSI issues on Linux hosts. Uses hypothesis-driven investigation — pup commands first, SSH second. Covers injection errors, tracer config, connectivity, and package remediation.
+description: Diagnose and fix Single Step Instrumentation (SSI) issues on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use if the agent and SSI are configured but traces are missing or instrumentation is not working.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -53,9 +53,9 @@ brew install datadog-labs/pack/pup
 pup auth status --site <DD_SITE>
 ```
 
-✅ Authenticated — proceed directly to Step 1.
+If authenticated — proceed directly to Step 1.
 
-❌ Not authenticated — ask the user to log in:
+ERROR: Not authenticated — ask the user to log in:
 
 ### What you need to do in a terminal
 
@@ -221,8 +221,8 @@ pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 4h
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "cat /etc/ld.so.preload"
 ```
-✅ Contains path ending in `launcher.preload.so` or `libdatadog-apm-inject.so` — launcher is armed for new processes.
-❌ Empty or missing — SSI was not fully set up. Re-run the install script with `DD_APM_INSTRUMENTATION_ENABLED=host`.
+If it contains a path ending in `launcher.preload.so` or `libdatadog-apm-inject.so` — launcher is armed for new processes.
+ERROR: Empty or missing — SSI was not fully set up. Re-run the install script with `DD_APM_INSTRUMENTATION_ENABLED=host`.
 
 **Is the tracer actually loaded into the running process?**
 
@@ -252,14 +252,14 @@ If process started before `/etc/ld.so.preload` was written, restart the service.
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "ldd --version 2>&1 | head -1 && cat /etc/os-release | grep PRETTY_NAME"
 ```
-❌ musl — SSI's launcher requires glibc. No workaround; must migrate to Debian/Ubuntu/RHEL/Amazon Linux.
+ERROR: musl — SSI's launcher requires glibc. No workaround; must migrate to Debian/Ubuntu/RHEL/Amazon Linux.
 
 **Is it a static binary?**
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "file /proc/<PID>/exe; ldd /proc/<PID>/exe 2>&1"
 ```
-❌ `statically linked` — SSI cannot instrument this binary. Manual instrumentation required.
+ERROR: `statically linked` — SSI cannot instrument this binary. Manual instrumentation required.
 
 **Are the APM packages actually present on disk?**
 
@@ -268,7 +268,7 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "ls /opt/datadog-packages/ && ls /opt/datadog-packages/datadog-apm-library-<LANG>/ | head -5"
 ```
-❌ Directory empty or missing — package is registered but broken on disk. Use the remediation flow.
+ERROR: Directory empty or missing — package is registered but broken on disk. Use the remediation flow.
 
 **Does the app have existing manual instrumentation?**
 ```bash
@@ -277,7 +277,7 @@ sudo cat /proc/<PID>/maps | grep -E 'ddtrace|opentelemetry|dd-trace'
 "
 ```
 Also check dependency manifests: `requirements.txt`, `package.json`, `Gemfile`, `pom.xml`.
-❌ Found — SSI silently disabled itself. Remove manual tracer, restart the service.
+ERROR: Found — SSI silently disabled itself. Remove manual tracer, restart the service.
 
 **Is the Agent APM receiver listening and receiving traces?**
 ```bash
@@ -292,7 +292,7 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo ss -tlnp 2>/dev/null | grep 8126 || sudo netstat -tlnp 2>/dev/null | grep 8126"
 ```
-❌ Port 8126 not listening — APM receiver disabled. Check `apm_config.enabled` in `/etc/datadog-agent/datadog.yaml`.
+ERROR: Port 8126 not listening — APM receiver disabled. Check `apm_config.enabled` in `/etc/datadog-agent/datadog.yaml`.
 
 **What service name did the tracer register?**
 
@@ -378,9 +378,9 @@ pup traces search --query "service:<SERVICE_NAME>" --from 15m --limit 5
 pup metrics query --query "sum:trace.*.request.hits{host:<DD_HOSTNAME>,service:<SERVICE_NAME>}.as_count()" --from 15m
 ```
 
-✅ No new injection errors + traces arriving — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+If there are no new injection errors and traces are arriving — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
 
-❌ Still failing — return to Step 2 with updated hypotheses.
+ERROR: Still failing — return to Step 2 with updated hypotheses.
 
 ---
 

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -63,6 +63,8 @@ ERROR: Not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 2. If OAuth login is not possible (e.g., no browser access), fall back to API keys:
 ```bash
 echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -43,15 +43,19 @@ If not found:
 
 ```bash
 brew tap datadog-labs/pack
-brew install pup
+brew install datadog-labs/pack/pup
 ```
 
-Check auth:
+**Auth — check in this order:**
+
+1. Check OAuth status:
 ```bash
 pup auth status --site <DD_SITE>
 ```
 
-If not authenticated:
+✅ Authenticated — proceed directly to Step 1.
+
+❌ Not authenticated — ask the user to log in:
 
 ### What you need to do in a terminal
 
@@ -59,19 +63,31 @@ If not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+2. If OAuth login is not possible (e.g., no browser access), fall back to API keys:
+```bash
+echo "DD_API_KEY set: $([ -n "${DD_API_KEY:-}" ] && echo yes || echo no)"
+echo "DD_APP_KEY set: $([ -n "${DD_APP_KEY:-}" ] && echo yes || echo no)"
+```
+
+If `DD_API_KEY` and `DD_APP_KEY` are both set — **proceed to Step 1**. pup will use them automatically even if `pup auth status` shows unauthenticated.
+
 ---
 
-## Context to resolve before acting
+## Context
 
-| Variable | How to resolve |
-|---|---|
-| `DD_HOSTNAME` | The hostname as Datadog sees it — from `datadog-agent status` output, or ask the user |
-| `SERVICE_NAME` | Ask the user — the service name as they expect it to appear in APM |
-| `ENV` | Ask the user — the environment tag |
-| `DD_SITE` | Ask the user, or `grep "^site:" /etc/datadog-agent/datadog.yaml` via SSH |
-| `SSH_KEY` | Path to SSH private key — from user or `/workspace/.ssh/id_ed25519` |
-| `SSH_USER` | SSH username — from user or `root` |
-| `SSH_HOST` | Hostname or IP of the target host |
+Use what the user already provided. Do not ask for missing context upfront — resolve variables lazily, only when a specific step needs them.
+
+| Variable | How to resolve | When needed |
+|---|---|---|
+| `DD_HOSTNAME` | From the user's message, or `datadog-agent status` via SSH | Step 1 — start here |
+| `SERVICE_NAME` | From the user's message | Step 1 — start here |
+| `ENV` | Ask the user only when a command requires it | Step 1 (`service-library-config get`), Step 3 |
+| `DD_SITE` | Ask the user, or `grep "^site:" /etc/datadog-agent/datadog.yaml` via SSH | Only if pup auth check fails |
+| `SSH_KEY` | From user or `/workspace/.ssh/id_ed25519` | Step 4 (SSH investigation) only |
+| `SSH_USER` | From user or default `root` | Step 4 (SSH investigation) only |
+| `SSH_HOST` | From user's message | Step 4 (SSH investigation) only |
+
+**If the user has already provided `DD_HOSTNAME` and `SERVICE_NAME`, go directly to Step 1. Do not ask for ENV or SSH details first.**
 
 ---
 
@@ -134,6 +150,13 @@ pup traces search --query "service:<SERVICE_NAME>" --from 15m --limit 5
 pup metrics query --query "sum:trace.*.request.hits{host:<DD_HOSTNAME>,service:<SERVICE_NAME>}.as_count()" --from 15m
 ```
 
+`ENV` is required for `service-library-config get`. If the user didn't provide it, ask for it before running that command.
+
+Key values to check in `service-library-config get` output:
+- `apm_enabled` — must be `true`. If `false`, the tracer won't send traces regardless of injection.
+- `trace_agent_url` — must point to `http://localhost:8126` or the correct agent socket. Wrong value = tracer can't reach the Agent.
+- `site` — must match your Datadog org's site.
+
 ---
 
 ## Step 2: State Your Hypotheses
@@ -191,6 +214,8 @@ pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 4h
 ---
 
 ## Step 4: Investigate via SSH (if pup didn't reveal the cause)
+
+**Before asking for SSH credentials, briefly explain what you need to check and why**, so the user understands the diagnostic plan before handing over access.
 
 **Is `/etc/ld.so.preload` set?**
 ```bash

--- a/dd-apm/linux-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/verify-ssi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-apm-linux-verify-ssi
-description: Verify APM SSI is working end-to-end on Linux hosts. Confirms /proc/maps injection, tracer telemetry, and Datadog backend visibility using pup commands and SSH process inspection.
+description: Verify Single Step Instrumentation (SSI) is working end-to-end on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use after enable-ssi has run.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -63,8 +63,8 @@ pup auth login --site <DD_SITE>
 
 Confirm with `pup auth status --site <DD_SITE>`.
 
-✅ Valid token — proceed.
-❌ No browser available: `export DD_APP_KEY=<your-app-key>`
+If valid token — proceed.
+ERROR: No browser available: `export DD_APP_KEY=<your-app-key>`
 
 ---
 
@@ -100,9 +100,9 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo cat /proc/<PID>/maps | grep -E 'launcher|apm-library|datadog'"
 ```
 
-✅ Output includes both the launcher (e.g. `launcher.preload.so`) and a language library (e.g. `apm-library-python`) — injection succeeded for this process.
+If the output includes both the launcher (e.g. `launcher.preload.so`) and a language library (e.g. `apm-library-python`) — injection succeeded for this process.
 
-❌ Launcher present but no language library — launcher ran but couldn't inject. Check for injection errors:
+ERROR: Launcher present but no language library — launcher ran but couldn't inject. Check for injection errors:
 
 ### Claude runs
 
@@ -110,7 +110,7 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 1h
 ```
 
-❌ Neither present — process was not injected. Check `/etc/ld.so.preload`:
+ERROR: Neither present — process was not injected. Check `/etc/ld.so.preload`:
 
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "cat /etc/ld.so.preload"
@@ -129,13 +129,13 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo datadog-agent status 2>&1 | grep -A 15 'APM Agent'"
 ```
 
-✅ Shows:
+Healthy output shows:
 - `feature_auto_instrumentation_enabled: true`
 - `Receiver (previous minute)` with `> 0` traces
 
-❌ `feature_auto_instrumentation_enabled: false` — SSI not active on the agent. Check `apm_config` in `/etc/datadog-agent/datadog.yaml`.
+ERROR: `feature_auto_instrumentation_enabled: false` — SSI not active on the agent. Check `apm_config` in `/etc/datadog-agent/datadog.yaml`.
 
-❌ `Receiver (previous minute): 0` — agent running but no traces yet. Generate traffic first (see Step 3), then recheck.
+ERROR: `Receiver (previous minute): 0` — agent running but no traces yet. Generate traffic first (see Step 3), then recheck.
 
 ---
 
@@ -147,11 +147,11 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 ```
 
-✅ `<SERVICE_NAME>` appears with `isTraced: true` — traces are reaching the Datadog backend.
+If `<SERVICE_NAME>` appears with `isTraced: true` — traces are reaching the Datadog backend.
 
-> **Flask / ddtrace v3 naming note:** With ddtrace ≥3.x, Flask spans are emitted as `service:flask` rather than `service:<DD_SERVICE>`. The `DD_SERVICE` value appears as `base_service` on the spans. If you set `DD_SERVICE=my-app`, search for `service:flask` in the APM UI — the service list will show `flask`, not `my-app`. Check the `base_service` tag to confirm it matches your `DD_SERVICE`.
+> **Flask / ddtrace v3 naming note:** With ddtrace >=3.x, Flask spans are emitted as `service:flask` rather than `service:<DD_SERVICE>`. The `DD_SERVICE` value appears as `base_service` on the spans. If you set `DD_SERVICE=my-app`, search for `service:flask` in the APM UI — the service list will show `flask`, not `my-app`. Check the `base_service` tag to confirm it matches your `DD_SERVICE`.
 
-❌ Service missing — generate traffic to trigger trace creation:
+ERROR: Service missing — generate traffic to trigger trace creation:
 
 ### Claude runs
 
@@ -172,7 +172,7 @@ DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 10m
 DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 10m --limit 5
 ```
 
-❌ Still missing — check for injection errors and go to `troubleshoot-ssi`:
+ERROR: Still missing — check for injection errors and go to `troubleshoot-ssi`:
 ```bash
 pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 1h
 ```

--- a/dd-apm/linux-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/verify-ssi/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dd-apm-linux-verify-ssi
+name: verify-ssi
 description: Verify Single Step Instrumentation (SSI) is working end-to-end on Linux hosts — SSI automatically instruments applications for APM without code changes. Only use after enable-ssi has run.
 metadata:
   version: "1.0.0"

--- a/dd-apm/linux-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/verify-ssi/SKILL.md
@@ -61,6 +61,8 @@ If not authenticated:
 pup auth login --site <DD_SITE>
 ```
 
+> This opens a browser tab for OAuth. Complete the login there — Claude will continue once the command exits.
+
 If valid token — proceed.
 ERROR: No browser available: `export DD_APP_KEY=<your-app-key>`
 

--- a/dd-apm/linux-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/verify-ssi/SKILL.md
@@ -55,13 +55,11 @@ pup auth status --site <DD_SITE>
 
 If not authenticated:
 
-### What you need to do in a terminal
+### Claude runs
 
 ```bash
 pup auth login --site <DD_SITE>
 ```
-
-Confirm with `pup auth status --site <DD_SITE>`.
 
 If valid token — proceed.
 ERROR: No browser available: `export DD_APP_KEY=<your-app-key>`

--- a/dd-apm/linux-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/verify-ssi/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: dd-apm-linux-verify-ssi
+description: Verify APM SSI is working end-to-end on Linux hosts. Confirms /proc/maps injection, tracer telemetry, and Datadog backend visibility using pup commands and SSH process inspection.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,apm,linux,ssi,verification,instrumentation,ld-preload
+  alwaysApply: "false"
+---
+
+# Verify APM SSI on Linux
+
+> **Before doing anything else:** Fully resolve all variables in `## Context to resolve before acting`. Do not begin Step 1 until every variable has a concrete value.
+
+## Triggers
+
+Invoke this skill when the user expresses intent to:
+- Confirm SSI is working after installing the Datadog Agent on Linux
+- Check whether a Linux process is being instrumented
+- Verify the tracer is running and reporting telemetry
+
+Do NOT invoke this skill if:
+- SSI has not been enabled yet — run `agent-install` first
+- Services have not been restarted since the agent was installed — restart them first, then verify
+
+---
+
+## Prerequisites
+
+- [ ] `agent-install` is complete
+- [ ] Application services have been restarted since the agent was installed
+
+### pup-cli: check, install, and authenticate
+
+### Claude runs
+
+```bash
+pup --version
+```
+
+If not found:
+
+### Claude runs
+
+```bash
+brew tap datadog-labs/pack
+brew install pup
+```
+
+Check auth:
+```bash
+pup auth status --site <DD_SITE>
+```
+
+If not authenticated:
+
+### What you need to do in a terminal
+
+```bash
+pup auth login --site <DD_SITE>
+```
+
+Confirm with `pup auth status --site <DD_SITE>`.
+
+✅ Valid token — proceed.
+❌ No browser available: `export DD_APP_KEY=<your-app-key>`
+
+---
+
+## Context to resolve before acting
+
+| Variable | How to resolve |
+|---|---|
+| `DD_HOSTNAME` | Hostname as Datadog sees it — from `sudo datadog-agent status` output |
+| `SERVICE_NAME` | Expected service name in APM — ask the user |
+| `ENV` | Environment tag — ask the user |
+| `DD_SITE` | `grep "^site:" /etc/datadog-agent/datadog.yaml` via SSH, or ask the user |
+| `SSH_KEY` | Path to SSH private key |
+| `SSH_USER` | SSH username |
+| `SSH_HOST` | Hostname or IP of the target host |
+
+---
+
+## Step 1: Confirm the Process is Injected
+
+Use `/proc/<pid>/maps` — this is the authoritative check. It shows the actual shared libraries loaded into the running process, which is the only way to confirm the launcher and tracer `.so` files were actually loaded.
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "pgrep -a -f '<SERVICE_NAME>' | head -5"
+```
+
+Use the PID from above:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo cat /proc/<PID>/maps | grep -E 'launcher|apm-library|datadog'"
+```
+
+✅ Output includes both the launcher (e.g. `launcher.preload.so`) and a language library (e.g. `apm-library-python`) — injection succeeded for this process.
+
+❌ Launcher present but no language library — launcher ran but couldn't inject. Check for injection errors:
+
+### Claude runs
+
+```bash
+pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 1h
+```
+
+❌ Neither present — process was not injected. Check `/etc/ld.so.preload`:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> "cat /etc/ld.so.preload"
+```
+
+If empty — install did not set up the launcher. Re-run the install script with `DD_APM_INSTRUMENTATION_ENABLED=host`. If non-empty but the process still isn't injected — the process was started before the launcher was installed. Restart the service and recheck.
+
+---
+
+## Step 2: Confirm the Agent is Receiving Traces
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo datadog-agent status 2>&1 | grep -A 15 'APM Agent'"
+```
+
+✅ Shows:
+- `feature_auto_instrumentation_enabled: true`
+- `Receiver (previous minute)` with `> 0` traces
+
+❌ `feature_auto_instrumentation_enabled: false` — SSI not active on the agent. Check `apm_config` in `/etc/datadog-agent/datadog.yaml`.
+
+❌ `Receiver (previous minute): 0` — agent running but no traces yet. Generate traffic first (see Step 3), then recheck.
+
+---
+
+## Step 3: Confirm the Service is Visible in Datadog
+
+### Claude runs
+
+```bash
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
+```
+
+✅ `<SERVICE_NAME>` appears with `isTraced: true` — traces are reaching the Datadog backend.
+
+> **Flask / ddtrace v3 naming note:** With ddtrace ≥3.x, Flask spans are emitted as `service:flask` rather than `service:<DD_SERVICE>`. The `DD_SERVICE` value appears as `base_service` on the spans. If you set `DD_SERVICE=my-app`, search for `service:flask` in the APM UI — the service list will show `flask`, not `my-app`. Check the `base_service` tag to confirm it matches your `DD_SERVICE`.
+
+❌ Service missing — generate traffic to trigger trace creation:
+
+### Claude runs
+
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "sudo ss -tlnp 2>/dev/null | grep <PID> || sudo netstat -tlnp 2>/dev/null | grep <PID>"
+```
+
+Use the port from above:
+```bash
+ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
+  "for i in \$(seq 1 10); do curl -s -o /dev/null http://localhost:<PORT>/; done"
+```
+
+Wait 30 seconds, then retry:
+```bash
+DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 10m
+DD_SITE=<DD_SITE> pup traces search --query "service:<SERVICE_NAME>" --from 10m --limit 5
+```
+
+❌ Still missing — check for injection errors and go to `troubleshoot-ssi`:
+```bash
+pup apm troubleshooting list --hostname <DD_HOSTNAME> --timeframe 1h
+```
+
+---
+
+## Done
+
+Exit when ALL of the following are true:
+- [ ] Step 1: launcher + language library both visible in `/proc/<PID>/maps`
+- [ ] Step 2: agent APM receiver shows `> 0` traces/min
+- [ ] Step 3: service appears in `pup apm services list`
+
+If any check fails, go to `troubleshoot-ssi`.
+
+When all steps pass, automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+
+---
+
+## Security constraints
+
+- Never write a raw API key into any file or chat message
+- Always confirm before restarting production services


### PR DESCRIPTION
Summary: 
This PR improves the K8s and Linux SSI onboarding skill suite.                                                                                                                                                                                              
   
Reduce credential friction
- Replaced the 5-step environment file flow (create file → fill in key → source file → verify → proceed) with a single inline command: ! export DD_API_KEY=.... The ! prefix runs it directly in the Claude Code session — one step instead of five. Applied to both k8s-ssi and linux-ssi agent-install skills.                                                                                                                     

Claude runs pup auth login automatically                                                                                                                                                                            
- All 6 skills (verify-ssi, onboarding-summary, troubleshoot-ssi for both k8s and linux) previously handed off pup auth login to the user when unauthenticated, interrupting the session mid-flow. Claude now runs it directly.                                                                                                                                                                                                        

Require confirmation before restarting application pods                                                                                                                                                             
- Claude was restarting production deployments via kubectl rollout restart without asking. Added explicit confirmation gates at all 5 unguarded restart points in k8s-ssi/enable-ssi and k8s-ssi/troubleshoot-ssi.  Claude now explains what it's about to restart and why, and waits for the user to confirm.                                                                                                                                    

Fix incorrect musl/Alpine restriction for K8s SSI                                                                                                                                                                   
- The skills incorrectly blocked SSI setup on Alpine/musl images, citing glibc ABI incompatibility. This is only true for Linux host SSI (which uses /etc/ld.so.preload). K8s SSI injects LD_PRELOAD as an environment variable directly into the pod, so it works on both musl and glibc. Removed the blocking prerequisite check from enable-ssi, removed musl from the silent failure list and triage table in troubleshoot-ssi, and updated the Alpine section to clarify it's not a blocker.  

K8s SSI silent failure warning
- Promoted the ddtrace/OTel dependency silent failure check to the very top of enable-ssi, before Triggers or Prerequisites. This failure is invisible at runtime — init containers complete, pods are healthy, but no traces arrive — so surfacing it first prevents the most common wasted debugging session. 