### PR TITLE
feat(dd-llmo): sync skill updates and add eval-session-classify

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.dat
 ```
 
 `experiment-analyzer` uses the core toolset for notebook export (optional). `eval-session-classify`
-requires it for RUM behavioral analysis:
+requires it for RUM behavioral analysis and efficient batched fetches of trace session spans:
 
 ```bash
 claude mcp add --scope user --transport http "datadog-mcp-core" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-logs** | Search logs |
 | **dd-apm** | Traces, services, performance |
 | **dd-docs** | Search Datadog documentation |
-| **dd-llmo** | LLM Observability: experiments, eval RCA, evaluator generation |
+| **dd-llmo** | LLM Observability: experiments, eval RCA, evaluator generation, session classification |
 
 ## Install
 
@@ -57,22 +57,29 @@ npx skills add datadog-labs/agent-skills \
 
 ### LLM Observability (LLMO)
 
-The `dd-llmo` directory contains three skills for working with LLM Observability data:
+The `dd-llmo` directory contains four skills for working with LLM Observability data:
 
 | Skill | Purpose |
 |-------|---------|
 | `experiment-analyzer` | Analyze and compare offline LLM experiments |
-| `eval-trace-rca` | Root-cause production failures using eval judge signal |
+| `eval-trace-rca` | Root-cause production failures using eval judge signal or runtime errors |
 | `eval-bootstrap` | Generate evaluator code from traces, optionally seeded by RCA output |
+| `eval-session-classify` | Classify whether user intent was satisfied in a session (trace + RUM signals) |
 
 **Eval pipeline flow:**
 
 ```
-eval-trace-rca → eval-bootstrap
- (diagnose why)   (build evals)
+eval-session-classify          eval-trace-rca → eval-bootstrap
+ (classify sessions)           (diagnose why)   (build evals)
 ```
 
-Run `eval-trace-rca` to understand why an app is failing by analyzing eval judge verdicts across production traces. Then run `eval-bootstrap` to generate evaluator code that captures those failure patterns. Pass the RCA output directly to `eval-bootstrap` to seed it with the discovered failure taxonomy.
+Run `eval-trace-rca` to understand why an app is failing by analyzing eval judge verdicts or
+runtime errors across production traces. Then run `eval-bootstrap` to generate evaluator code
+that captures those failure patterns. Pass the RCA output directly to `eval-bootstrap` to seed
+it with the discovered failure taxonomy.
+
+Use `eval-session-classify` independently to evaluate whether individual assistant sessions
+satisfied user intent, combining LLM Obs trace data with RUM behavioral signals.
 
 #### Install
 
@@ -81,17 +88,19 @@ Run `eval-trace-rca` to understand why an app is failing by analyzing eval judge
 cp -r dd-llmo/experiment-analyzer ~/.claude/skills
 cp -r dd-llmo/eval-trace-rca ~/.claude/skills
 cp -r dd-llmo/eval-bootstrap ~/.claude/skills
+cp -r dd-llmo/eval-session-classify ~/.claude/skills
 ```
 
 #### MCP Requirements
 
-All three skills require the LLMO toolset:
+All four skills require the LLMO toolset:
 
 ```bash
 claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'
 ```
 
-`experiment-analyzer` optionally uses the core toolset for notebook export:
+`experiment-analyzer` uses the core toolset for notebook export (optional). `eval-session-classify`
+requires it for RUM behavioral analysis:
 
 ```bash
 claude mcp add --scope user --transport http "datadog-mcp-core" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core'
@@ -109,11 +118,15 @@ experiment-analyzer <id(s)> [question] --output notebook    # export to Datadog 
 # Root-cause why an app is failing
 What's wrong with <ml_app> based on its evals over the last 24h
 Analyze eval failures for <eval_name> over the last week
+Look at the errors on <ml_app> over the last 24h
 
 # Generate evaluator code from production traces
 /eval-bootstrap <ml_app>                                    # cold start
 /eval-bootstrap <ml_app> [paste eval-trace-rca output here] # seeded from RCA
 /eval-bootstrap <ml_app> --data-only                        # emit JSON spec instead of Python SDK code
+
+# Classify a session
+/eval-session-classify <session_id>
 ```
 
 ## Quick Reference

--- a/dd-llmo/eval-bootstrap/SKILL.md
+++ b/dd-llmo/eval-bootstrap/SKILL.md
@@ -291,6 +291,8 @@ If you have access to dd-trace-py locally, verify the API surface by reading:
 
    By the end of this step you have a complete coverage map: `{eval_name → source, enabled, dimension}`. Carry this into Phase 2 for deduplication.
 
+5. **Notebook context detection**: Scan the current conversation for a Datadog notebook URL that was produced by `/eval-trace-rca` (pattern: `https://app.datadoghq.com/notebook/{numeric-id}`). If found, store it as `rca_notebook_url` and extract the numeric ID as `rca_notebook_id`. This is used after Phase 3 to offer appending the evaluator suite to that notebook instead of creating a new one.
+
 ---
 
 ### Phase 1: Explore Traces & Identify Eval Targets
@@ -461,6 +463,55 @@ Wrote {N} evaluators to `{output_path}`:
 2. **Test offline**: Use `LLMObs.experiment(evaluators=evaluators)` to batch-evaluate against a labeled dataset and verify scores
 ```
 
+#### Notebook export (after summary)
+
+After displaying the summary, offer notebook export:
+
+- **If `rca_notebook_url` was detected in Phase 0**:
+  > An RCA notebook was created earlier in this session: `{rca_notebook_url}`
+  > Would you like to (a) append the evaluator suite summary to that notebook, or (b) create a new standalone notebook?
+
+  If **append**: call `mcp__datadog-mcp-core__edit_datadog_notebook` with `id={rca_notebook_id}`, `append_only=true`, and the evaluator suite summary cell (see Notebook cell content below).
+
+  If **new**: call `mcp__datadog-mcp-core__create_datadog_notebook` (see below).
+
+- **If no `rca_notebook_url`**:
+  > Would you like to export this evaluator suite summary to a Datadog notebook?
+
+  If yes: call `mcp__datadog-mcp-core__create_datadog_notebook` with:
+  - **`name`**: `Eval Bootstrap: {ml_app} — YYYY-MM-DD`
+  - **`type`**: `report`
+  - **`cells`**: single markdown cell with the evaluator suite summary
+  - **`time`**: `{ "live_span": "1h" }`
+
+After the notebook is created or updated, output the URL:
+`Evaluator suite exported to notebook: <url>`
+
+**Notebook cell content** — the markdown cell should contain:
+
+```markdown
+## Eval Bootstrap: {ml_app}
+
+**Generated**: YYYY-MM-DD | **App profile**: {LLM | RAG | Agent | Multi-agent} | **Entry mode**: {cold_start | from_rca}
+**Generated code**: `{output_path}`
+
+### Evaluator Suite
+
+| # | Name | Type | Measures | Pass Criteria |
+|---|------|------|----------|---------------|
+| 1 | ... | ... | ... | ... |
+
+### Evidence
+
+{For each evaluator: name — 1-line description — [Trace link]}
+
+### Next Steps
+
+1. Review generated prompts in `{output_path}`
+2. Run against a labeled dataset to validate scores
+3. Deploy to Datadog LLM Experiments
+```
+
 ---
 
 ## Output Format
@@ -621,6 +672,10 @@ Wrote `./evals/{ml_app}_eval_spec.json`:
    - Custom code: call your LLM API with the rubric and parse the structured output
 3. **Label**: `suggested_labels` are Claude's best guesses from trace inspection — verify against ground truth before using as training data
 ```
+
+#### Notebook export (after summary)
+
+Same logic as Phase 3A — offer to append to the RCA notebook if `rca_notebook_url` was detected, or create a new standalone notebook. Use the same notebook cell format as Phase 3A, substituting `output_path` with the JSON spec file path.
 
 ---
 

--- a/dd-llmo/eval-session-classify/SKILL.md
+++ b/dd-llmo/eval-session-classify/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: eval-session-classify
+description: Classify whether a user's intent was satisfied in a Datadog assistant session. Use when given a session_id and asked to evaluate satisfaction, intent classification, or RUM-based session quality.
+---
+
+# Skill: eval-session-classify
+
+Given a Datadog assistant session ID, classify whether the user's intent was satisfied.
+Uses the Datadog LLM Obs and core MCP servers.
+
+---
+
+## Input
+
+A single `session_id` UUID, e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`.
+
+---
+
+## What the Datadog MCP LLM Obs toolset gives you
+
+Starting from only a `session_id`, three MCP calls reconstruct everything:
+
+| Call | What you get |
+|------|-------------|
+| `search_llmobs_spans(session_id:<id>)` | `trace_id`, agent `span_id`, all span tags: `user_handle`, `user_id`, `org_id`, `product_area`, `message_id`, `iteration` counts, `stop_reason`, `matched_model_name`, tool names |
+| `get_llmobs_span_details(agent_span_id)` | All evaluations on the span with full reasoning (any judges that ran — built-in, user-uploaded, or external), `content_info` map (shows available metadata fields: `query_string`, `referrer_path`, `referrer_url`, `entities_json`, `user_info_json`) |
+| `get_llmobs_agent_loop(trace_id, agent_span_id)` | **Full conversation**: system prompt, user message + ROUTE_CONTEXT (recent pages with popularity scores), assistant thinking blocks, all tool call arguments + results, final response |
+
+The agent loop tool reconstructs the full conversation from
+the child LLM spans, which do carry content — the null inputs/outputs are only on the agent
+span itself, not on the underlying `anthropic.request` spans.
+
+---
+
+## Step 1 — Get trace identity and span structure
+
+```
+search_llmobs_spans(
+  query  = "session_id:<SESSION_ID>",
+  from   = "<reasonable window, e.g. now-30d>",
+  to     = "now",
+  limit  = 50
+)
+```
+
+From the results, extract:
+- `trace_id` (same on all spans)
+- `span_id` of the span with `span_kind=agent` and `name=assistant` → this is the **agent span**
+- From agent span tags: `user_handle`, `user_id`, `org_id`, `product_area`, `message_id`, `start_ms`
+- Tool span names (all `span_kind=tool` entries) → what tools were called
+- Iteration count from `iteration` tags on `get_answer_from_model_step` spans (0-indexed, so max+1 = total iterations)
+- `stop_reason` on the last iteration's LLM span (`end_turn` = clean finish, `tool_use` = ended mid-tool)
+
+**Key metadata available from tags alone — before reading any content:**
+- `product_area` → the pod (`workflow`, `rca`, `dashboard`, `monitor`, etc.)
+- `user_handle` → email, needed for RUM queries
+- `matched_model_name` → which model served the session
+- `mcp:true/false` on tool spans → whether tools were MCP-backed
+- `response_truncated:true/false` → whether the response was cut off
+
+**If `search_llmobs_spans` returns no results** → stop immediately, output error `llmobs_not_found`.
+
+---
+
+## Step 2 — Get evaluations and metadata fields
+
+```
+get_llmobs_span_details(
+  trace_id  = "<TRACE_ID>",
+  span_ids  = ["<AGENT_SPAN_ID>"],
+  from/to   = <same window>
+)
+```
+
+### Evaluations
+
+The `evaluations` map contains every judge verdict that ran against this span. Evaluations in
+LLM Observability are simply named key-value results attached to a span — any party can upload
+them. There are two common sources:
+
+**Platform-run judges** (run server-side by Datadog automatically on sampled spans):
+these show up with names like `tribunal_*` or `prompt-injection`. Each has a `.value` (the
+label or score) and usually a `.reasoning` (prose explanation from the judge LLM). Always
+read the reasoning, not just the value — it often contains the most useful signal.
+
+**User-uploaded evaluations** (run externally and pushed back via the LLM Obs SDK or API):
+these appear under whatever name the team chose. They follow the same structure. Treat them
+with the same weight — a user-defined judge for e.g. `groundedness` or `helpfulness` is as
+authoritative as a platform judge.
+
+**How to read the evaluations map:**
+- Iterate over all keys — don't assume a fixed set of judge names
+- For each evaluation: note `.value` (the verdict), `.reasoning` (if present), and `.tags`
+  (which can carry experiment names, judge versions, billing plan, etc.)
+- Categorical evaluations have a string `.value`; score evaluations have a numeric `.value`
+- A missing evaluation key means the judge didn't run on this span (sampling, not failure)
+
+Treat whatever evaluations are present as the authoritative set for that span.
+
+### Metadata fields
+
+From `content_info.metadata`:
+- `query_string` → the raw text the user typed
+- `referrer_path` → the Datadog page the user was on when they opened the assistant
+- `referrer_url` → full URL
+- `entities_json` → any Datadog entities the user added as context (`@asset`)
+- `user_info_json` → user profile info
+
+**These metadata fields are available via `get_llmobs_span_content(field="metadata")` if you
+need the actual values.** The `content_info` map only confirms they exist and their type.
+
+**Known bug:** `get_llmobs_span_details` `span_ids` parameter consistently fails with a Go type
+unmarshal error regardless of how the array is passed. This is a known platform bug affecting all
+sessions — skip step 2 silently and proceed to step 3. This is not a classification error.
+
+---
+
+## Step 3 — Read the full conversation
+
+```
+get_llmobs_agent_loop(
+  trace_id           = "<TRACE_ID>",
+  span_id            = "<AGENT_SPAN_ID>",
+  from/to            = <same window>,
+  max_content_length = 3000   ← increase for full tool results
+)
+```
+
+**If this call returns a 404 or any error** → stop immediately, output error `llmobs_content_expired`.
+
+**If the response contains `<REDACTED_INPUT>` or `<MASKED_STREAMING_RESPONSE>`** → stop immediately,
+output error `llmobs_content_masked`. Do not attempt to classify from tool names or structural signals.
+
+The response has two parallel structures:
+
+**`iterations[]`** — one entry per LLM call in order:
+- `iteration` (1-indexed)
+- `content` — the assistant's output for this iteration (thinking block JSON or final text)
+- `tool_calls[]` — array of `{name, arguments, result}` for any tool calls made
+- `input_tokens`, `output_tokens`, `cache_read_input_tokens` — token economics
+- `stop_reason` implicit from whether there are more iterations
+
+**`timeline[]`** — flat chronological message list:
+- `role: system` at iteration 1 — the full system prompt
+- `role: user` at iteration 1 — the user's message + full `ROUTE_CONTEXT` (recent pages with
+  popularity scores) + any custom context
+- `role: assistant` at each iteration — thinking blocks and tool calls
+- Final assistant response as the last `role: ""` entry (the actual text sent to the user)
+
+**From the user message's ROUTE_CONTEXT you get:**
+- Which pages the user visited recently and how often (popularity score)
+- The current page they were on when they sent the message
+- What Datadog products/features they were working in before the session
+
+This is pre-session behavioral context embedded in the LLM Obs trace — no RUM query needed
+to understand what the user was doing.
+
+---
+
+## Step 4 — Get RUM behavioral signals
+
+With `user_handle` (from step 1) and `start_ms` (agent span start), define the time window:
+
+- **pre**: `[start_ms − 30min, start_ms]`
+- **during**: `[start_ms, start_ms + session_duration_ms]`
+- **post**: `[start_ms + session_duration_ms, start_ms + session_duration_ms + 60min]`
+
+Run two RUM queries in parallel via `analyze_rum_events` (SQL-based, `rum` toolset).
+
+**If either RUM query returns 0 rows**, query a wider window (last 30 days) to check whether the
+user has any web RUM data at all. If they have data on other days but not on the session date
+(web RUM gap), or if they have no RUM data at all → stop, output error `rum_unavailable`.
+Do not fall back to trace-only classification.
+
+### RUM Query A — Page view timeline
+
+```
+analyze_rum_events(
+  event_type  = "view",
+  filter      = "@usr.email:<user_handle>",
+  from        = <pre_start>,
+  to          = <post_end>,
+  sql_query   = "SELECT timestamp, view_url, \"@view.time_spent\" FROM rum ORDER BY timestamp LIMIT 200",
+  extra_columns = [{"name": "@view.time_spent", "type": "int64"}]
+)
+```
+
+`@view.time_spent` is in nanoseconds — divide by 1e9 for seconds. Sort ascending for navigation arc.
+
+### RUM Query B — Custom actions only
+
+```
+analyze_rum_events(
+  event_type    = "action",
+  filter        = "@action.type:custom @usr.email:<user_handle>",
+  from          = <pre_start>,
+  to            = <post_end>,
+  sql_query     = "SELECT timestamp, \"@action.name\", view_url FROM rum ORDER BY timestamp LIMIT 200",
+  extra_columns = [{"name": "@action.name", "type": "string"}]
+)
+```
+
+`@action.type:custom` filters to developer-instrumented events only, excluding auto-collected clicks and keypresses. 
+A typical 1.5h session window yields ~150–200 custom events — manageable in 1–2 calls.
+
+From each row: `@action.name`, `view_url`, `timestamp`. Sort ascending.
+
+**Pagination**: if `is_truncated: true`, re-call with `start_at=<displayed_rows>` and the same
+`LIMIT`. `start_at` is a row offset into the SQL result, not a cursor. Use `max_tokens` to tune
+response size.
+
+**External customer RUM noise**: Some sessions generate far more framework telemetry per page load. APM service pages can emit 200+ custom events in 2 minutes, exhausting the LIMIT before reaching the session time. When this happens, use SQL `WHERE` filters to reduce noise. Each agent team will have their own set of actions to filter out or target — the examples below are illustrative, not prescriptive.
+
+**Query 1 — Navigation & non-assistant actions (framework noise filtered):**
+
+```python
+analyze_rum_events(
+    event_type    = "action",
+    filter        = "@action.type:custom @usr.email:<user_handle>",
+    from          = <pre_start>,
+    to            = <post_end>,
+    sql_query     = """
+        SELECT timestamp, "@action.name", view_url
+        FROM rum
+        WHERE "@action.name" NOT IN (
+            'dataviz.first_significant_render',
+            'perf.scroll.dashboard',
+            'perf.trafficTelemetry.initialLoad',
+            'getInitialContrastMode',
+            'DSM__root__Widget-Map--view',
+            'DataStreamsRelationGraph__ErrorBoundary--view',
+            'DataStreamsRelationGraphWrapper__ErrorBoundary--view',
+            'dsm-topology-map-fetch-finish',
+            'apm_autopilot_notification_stats',
+            'noEventInCache',
+            'useEventPlatformQuery without query',
+            'Experiments explicit fetch completed',
+            'discussions.discussionCountFetched',
+            'Feature Flags Provider'
+        )
+        ORDER BY timestamp LIMIT 200
+    """,
+    extra_columns = [{"name": "@action.name", "type": "string"}]
+)
+```
+
+**Query 2 — Assistant-specific signals only:**
+
+```python
+analyze_rum_events(
+    event_type    = "action",
+    filter        = "@action.type:custom @usr.email:<user_handle>",
+    from          = <pre_start>,
+    to            = <post_end>,
+    sql_query     = """
+        SELECT timestamp, "@action.name", view_url
+        FROM rum
+        WHERE (
+            "@action.name" LIKE 'command-assistant%'
+            OR "@action.name" LIKE 'workbench%'
+            OR "@action.name" LIKE 'ai-experiences%'
+            OR "@action.name" = 'click on Bad response'
+            OR "@action.name" = 'click on Incorrect result'
+            OR "@action.name" = 'click on Submit'
+            OR "@action.name" = 'click on Reasoning'
+            OR "@action.name" = 'Rendered a Code block'
+        )
+        ORDER BY timestamp LIMIT 200
+    """,
+    extra_columns = [{"name": "@action.name", "type": "string"}]
+)
+```
+
+These two complementary queries — one filtering out known noise, one targeting known signal — typically reduce thousands of events to the handful that matter for classification. Your agent team's RUM instrumentation will differ; adapt the action names accordingly.
+
+**To interpret what the action names mean for your agent, consult the agent-specific RUM
+action reference file:**
+
+@rum-actions-bits-assistant.md
+
+Each LLM agent team instruments their own custom actions. If you are classifying a different
+agent, you need the equivalent reference file for that agent's RUM instrumentation. The
+classification logic (what constitutes a positive vs negative post-session signal) depends
+entirely on which actions are tracked and what they mean in that product's context.
+
+---
+
+## Step 5 — Classify
+
+With the conversation (step 3), evaluations (step 2), and RUM signals (step 4), apply
+the following classification schema.
+
+### User intent (1 sentence)
+From the user message in the agent loop timeline. What did they want to achieve?
+
+### Pod
+Primary source: `product_area` tag from step 1.
+Secondary confirmation: any pod/area classifier evaluation present in step 2 (e.g. `tribunal_pod_classifier.value`).
+If they disagree, note the discrepancy — the tag reflects where the user was in the UI,
+the evaluation reflects what the conversation was actually about.
+
+### What the assistant did (2–4 bullets)
+From the agent loop: which tools were called (with arguments), what docs/data was retrieved, what the final response said.
+
+### Failure mode taxonomy
+
+| Code | Meaning |
+|------|---------|
+| `wrong_answer` | Factually incorrect claim (check feature flags for platform limitation claims) |
+| `incomplete_answer` | Correct as far as it went, but missed important paths |
+| `broke_existing_state` | Assistant damaged something the user had |
+| `excessive_turns` | Goal achieved but took too many round-trips |
+| `context_loss` | Assistant forgot earlier context or repeated mistakes |
+| `wrong_tool_use` | Called wrong tool or with wrong parameters |
+| `hallucination` | Invented IDs, URLs, or facts not in tool results |
+| `other: <describe>` | |
+
+### Satisfaction verdict
+`yes` / `partial` / `no`
+
+**From the trace alone:**
+- `yes`: Final response directly answers the user's intent, no negative feedback, no abandon signals
+- `partial`: Response was partially right or user got unblocked through continued effort
+- `no`: Negative feedback given, user abandoned, or core intent structurally unachievable with the response given
+
+---
+
+## Error output schema
+
+When any required data source fails, stop classification and emit:
+
+```json
+{
+  "session_id": "<id>",
+  "classification_with_rum": "error",
+  "error": "<error_code>: <detail>"
+}
+```
+
+Error codes:
+- `llmobs_not_found` — `search_llmobs_spans` returned no spans for this session_id
+- `llmobs_content_expired` — `get_llmobs_agent_loop` returned 404 (trace past retention window)
+- `llmobs_content_masked` — agent loop returned `<REDACTED_INPUT>` / `<MASKED_STREAMING_RESPONSE>`
+- `rum_unavailable` — no web RUM data found for this user on or around the session date
+
+---
+
+## Classification output schema
+
+```markdown
+# Classification: <session_id>
+
+## Session metadata
+- **Trace ID:** <trace_id>
+- **Agent span ID:** <span_id>
+- **Start:** <UTC timestamp>
+- **Duration:** <seconds>s
+- **User:** <user_handle>
+- **Product area:** <tag value>
+- **Model:** <matched_model_name>
+- **Iterations:** <N> (stop reason: <end_turn|tool_use>)
+- **Tools called:** <tool names, counts>
+- **Evaluations:** <name: value — "reasoning excerpt"> for each judge that ran
+- **Referrer page:** <referrer_path>
+
+## User intent
+One sentence.
+
+## What the assistant did
+- Bullet 1
+- Bullet 2
+
+## Why the user gave negative feedback
+(skip if no feedback)
+
+## Was the core intent satisfied?
+**yes / partial / no** — one sentence justification.
+
+## Failure mode
+- `code`: explanation
+
+## RUM behavioral signals
+
+### Pre-session context (from ROUTE_CONTEXT in agent loop)
+What the user was working on before the session, from the popularity-scored page list.
+
+### Assistant panel actions
+| Time | Action | Page |
+|------|--------|------|
+
+### Post-session navigation
+| Time | URL | Dwell |
+|------|-----|-------|
+
+### Feature flags (from RUM event on session page)
+List any product-area flags that are relevant to the classification.
+
+### RUM verdict
+One sentence: does behavioral evidence support or contradict the trace-only verdict?
+
+## Revised satisfaction verdict (with RUM)
+yes / partial / no
+```
+
+---
+
+## Notes on limitations
+
+**What LLM Obs MCP gives that nothing else does:**
+- The `ROUTE_CONTEXT` in the user message is pre-session behavioral context embedded in the
+  trace — the assistant received this as part of the conversation. It lists pages the user
+  visited recently with popularity scores. This is more accurate than RUM page views for
+  understanding pre-session intent because it's what the assistant actually saw.
+- Evaluation reasoning fields are full prose explanations, not just labels — always read
+  `.reasoning`, not just `.value`. This applies to any judge, platform-run or user-uploaded.
+- Token economics per iteration (`input_tokens`, `cache_read_input_tokens`) reveal whether
+  the model was working with a hot cache (cost-efficient, but also means the conversation
+  context was being reused from prior sessions — relevant for context_loss analysis).
+
+**What LLM Obs MCP does NOT give:**
+- Post-session behavior: what did the user do after getting the response? RUM required.
+- Feature flags active on the user's browser: RUM required.
+- Whether the user continued with more sessions after giving negative feedback: RUM required
+  (count of `ai-experiences.chat-submit` events after `start_ms + duration`).
+- Other concurrent sessions by the same user in the same time window: requires a second
+  `search_llmobs_spans` call filtered by `user_handle` across a broader window.

--- a/dd-llmo/eval-session-classify/rum-actions-bits-assistant.md
+++ b/dd-llmo/eval-session-classify/rum-actions-bits-assistant.md
@@ -1,0 +1,249 @@
+# RUM Custom Actions — Bits AI Assistant (assistant_api)
+
+This file documents the custom RUM actions instrumented by the Bits AI / CMD+I assistant
+team (`web-ui` / `ai-experiences` package). Use it to interpret the output of the RUM
+custom action query in Step 4 of the classification skill.
+
+**This file is specific to `ml_app: assistant_api`.** If you are classifying a different
+agent's sessions, create a parallel file for that agent's instrumented actions.
+
+---
+
+## How to query
+
+Custom actions are developer-instrumented events (`@action.type:custom`), as opposed to
+auto-collected clicks and keypresses. This filter dramatically reduces volume (~150–200 events
+per 1.5h window vs thousands of raw events).
+
+Use `analyze_rum_events` (SQL-based, requires `rum` toolset enabled):
+
+```python
+analyze_rum_events(
+  event_type    = "action",
+  filter        = "@action.type:custom @usr.email:<user_handle>",
+  from          = <pre_start>,
+  to            = <post_end>,
+  sql_query     = 'SELECT timestamp, "@action.name", view_url FROM rum ORDER BY timestamp LIMIT 200',
+  extra_columns = [{"name": "@action.name", "type": "string"}]
+)
+```
+
+The response is TSV with three columns: `timestamp`, `@action.name`, `view_url`. These are
+directly usable — no nested attribute path parsing required.
+
+If `is_truncated: true` appears in the metadata, paginate with `start_at=<displayed_rows>`
+(same SQL, same LIMIT) until all rows are returned.
+
+---
+
+## Assistant panel lifecycle
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.panel.open` | User opened the CMD+I panel | `interaction`: `keyboard`/`navbar`/`cmd-k`/`top-nav`/`bottom-nav`; `initialQuery` if pre-filled | Note the `url_path` — this is the page context the assistant received. `interaction` tells you how they opened it. Multiple opens in a short window = prior failed attempts |
+| `command-assistant.panel.close` | User closed the panel | `conversationId`, `conversationKey` | If before LLM span end → user abandoned mid-generation |
+| `workbench.dock.show` | Panel docked / made visible (fires on every surface) | — | Counts assistant opens across product areas in the session window |
+| `workbench.dock.click:undock` | User detached the panel into floating mode | — | |
+| `trace-assistant.troubleshoot-error-button.click` | User opened via the "Troubleshoot Error" button on a trace or error | — | Strong intent signal: user wants a fix, not just information |
+
+---
+
+## Message send
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.message.send` | User sent a message (CMD+I flow) | `interaction`: `'assistant-conversation'`; `messagesLength` (turn number); `message` (text) | One per turn; count for multi-turn detection |
+| `ai-experiences.chat-submit` | User submitted a message (all surfaces: CMD+I, embedded workflow/notebook chat) | — | Also fires at feedback submit — disambiguate by checking whether feedback actions preceded it |
+
+---
+
+## Navigation within the assistant panel
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.navigation` | User navigated: in-panel view change, clicked a markdown link, or clicked an entity pill | `interaction`: `'in-panel'`/`'markdown-link'`/`'entity-pill'`; `title` (link text or panel view name); `host` (`'relative'` or external hostname); `path` (URL path) | **`'markdown-link'`** = user clicked a link in the response — strong engagement signal. `host` tells you if they left to an external site (e.g. docs). `path` shows what resource they navigated to |
+
+**Derived signals:**
+- `interaction: 'in-panel'` with `title: '#conversation'` / `'#history'` etc. = user switched tabs inside the panel
+- `interaction: 'markdown-link'` + `host: 'docs.datadoghq.com'` = user went to docs after the response → possible negative signal (didn't trust the answer)
+- `interaction: 'entity-pill'` = user clicked an entity pill inline in the response → reading/verifying the data
+
+---
+
+## Context enrichment
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.entity.add` | User added a Datadog entity (`@asset`) as context | `interaction`: `'auto-detection'`/`'context-button'`/`'screenshot-button'`/`'upload-button'`/`'paste'`/`'drag'`; `entity.type`, `entity.label` | Methodical user; `interaction` tells you how the entity was added. Multiple `entity.add` events during a timeout wait = user actively enriching context |
+| `command-assistant.entity.remove` | User removed an entity from context | `entity.type`, `entity.label` | User changed their mind about context — may indicate they realized the assistant was looking at the wrong resource |
+
+---
+
+## Tool call approval flow
+
+These events cover the client tool (write-action) approval lifecycle. Write-type client tools
+(notebook edits, dashboard changes, etc.) require explicit user approval before executing.
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.tool_call.accepted` | User approved a single tool call | `toolName`, `toolCallId`, `reason`: `'user_accepted'`/`'auto_accepted'`, `isAutoApproveEnabled`, `source`: `'chat'`/`'app'`, `interaction`: `'tool-block'`/`'prompt-bar'` | `reason: 'auto_accepted'` = read-only tool auto-approved; `'user_accepted'` = user clicked approve. `interaction: 'prompt-bar'` = used the banner, `'tool-block'` = clicked directly on the tool card |
+| `command-assistant.tool_call.rejected` | User rejected a single tool call | `toolName`, `toolCallId`, `reason`: `'user_rejected'`/`'app_canceled'`, `source`, `interaction` | `reason: 'app_canceled'` = host app canceled (not user). Single reject after multiple accepts = user stopped the flow mid-way |
+| `command-assistant.tool_call.accepted_all` | User clicked "Accept All" in the pending tools banner | `toolCount` (number of tools approved at once) | Bulk approval — user trusted everything in the queue |
+| `command-assistant.tool_call.rejected_all` | User clicked "Reject All" in the pending tools banner | `toolCount` | Bulk rejection — user changed their mind entirely |
+| `command-assistant.tool_call.result` | Client tool execution completed (success or error) | `toolName`, `toolCallId`, `status`: `'success'`/`'error'`, `durationMs`, `errorType`: `'tool_not_found'`/`'handler_exception'`/`'validation_failed'`, `isAutoApproveEnabled` | **Critical for failure analysis**: `status: 'error'` with `errorType` directly identifies what failed. `'validation_failed'` = tool args didn't pass schema check; `'handler_exception'` = the client-side handler threw; `'tool_not_found'` = tool not registered on this page |
+
+**`tool_call.result` vs `clienttoolerror` in LLM Obs:**
+- `command-assistant.tool_call.result` fires client-side immediately after execution
+- `clienttoolerror` in LLM Obs appears on the agent span `stop_reason` when the error is sent back to the model
+- Both signals identify the same failure; RUM gives `errorType` and `durationMs` which LLM Obs does not
+
+---
+
+## Tool call and thinking UI interaction
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.tool_call.toggled` | User expanded or collapsed a single tool call accordion | `isOpen` (bool), `title` (tool step title) | User inspecting a specific tool result; `isOpen: true` = expanded to read, `false` = collapsed after reading |
+| `command-assistant.tool_group.toggled` | User expanded or collapsed the grouped tool calls accordion (the "N tool calls" collapse container) | `isOpen` (bool), `toolCount` | `isOpen: true` = user wanted to see all tool calls; absence of this event = user didn't inspect the tool calls at all |
+| `command-assistant.thinking.toggled` | User expanded or collapsed the thinking/reasoning section | `isOpen` (bool), `title` | User opened the thinking block — often signals they're verifying or skeptical of the response |
+
+**Note:** Some sessions show `click on Reasoning` as an action name instead of `thinking.toggled`.
+This is the browser SDK's auto-instrumented click on the button element — both events may appear
+in the same session. `thinking.toggled` is the structured event and carries `isOpen`; `click on Reasoning`
+is the raw click. Treat either as "user read the thinking block."
+
+---
+
+## Suggestion selection
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.suggestion.select` | User clicked a suggested prompt card (shown on empty conversation) | `message` (the suggestion text) | User didn't know what to ask — they picked from the list. The `message` shows which suggestion was selected |
+
+---
+
+## Model selection
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.model.change` | User changed the model in the panel | `interaction` (how it was changed), `modelValue`, `modelLabel` | If a user changes model mid-session, earlier turns used a different model than later ones — cross-reference with LLM Obs `matched_model_name` per turn |
+
+---
+
+## Dictation (voice input)
+
+Behind feature flag `command-assistant-dictation`. Only fires if the user has dictation enabled.
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.dictation.start` | User clicked the microphone button to start recording | — | User is dictating instead of typing |
+| `command-assistant.dictation.stop` | User stopped recording | — | Time between start and stop = dictation duration |
+
+---
+
+## Rich tag interaction (entity tags inline in response)
+
+Tags like `service:foo` or `env:prod` rendered inline in the assistant response can be clicked.
+
+| Action name | When it fires | Payload fields | Signal for classification |
+|-------------|--------------|----------------|--------------------------|
+| `command-assistant.tag.click` | User clicked an inline tag in the response | `tag` (full tag string, e.g. `service:foo`), `tagKey`, `tagValue` | User engaged with a specific entity mentioned in the response — strong engagement signal. The `tagKey`/`tagValue` show which dimension they were interested in |
+| `command-assistant.tag.copy` | User copied an inline tag | `tag`, `tagKey`, `tagValue` | User extracted a value from the response for use elsewhere — very strong "response was useful" signal |
+
+---
+
+## Content engagement
+
+| Action name | When it fires | Signal for classification |
+|-------------|--------------|--------------------------|
+| `Rendered a Code block` | A code block appeared in the assistant response | Assistant gave code; check post-session navigation for evidence it was used |
+| `click on Reasoning` | Auto-collected click: user expanded the thinking/reasoning section | Equivalent to `thinking.toggled` with `isOpen: true` (see above) |
+| `click on Reasoning Reasoning` | User re-expanded a thinking section after collapsing it | Deep read of thinking |
+
+---
+
+## Feedback sequence
+
+These fire in order when a user gives a thumbs-down. The full sequence is:
+`Bad response` → reason click → `Add details` (optional) → `Submit`.
+
+| Action name | When it fires | Signal for classification |
+|-------------|--------------|--------------------------|
+| `click on Bad response` | Thumbs-down button clicked | Negative feedback initiated |
+| `command-assistant.message.feedback` | Feedback event (fires at initiation and at submit) | |
+| `ai-experiences.chat-submit-feedback` | Same feedback event, alternate name (fires alongside the above) | |
+| `click on Incorrect result` | User selected this reason | Response was factually wrong from user's perspective |
+| `click on Correct but incomplete` | User selected this reason | Response was partially right |
+| `click on Add details` | User clicked to type a free-text reason | Time between this and `click on Submit` = how long they typed; longer = more frustration |
+| `click on Submit` | Feedback submitted | Final commit; note the `url_path` — what the user was looking at when they formed their verdict |
+
+**Key derived signals from the feedback sequence:**
+- Time from `command-assistant.message.send` → `click on Bad response`: how quickly they rejected (< 60s = near-instant; suggests the response was obviously wrong, not a slow read)
+- `click on Add details` present → user typed a custom reason; retrieve it if possible via session replay
+- `click on Incorrect result` vs `click on Correct but incomplete` → distinguishes `wrong_answer` from `incomplete_answer` failure modes directly from user selection
+
+---
+
+## Workflow Automation — action catalog
+
+These actions fire inside the Workflow Automation editor when users interact with the step catalog.
+
+| Action name | When it fires | Signal for classification |
+|-------------|--------------|--------------------------|
+| `actionPlatform.actionCatalog.openModal` | User opened the action catalog modal | User is actively building the workflow themselves (strong positive engagement signal) |
+| `actionPlatform.actionCatalog.inputSearch` | User typed a search query in the catalog | Each keystroke fires; count distinct bursts, not keystrokes |
+| `actionPlatform.actionCatalog.pickAction` | User selected an action from the catalog | Workflow step added |
+| `actionCatalog.pickAction` | Same event, alternate namespace (both fire on the same pick) | Treat as a single pick |
+| `actionPlatform.actionCatalog.closeModal` | User closed the catalog (with or without picking) | |
+| `root__toggle_editor_accordion_section--click` | User expanded/collapsed an accordion section in the workflow step editor | User is inspecting a step's config; note the `view_url` fragment (`#step-<StepName>`) for which step |
+| `InputWithVariables__open-autocomplete-menu--keypress` | User opened the autocomplete menu in a step's input field | User is configuring a step parameter |
+
+**Note on `view_url` fragments in Workflow Automation:**
+The URL hash encodes the currently-selected step: `/workflow/<id>#step-<StepName>`. This appears
+in every RUM event fired while that step is selected, giving a per-step activity timeline at no
+extra query cost.
+
+---
+
+## Post-session continued assistant usage
+
+After giving feedback, users often send more messages in follow-up sessions.
+Each `ai-experiences.chat-submit` event after the session end timestamp is one follow-up send.
+
+A high count (5+) over a short window (< 30 min) = user was persistent and likely tried a
+different approach. Combine with `Rendered a Code block` to confirm the assistant eventually
+delivered something useful.
+
+---
+
+## Interpreting absence
+
+| Absence | What it means |
+|---------|--------------|
+| No `command-assistant.panel.open` in the pre-window | Session was the first assistant interaction in this window; no prior browsing with the panel |
+| No `command-assistant.thinking.toggled` or `click on Reasoning` | User did not read the thinking section |
+| No `command-assistant.tool_call.toggled` | User did not inspect individual tool results |
+| No feedback actions | User gave no explicit signal; satisfaction is inferred from navigation only |
+| No `ai-experiences.chat-submit` post-session | User did not retry; either satisfied or completely gave up |
+| No `command-assistant.navigation` with `interaction: 'markdown-link'` | User did not follow any links from the response |
+| No `command-assistant.tag.click` or `tag.copy` | User did not interact with inline entity tags |
+
+---
+
+## Feature flags (bonus signal, same RUM event)
+
+Any RUM event on the session page carries `_dd.available_feature_flags` in its attributes.
+This is an array of all feature flags active on the user's browser for that page load.
+
+Flags relevant to Bits AI / Workflow Automation:
+- `ap-cloud-python-action` — experimental cloud Python execution step in Workflow Automation
+- `wfa-ai-chat-diff-message` — diff-style AI response in workflow editor
+- `wfa-auto-description` — AI auto-description of workflow steps
+- `command-assistant-usage-indicator` — usage indicator in the CMD+I panel
+- `command-assistant-dictation` — voice dictation input (gates `dictation.start/stop` events)
+- `command-assistant-debug-mode` — debug mode in the assistant panel
+- `assistant-skills` — assistant skills / suggestions feature
+
+If the assistant made a platform limitation claim (e.g. "Python is not supported") and a
+relevant experimental flag is enabled, the "Incorrect result" feedback may be correct —
+the user's environment differs from what the assistant assumed.

--- a/dd-llmo/eval-trace-rca/SKILL.md
+++ b/dd-llmo/eval-trace-rca/SKILL.md
@@ -3,9 +3,16 @@ name: eval-trace-rca
 description: Root cause analysis on production LLM traces using eval judge results as signal. Diagnoses why the user's application is failing. Use when user says "eval RCA", "root cause analysis", "analyze eval failures", "why is my eval failing", "why is my app failing", "failure analysis", "diagnose eval", "what's wrong with my app", or wants to understand production failure patterns. Works with ml_app or eval name.
 ---
 
-# Eval RCA — Root Cause Analysis from Production Eval Signal
+# Eval RCA — Root Cause Analysis from Production Trace Signal
 
-Perform structured root cause analysis on production LLM traces using LLM judge verdicts and reasoning. The goal is to diagnose **why the user's application is failing** — not to evaluate the judge itself. The judge is the signal; the app is the patient.
+Perform structured root cause analysis on production LLM traces. Supports two modes depending on what signal is available:
+
+| Mode | Signal used | When to use |
+|------|-------------|-------------|
+| **Eval Signal** | LLM judge verdicts and reasoning (pass/fail rates, scoring) | App has evaluators configured; goal is to understand *why* evals are failing |
+| **Error Signal** | Runtime errors in traces (`@status:error`, error types, stack traces) | No evals configured, or user explicitly wants to analyze crashes/exceptions/tool failures |
+
+If the mode cannot be inferred from context, ask **one clarifying question** before proceeding: "Would you like me to analyze eval pass/fail patterns, or look at runtime errors and exceptions in traces?"
 
 ## Methodology
 
@@ -16,14 +23,15 @@ Perform structured root cause analysis on production LLM traces using LLM judge 
 ```
 What's wrong with <ml_app> based on its evals over the last <timeframe>
 Analyze eval failures for <eval_name> over the last <timeframe>
+Look at the errors on <ml_app> over the last <timeframe>
 ```
 
 ### Inputs
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `ml_app` | One of these | — | The application to analyze. The skill discovers all configured evals via `list_llmobs_evals`. |
-| `eval_name` | One of these | — | A specific evaluator to focus on. Eval names are unique per org — each eval belongs to exactly one `ml_app`. |
+| `ml_app` | One of these | — | The application to analyze. |
+| `eval_name` | One of these | — | A specific evaluator to focus on (always Eval Signal mode). |
 | `timeframe` | No | `now-24h` | How far back to look |
 
 Either `ml_app` or `eval_name` must be provided. If neither is given, ask the user.
@@ -90,19 +98,37 @@ Additional filters combine with space (AND): `@evaluations.custom.<name>:* @stat
 
 ---
 
-### Phase 0: Resolve Inputs
+### Phase 0: Resolve Inputs & Mode
 
 1. If neither `ml_app` nor `eval_name` provided → ask the user.
 2. If `timeframe` not provided → default to `now-24h`.
-3. **ml_app entry point**: If `ml_app` provided without `eval_name`, call `list_llmobs_evals(ml_app)` to discover all configured evals. Then call `get_llmobs_eval_aggregate_stats` for each eval (in parallel) to get a quick health snapshot. Present the overview to the user and proceed to analyze ALL evals with issues (don't ask the user to pick one).
-4. **eval_name entry point**: Proceed directly to Phase 1 for the specified eval.
-5. Note any additional filters (tags, span_kind) for all subsequent queries.
+3. **Resolve mode**:
+   - `eval_name` provided → **Eval Signal**. Proceed to Phase 1 for the specified eval.
+   - User explicitly mentions errors, exceptions, crashes, runtime failures, or "look at errors" → **Error Signal**.
+   - `ml_app` provided, no explicit signal → call `list_llmobs_evals(ml_app)`:
+     - Evals exist → **Eval Signal** (default). Get aggregate stats for each eval in parallel.
+     - No evals configured → **Error Signal** automatically; inform the user.
+     - Evals exist but context is ambiguous → ask one question: "Would you like me to analyze eval pass/fail patterns, or look at runtime errors and exceptions in traces?"
+4. Note any additional filters (tags, span_kind) for all subsequent queries.
 
 ---
 
 ### Phase 1: Gather Context & Collect Evidence
 
 **Goal**: Get the big picture, sample failure spans, and determine the app profile.
+
+> **If mode = Error Signal**, replace Steps 1a–1b below with the Error Signal path:
+>
+> **Step 1a (Error Signal): Sample error spans**
+> Call `search_llmobs_spans(query="@ml_app:{ml_app} @status:error", from=timeframe, limit=50)`. Paginate until ≥ 30 error spans or no more pages. Group spans by `error_type` tag to build an initial frequency table. Report: `Found {N} error spans across {K} distinct error types: {type1} ({count}), {type2} ({count}), ...`
+>
+> **Step 1b (Error Signal): Fetch stack traces per error type**
+> For the top 3–4 error types, pick 2–3 representative trace IDs and call `find_llmobs_error_spans(trace_id)` in parallel. Extract the error message, stack trace, and the span kind/name where the error originated. Note whether errors propagate from children to parents (cascade vs. isolated).
+>
+> **Step 1c (Error Signal): Determine app profile**
+> Inspect span names, kinds, and tags from the error spans to understand the app structure (same as Eval Signal Step 1c). Then proceed to Phase 2 (Open Coding) treating each distinct error pattern as a failure category — the error_type + origin span + triggering condition is the "judge reasoning" equivalent.
+>
+> The Output Format for Error Signal mode uses the same structure but replaces **Eval Overview** / **Judge reasoning** fields with **Error type counts** / **Stack trace excerpts**.
 
 #### Step 1a: Eval overview (parallel)
 
@@ -344,91 +370,156 @@ Write the full report following the Output Format below. **This is the primary d
 1. Save the report to `eval-rca-{eval_name}-{date}.md`
 2. Apply fixes (if codebase is available)
 3. Deeper investigation of remaining categories
+4. Export the report to a Datadog notebook
+5. Run on an expanded time range (re-run the full analysis from Phase 1 with a wider `timeframe`, e.g. `now-7d` if the current window was `now-24h`)
+
+**If the user chooses option 4**, call `mcp__datadog-mcp-core__create_datadog_notebook` with:
+- **`name`**: `Eval RCA: {eval_name or ml_app} — YYYY-MM-DD`
+- **`type`**: `report`
+- **`time_span`**: `1w`
+- **`cells`**: **one cell per section** (see Notebook Cell Structure below) — do NOT put the entire report in a single cell
+
+After creation, output the URL on its own line:
+`RCA report exported to notebook: <url>`
+
+Print the URL prominently — if `/eval-bootstrap` runs next in the same session, it will detect this URL and offer to append the evaluator suite to the same notebook.
+
+#### Notebook Cell Structure
+
+Split the report into separate cells — one per major section. This renders far better than a single large cell.
+
+**Cell 1 — Overview**
+```
+**Date**: YYYY-MM-DD | **Timeframe**: {from} → {to} | **App**: {ml_app} | **Signal**: {Eval | Error}
+**App profile**: {description}
+
+{2-3 sentence executive summary}
+```
+
+**Cell 2 — Error/Eval Health Summary** (table)
+
+**Cell 3 — Failure Taxonomy** (table)
+
+**Cells 4…N — one cell per Failure Mode**
+
+**Cell N+1 — Prioritized Action Plan + Limitations**
+
+**Notebook formatting rules** (apply to every cell):
+- **No triple-backtick code blocks** — they render as separate plaintext blocks in Datadog notebooks. Use blockquotes (`>`) for prompts/rubrics, and inline code (`` ` ``) for short values.
+- **Evidence as tables** — not bullet lists. See Output Format.
+- **Tool inputs as tables** — Argument | Wrong value passed | Correct approach.
+- **Action plan as a table** — Priority | Action | Confidence | Impact.
 
 ---
 
 ## Output Format
 
-```markdown
-# Eval RCA Report: `{eval_name or ml_app}`
-
-**Date**: {YYYY-MM-DD}  |  **Timeframe**: {from} → {to}
-**App profile**: {LLM | RAG | Agent | Multi-agent}
-
-{If single eval:
-**Eval**: {Custom/OOTB}  |  **Metric**: {boolean/score/categorical}
-**Total spans**: {total_count}  |  **Pass rate**: {pass_rate}%
-**Sample**: {sample_size} ({pass_count} pass / {fail_count} fail)
-}
-
-{If multiple evals (ml_app entry):
-## Eval Health Summary
-
-| Eval | Type | Total | Pass Rate | Status |
-|------|------|------:|:---------:|--------|
-| ... | ... | ... | ... | ... |
-}
-
-{If custom eval:
-## Eval Definition
-**Measures**: {summary}  |  **Criteria**: {pass_when/threshold}
-}
-
-[2-3 sentence executive summary: overall health, most important finding with numbers.]
-
-## Failure Taxonomy
-
-| # | Failure Mode | Count | % | Severity | Root Cause |
-|---|-------------|------:|:-:|:--------:|-----------|
-| 1 | ... | ... | ... | ... | ... |
-
-## Detailed Analysis
-
-### Failure Mode 1: [Name]
-
-**Count**: {n} ({pct}%)  |  **Severity**: High  |  **Root Cause**: [Category]
-
-**What's happening**: [3-5 sentences. What goes wrong, when, what triggers it.]
-
-**Evidence**:
-- [Trace {id_short}](https://app.datadoghq.com/llm/traces?query=trace_id:{full_id}): [what happened]
-
-**Judge reasoning**: > "{quoted reasoning}"
-
-**Trace deep-dive**: [What the trace investigation revealed — system prompt content, tool calls, agent decisions, errors found, retrieved documents]
-
-**Root cause**: [WHY this happens, tied to trace evidence]
-
-**Recommendation**:
-- **Type**: [System Prompt Edit | Tool Gap | Routing Fix | Retrieval Fix | Evaluator Prompt Edit | Other]
-- **What to change**:
-  ```text
-  BEFORE: [actual text from trace]
-  AFTER: [proposed replacement]
-  ```
-
-- **Why**: [causal link]
-- **Impact**: ~{n} failures ({pct}%)
+The in-chat report (Phase 6) and the notebook export (Phase 7) use the same structure. Differences are noted inline.
 
 ---
 
-[Repeat for top 3-5 failure modes]
+### Header
 
-## Prioritized Action Plan
+```
+# Eval RCA Report: `{eval_name or ml_app}`
 
-1. **[Title]** ({pct}%) — [concrete change] — Confidence: High/Medium/Low
+**Date**: YYYY-MM-DD | **Timeframe**: {from} → {to} | **App**: {ml_app} | **Signal**: {Eval | Error}
+**App profile**: {LLM | RAG | Agent | Multi-agent, with brief description}
 
-## Remaining / Low-Confidence
+{2-3 sentence executive summary: overall health, most important finding with numbers.}
+```
 
-| Mode | Count | Notes |
-|------|------:|-------|
-| ... | ... | ... |
+---
 
-## Limitations & Follow-ups
+### Error / Eval Health Summary
 
-- [What needs more data]
-- [Suggested follow-ups]
+Table — one row per error type or eval:
 
+```
+| Error Type | Spans | Traces | Versions Affected | Status |
+|---|:---:|:---:|---|:---:|
+| `monitor_groups_search` 400 | ~21 | 4+ | All | ⚠️ Active |
+| `CancelledError` | ~25 | 12+ | All | ⚠️ Active |
+| `load_datadog_skill` | ~7 | 7 | v1.0–v1.3 only | ✅ Resolved |
+```
+
+---
+
+### Failure Taxonomy
+
+```
+| # | Failure Mode | Traces | % | Severity | Root Cause |
+|---|---|:---:|:---:|:---:|---|
+| 1 | Short description | 4+ | ~20% | **High** | Tool Misuse |
+```
+
+---
+
+### Failure Mode Sections (one per mode)
+
+```
+## Failure Mode N: [Name]
+
+**Count**: {n} spans, {t} traces | **Severity**: High/Medium/Low | **Root Cause**: [Category]
+
+[3-5 sentences: what goes wrong, when, what triggers it, causal chain.]
+
+**Evidence**
+
+| Trace | Behavior | Version |
+|---|---|---|
+| [69de86a7...](https://app.datadoghq.com/llm/traces?query=trace_id:{full_id}) | 7 parallel calls, all 400 | v107624932 |
+| [69de473f...](https://app.datadoghq.com/llm/traces?query=trace_id:{full_id}) | 7x 400 + CancelledError after 153s | v107574104 |
+
+{For tool misuse: add a tool inputs table}
+**Tool inputs (100% of sampled calls have this pattern)**
+
+| Argument | Value passed (wrong) | Correct approach |
+|---|---|---|
+| `query` | `"monitor_id:123 group_status:alert"` | `"monitor_id:123"` (name/tag only) |
+| `group_states` | *(not passed)* | `["alert"]` (separate param) |
+
+{For eval signal: add judge reasoning as a blockquote}
+> "{quoted judge reasoning}"
+
+**Root cause**: [WHY this happens, tied to trace evidence — specific span, parameter, or prompt.]
+
+**Fix**: [Concrete action. For schema/prompt changes, show before/after inline — no code blocks:
+  BEFORE: query: string  # "Search query"
+  AFTER: query: string  # Name/tag filters only — do not embed state filters here
+         group_states: array[enum]  # ["alert", "warn", "no data", "ignored", "ok"]
+]
+
+**Impact**: Eliminates ~{n} spans/timeframe{; also describe secondary effects if any}.
+```
+
+**Evidence table columns** — use the most informative subset:
+- **Error Signal**: Trace | Behavior | Version
+- **Eval Signal**: Trace | Judge verdict | What the trace revealed
+- Always omit columns that add no information for a given mode.
+
+---
+
+### Prioritized Action Plan
+
+Table — not a numbered list:
+
+```
+| Priority | Action | Confidence | Impact |
+|:---:|---|:---:|---|
+| 1 | Fix `monitor_groups_search` schema — add `group_states` param | High | Eliminates ~21 spans/7d |
+| 2 | Cap `max_retries` + handle `CancelledError` gracefully | High | Reduces retry storms |
+| 3 | Upgrade pydantic-ai for cross-task cancel scope fix | Medium | Fixes ~8 spans/7d |
+```
+
+---
+
+### Limitations & Follow-ups
+
+Bullet list — unchanged from before:
+
+```
+- **{Topic}** — {what needs more data or follow-up action}
 ```
 
 ## Operating Rules

--- a/dd-llmo/experiment-analyzer/SKILL.md
+++ b/dd-llmo/experiment-analyzer/SKILL.md
@@ -72,6 +72,7 @@ Never ask multiple rounds of clarifications. One message covers everything unres
    See: https://docs.datadoghq.com/bits_ai/mcp_server/setup/
    ```
    Then ask: "Would you like to fall back to file or agent output instead?"
+   See Phase 5 for full notebook call details.
 
 After resolving mode and output, proceed fully automatically through Phases 1–5 with no further user interaction.
 
@@ -140,6 +141,10 @@ Rules:
 For each sampled event, generate a direct span link:
 `https://app.datadoghq.com/llm/experiments/{experiment_id}?selectedTab=overview&sp=[{"p":{"experimentId":"{experiment_id}","spanId":"{span_id}"},"i":"experiment-details"}]&spanId={span_id}`
 
+For each Deep Dive segment, generate a direct link to view those events in the (candidate) experiment:
+`https://app.datadoghq.com/llm/experiments/{experiment_id}?selectedTab=overview&filter[{dimension}]={value}`
+If you are not confident the filter URL format works for this dimension, omit the filter params and link to the experiment root instead. Never fabricate filter URLs.
+
 ---
 
 ## Phase 4 — Synthesis
@@ -176,7 +181,23 @@ All modes: use quantified deltas/rates wherever possible. Redact PII.
 
 **File:** Write the report to the pre-confirmed path. Confirm with: "Report saved to `<path>`."
 
-**Notebook:** Call `mcp__datadog-mcp-core__create_datadog_notebook` with the report content structured as notebook cells. Return the notebook URL.
+**Notebook:** Call `mcp__datadog-mcp-core__create_datadog_notebook` with the following parameters:
+
+- **`name`** (by mode):
+  | Mode | Name |
+  |------|------|
+  | Comparative Exploratory | `Experiment Analysis: {baseline_short} (Baseline) vs {candidate_short} (Candidate) — YYYY-MM-DD` |
+  | Comparative Q&A | `Experiment Q&A: {baseline_short} vs {candidate_short} — YYYY-MM-DD` |
+  | Single Exploratory | `Experiment Analysis: {experiment_short} — YYYY-MM-DD` |
+  | Single Q&A | `Experiment Q&A: {experiment_short} — YYYY-MM-DD` |
+  where `short` = first 8 characters of the UUID.
+
+- **`cells`**: the full report as a single markdown cell — `[{ "type": "markdown", "text": "<full report markdown>" }]`. Omit the `# Experiment Analysis Report` top-level heading from the cell content — it is already shown as the notebook title.
+- **`time`**: `{ "live_span": "1h" }`
+
+After the notebook is created, output the URL in chat: `"Report exported to notebook: <url>"`
+
+If the tool is unavailable, follow the fallback instructions in Phase 0.
 
 ---
 
@@ -203,15 +224,36 @@ Stay active after the report. Answer follow-up questions using the same MCP tool
 
 ## Report Format
 
+Link rules:
+- **Experiment IDs**: Wherever a full experiment UUID appears, render it as a Markdown link to `https://app.datadoghq.com/llm/experiments/{full_uuid}`.
+- **Comparative table column headers**: In the Orientation table and in every subsequent table that has Baseline/Candidate columns, wrap the *entire* column header as a link — not just the short ID. Format: `[Baseline \`{short_id}\`]({baseline_url})` and `[Candidate \`{short_id}\`]({candidate_url})`. This makes the full header cell clickable, not just the ID portion.
+
 ```markdown
 # Experiment Analysis Report
-## [Mode: Comparative Exploratory | Comparative Q&A | Single Exploratory | Single Q&A]
 
-[2–3 sentence executive summary: experiment(s) purpose, scale, and key finding with specific numbers.]
+> **Question:** {original question text}
+> _(Q&A modes only — omit for Exploratory modes)_
+
+## Summary & Recommendations
+
+[Comparative: **Baseline**: [`{baseline_short}`]({baseline_url}) | **Candidate**: [`{candidate_short}`]({candidate_url}) | **Compare**: [`{baseline_short}-{candidate_short}`](https://app.datadoghq.com/llm/experiment-comparison?baselineExperimentId={baseline_id}&experimentIds={candidate_id}%2C{baseline_id}&tableView=all&selectedEvaluation=pass) — Single: **Experiment**: [`{experiment_short}`]({experiment_url}). Always the first line of this section.]
+
+[2–3 sentence executive summary directly below the links line. Open with "This is a **{Mode}** analysis..." where {Mode} is one of: Comparative Exploratory, Comparative Q&A, Single Exploratory, Single Q&A. Include experiment(s) purpose, scale, and key finding with specific numbers.]
+
+[If the report uses opaque dimension values (e.g. category labels like b1/b2/b3/bx), add a `### Dataset Categories` subsection here. Include: one sentence explaining where the categories come from (i.e. labels from the evaluation dataset grouping questions by required tools/data sources), then a bullet per value with its name bolded and a brief description. Infer descriptions from input question patterns, capability tags, and expected tool calls. Omit this subsection if all dimension values are self-explanatory.]
+
+[Wins, regressions, neutral areas, prioritized actions. For Q&A: verdict + rationale.]
 
 ## Orientation
 
-[Side-by-side table for comparative; summary table for single. Include: events, error rate, metrics, dimensions.]
+[Side-by-side table for comparative; summary table for single. Include: events, error rate, metrics, dimensions. Experiment IDs in column headers must be Markdown links.]
+
+
+## What Changed
+
+[Comparative modes only. Table of differences between baseline and candidate: model, toolset/skill profile,
+dataset, evaluator schema, and any other metadata differences detectable from the summary data.
+If no differences are detectable, write: "No configuration differences detected between experiments."]
 
 ## [Signals | Answer to Question]
 
@@ -222,9 +264,9 @@ Stay active after the report. Answer follow-up questions using the same MCP tool
 
 ### [Issue/Finding Title]
 
-**Segment**: `[dimension=value]` | **Impact**: N events | **Severity**: metric pass rate = X%
+**Segment**: `[dimension=value]` | **Impact**: N events | **Severity**: metric pass rate = X% | [View events](https://app.datadoghq.com/llm/experiments/{experiment_id}?selectedTab=overview&filter[{dimension}]={value})
 
-**What's happening**: [3–5 sentences with specific observations]
+**What's happening**: [1–2 sentences: key observation and metric impact only]
 
 **Representative examples**:
 - [Span link]: [input → output → expected, what went wrong]
@@ -235,10 +277,6 @@ Stay active after the report. Answer follow-up questions using the same MCP tool
 
 ---
 [Repeat for each major issue]
-
-## Summary & Recommendations
-
-[Wins, regressions, neutral areas, prioritized actions. For Q&A: verdict + rationale.]
 
 ## UI Links
 


### PR DESCRIPTION
## What's new

### New skill: `eval-session-classify`

Classifies whether a user's intent was satisfied in a Datadog assistant session. Combines LLM Obs trace data (full conversation, tool calls, evaluations) with RUM behavioral signals (pre/during/post-session navigation, feedback actions) to produce a structured satisfaction verdict.

- `eval-session-classify/SKILL.md` — full classification workflow (5 steps: span search → span details → agent loop → RUM queries → classify)
- `eval-session-classify/rum-actions-bits-assistant.md` — RUM action reference for `assistant_api`; serves as a template for other agents' instrumentation

**MCP requirements**: LLMO toolset (existing) + core toolset (required for `analyze_rum_events`)

---

## Skill updates

### `eval-trace-rca`

- **Dual-mode support**: new **Error Signal** mode alongside the existing Eval Signal mode — analyzes `@status:error` spans, error type frequency tables, and stack traces when no evals are configured or the user asks to look at runtime errors
- **Notebook export**: Phase 7 now offers exporting the RCA report to a Datadog notebook with a multi-cell structure (one cell per section) and formatting rules for Datadog's renderer
- **Richer output format**: Error/Eval Health Summary table, evidence tables with per-mode columns, action plan as a table

### `eval-bootstrap`

- **`--data-only` mode** (Phase 3B): emits a self-contained JSON spec file instead of Python SDK code — framework-agnostic rubrics usable with OpenAI Evals, Braintrust, Promptfoo, or custom code
- **Notebook export**: after Phase 3A or 3B, offers appending the evaluator suite to an existing RCA notebook (if one was created earlier in the session) or creating a standalone notebook
- **Phase 0 notebook detection**: scans the conversation for a Datadog notebook URL produced by `eval-trace-rca` to enable cross-skill chaining

### `experiment-analyzer`

- **Report structure**: Summary & Recommendations now leads (previously at the end); executive summary opens with mode label (`Comparative Exploratory`, `Single Q&A`, etc.)
- **Dataset Categories subsection**: auto-generated when dimension values are opaque labels (e.g. `b1`/`b2`/`bx`)
- **Linked column headers**: Baseline/Candidate column headers in all comparison tables are full clickable links, not just the short ID
- **What Changed section**: surfaces model, dataset, and evaluator schema differences between baseline and candidate
- **Deep Dive links**: segment filter links (`?filter[dimension]=value`) and span links use the full SP parameter format
- **Conversational follow-up** (Phase 6): appends suggested follow-up questions after the report

---

## README

- Skills table updated to include `eval-session-classify`
- MCP requirements clarified: core toolset is optional for `experiment-analyzer` (notebook export), **required** for `eval-session-classify` (RUM analysis)
- Install commands and usage examples updated for all four skills
- Pipeline flow section rewritten to describe the RCA→bootstrap pipeline and session classification as separate flows

## Test plan

- [ ] Copy `eval-session-classify` to `~/.claude/skills` and run `/eval-session-classify <session_id>` against a known session
- [ ] Verify `eval-trace-rca` Error Signal mode triggers when asking about runtime errors on an app without evals
- [ ] Verify `eval-bootstrap --data-only` emits JSON spec instead of Python
- [ ] Verify `experiment-analyzer` report opens with Summary & Recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)