### PR TITLE
fix(dd-apm): improve onboarding UX for new Datadog users

### DIFF
--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -90,11 +90,11 @@ kubectl get pods -A -o json | grep -o '"datadog-lib[^"]*"' | sort -u
 
 Expected: `"datadog-lib-python-init"` (or the language-appropriate init container).
 
-For full details read: `.claude/skills/k8s-ssi/agent-install/SKILL.md` then `.claude/skills/k8s-ssi/enable-ssi/SKILL.md`
+**Immediately read** `.claude/skills/dd-apm/k8s-ssi/agent-install/SKILL.md` now, then `.claude/skills/dd-apm/k8s-ssi/enable-ssi/SKILL.md` — do not proceed from memory or the summary above.
 
 ---
 
-**For Linux APM install/instrument tasks:** Read `.claude/skills/linux-ssi/agent-install/SKILL.md` then enable-ssi then verify-ssi.
+**For Linux APM install/instrument tasks:** **Immediately read** `.claude/skills/dd-apm/linux-ssi/agent-install/SKILL.md` now, then enable-ssi then verify-ssi — do not proceed from memory or the summary above.
 
 **For trace search, service analysis, metrics:** Continue below.
 

--- a/dd-apm/k8s-ssi/agent-install/SKILL.md
+++ b/dd-apm/k8s-ssi/agent-install/SKILL.md
@@ -38,6 +38,12 @@ Do not proceed until `helm` is available.
 
 **If `DD_API_KEY` is not set** — tell the user:
 
+> I need two things to continue:
+>
+> **1. Datadog API Key** — used to authenticate the Agent with your Datadog account. You can find or create one at: https://app.datadoghq.com/organization-settings/api-keys
+>
+> **2. Datadog Site** — the region your Datadog account is on. Most accounts use `datadoghq.com`. Check your Datadog URL to confirm (e.g. `app.datadoghq.eu` → site is `datadoghq.eu`). Other options: `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`.
+>
 > Please run the following in this chat to set your credentials (the `!` prefix executes it in this session):
 > ```
 > ! export DD_API_KEY=your-api-key-here
@@ -53,7 +59,18 @@ Wait for the user to run the commands, then re-run the check above before contin
 - [ ] Kubernetes v1.20+ — `kubectl version`
 - [ ] helm v3+ — `helm version`
 - [ ] kubectl configured to target cluster — `kubectl config current-context`
-- [ ] pup-cli installed — check with `pup --version`; if missing, install with `brew tap datadog-labs/pack && brew install pup`
+- [ ] pup-cli installed — check with `pup --version`; if missing, install it now:
+  ```bash
+  if [[ "$(uname)" == "Darwin" ]]; then
+    brew tap datadog-labs/pack && brew install pup
+  else
+    PUP_VERSION=$(curl -s https://api.github.com/repos/datadog-labs/pup/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+    curl -L "https://github.com/datadog-labs/pup/releases/download/${PUP_VERSION}/pup_linux_amd64.tar.gz" | tar xz -C /usr/local/bin pup
+    chmod +x /usr/local/bin/pup
+  fi
+  pup --version
+  ```
+  Do not skip — proceed only once `pup --version` succeeds.
 
 ---
 

--- a/dd-apm/k8s-ssi/enable-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/enable-ssi/SKILL.md
@@ -256,3 +256,4 @@ Automatically proceed to `verify-ssi` now — do not ask the user for permission
 - Exception: UST labels (`tags.datadoghq.com/*`) on application Deployments are required and intentional
 - Never run `kubectl delete` without user confirmation
 - `docker push` to a registry always requires user confirmation
+- **Never use `kubectl patch` to apply UST labels or any Deployment changes.** Always edit the Deployment YAML file and `kubectl apply -f`. Changes made with `kubectl patch` are transient and will be overwritten on the next rollout.


### PR DESCRIPTION
- Add sub-skill routing section to dd-apm/SKILL.md with explicit "read now" directives
- Explain DD_API_KEY (with link to UI) and DD_SITE (with region guidance) in k8s agent-install Phase 0
- Fix pup install in k8s agent-install prerequisites to detect OS and use correct install path on Linux
- Forbid kubectl patch for UST labels in enable-ssi — require manifest edit + kubectl apply to avoid transient changes