### PR TITLE
fix(experiment-analyzer): guard against content-block-wrapped MCP responses

### DIFF
--- a/dd-llmo/experiment-analyzer/SKILL.md
+++ b/dd-llmo/experiment-analyzer/SKILL.md
@@ -293,3 +293,4 @@ If no differences are detectable, write: "No configuration differences detected 
 - Avoid speculative explanations not supported by observed evidence.
 - Mask or redact PII in all user-visible output.
 - Never show internal tool calls, schemas, or implementation details to the user.
+- **MCP result parsing safety**: Before writing any script (Python, jq, etc.) that iterates over or accesses fields in an MCP tool result, inspect the raw structure first — check `type(result)`, top-level keys, and whether the payload is nested inside a content block (e.g. `[{'type': 'text', 'text': '<json>'}]`). Extract and `json.loads()` the inner payload if needed before parsing. Never assume MCP results are bare dicts or lists.


### PR DESCRIPTION
## Summary

- Adds an operating rule to the experiment-analyzer skill's **Operating Rules** section instructing Claude to inspect raw MCP tool result structure before writing any parsing script
- Fixes `AttributeError: 'str' object has no attribute 'get'` failures seen when MCP results arrive as content blocks (`[{'type': 'text', 'text': '<json>'}]`) rather than bare dicts/lists
- Claude is now explicitly told to check `type(result)`, inspect top-level keys, and `json.loads()` inner payloads when needed before parsing

## Test plan

- [ ] Run experiment-analyzer on an experiment and confirm no `AttributeError` in any generated parsing scripts
- [ ] Verify Claude inspects raw result structure in Phase 1 before iterating over span/event data

> **Note: Do not merge** — opened for review/discussion only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)