### PR TITLE
fix(dd-llmo): use list_llmobs_evals_by_ml_app and include rum toolset in session-classify

### DIFF
--- a/dd-llmo/llm-obs-session-classify/SKILL.md
+++ b/dd-llmo/llm-obs-session-classify/SKILL.md
@@ -13,7 +13,7 @@ description: Classify whether user intent was satisfied in a Datadog LLM Obs tra
 4. If MCP tools are absent → check whether `pup` is executable: run `pup --version` via Bash. A JSON response containing `"version"` confirms pup is available.
 5. If pup responds → use **pup mode** throughout. Translate every MCP tool call to its pup equivalent using the Tool Reference appendix at the bottom of this file.
 6. If neither is available → stop and tell the user:
-   > "Neither the Datadog MCP server nor the pup CLI is available. Connect the MCP server (`claude mcp add --scope user --transport http datadog-llmo-mcp 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'`) or install pup."
+   > "Neither the Datadog MCP server nor the pup CLI is available. Connect the MCP server (`claude mcp add --scope user --transport http datadog-llmo-mcp 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs,rum'`) or install pup."
 
 `--backend pup` is accepted anywhere in the invocation arguments and is stripped before passing remaining args to the skill logic.
 

--- a/dd-llmo/llm-obs-trace-rca/SKILL.md
+++ b/dd-llmo/llm-obs-trace-rca/SKILL.md
@@ -181,7 +181,7 @@ Then **skip Phase 1 and jump directly to Phase 2**. Carry forward:
 4. **Resolve mode** (skip if `mode` was explicitly provided):
    - `eval_name` given → **Eval Signal**
    - User explicitly mentioned errors/exceptions/crashes → **Error Signal**
-   - Otherwise → call `list_llmobs_evals(ml_app)`:
+   - Otherwise → call `list_llmobs_evals_by_ml_app(ml_app)`:
      - Evals returned → **Eval Signal**
      - No evals → **Error Signal** (announce auto-selection in Phase 1)
 5. When `eval_name` is multi-valued, note for Phase 1: run parallel per-eval searches and merge+dedup by `(trace_id, span_id)`.


### PR DESCRIPTION
## Summary

Ports two bug fixes from [dd-source#441142](https://github.com/DataDog/dd-source/pull/441142) (originally surfaced by Codex P2 review):

- **llm-obs-trace-rca**: Phase 0 mode inference called `list_llmobs_evals(ml_app)` but that tool takes no arguments (org-wide, `ListEvalsArgs` is empty). The scoped tool is `list_llmobs_evals_by_ml_app`. Without this fix, the call would be rejected or return evals from all apps, causing wrong mode selection.
- **llm-obs-session-classify**: The "neither backend available" recovery command showed `?toolsets=llmobs` only. The skill calls `analyze_rum_events` (registered under `ToolsetRUM`), so users following that command would hit missing-tool errors in session_id mode. Fixed to `?toolsets=llmobs,rum`.

## Test plan

- [ ] In llm-obs-trace-rca Phase 0, with `ml_app` and no `eval_name`, the agent calls `list_llmobs_evals_by_ml_app(ml_app=...)` (not `list_llmobs_evals`)
- [ ] The session-classify recovery message shows `toolsets=llmobs,rum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)