### PR TITLE
[codex] Install skills individually in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,33 @@ npx skills add datadog-labs/agent-skills \
 For ALL skills:
 
 ```bash
-npx skills add datadog-labs/agent-skills --full-depth -y
+npx skills add datadog-labs/agent-skills \
+  --skill dd-pup \
+  --skill dd-monitors \
+  --skill dd-logs \
+  --skill dd-apm \
+  --skill dd-docs \
+  --skill dd-browser-sdk \
+  --skill dd-audit \
+  --skill service-remapping \
+  --skill agent-install \
+  --skill enable-ssi \
+  --skill verify-ssi \
+  --skill troubleshoot-ssi \
+  --skill onboarding-summary \
+  --skill upgrade-browser-sdk-v7 \
+  --skill dd-audit-security-investigation \
+  --skill dd-audit-key-compromise \
+  --skill dd-audit-cost-spike-investigation \
+  --skill dd-audit-compliance-report \
+  --skill dd-audit-ai-activity \
+  --skill llm-obs-experiment-analyzer \
+  --skill llm-obs-trace-rca \
+  --skill llm-obs-eval-bootstrap \
+  --skill llm-obs-eval-pipeline \
+  --skill llm-obs-session-classify \
+  --skill k9-ownership-byod-setup \
+  --full-depth -y
 ```
 
 ### LLM Observability (LLMO)

--- a/dd-llmo/llm-obs-session-classify/SKILL.md
+++ b/dd-llmo/llm-obs-session-classify/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: llm-obs-session-classify
-description: Classify whether user intent was satisfied in a Datadog LLM Obs trace or session. Three modes: (1) session_id — classify a single CMD+I assistant session with RUM; (2) trace_id — classify a single LLM Obs trace without RUM; (3) ml_app — sample and classify multiple sessions or traces from a given LLM app. Output is compact by default (verdict + one-sentence reason). Use when evaluating satisfaction, classifying sessions/traces, labeling data, or generating signal for llm-obs-eval-pipeline or llm-obs-trace-rca.
+description: >
+  Classify whether user intent was satisfied in a Datadog LLM Obs trace or session.
+  Three modes: (1) session_id — classify a single CMD+I assistant session with RUM;
+  (2) trace_id — classify a single LLM Obs trace without RUM; (3) ml_app — sample
+  and classify multiple sessions or traces from a given LLM app. Output is compact
+  by default (verdict + one-sentence reason). Use when evaluating satisfaction,
+  classifying sessions/traces, labeling data, or generating signal for
+  llm-obs-eval-pipeline or llm-obs-trace-rca.
 ---
 
 ## Backend


### PR DESCRIPTION
What does this PR do?
----------------------
This PR updates the README all-skills command so it installs every skill individually with explicit `--skill` flags instead of installing the entire repository wholesale.

It also fixes the YAML frontmatter for `llm-obs-session-classify` so the `skills` CLI can discover it. Without that frontmatter fix, the explicit all-skills command would not include the session classifier.

Motivation
----------
The current all-skills command relies on repo-wide installation behavior. Listing every skill explicitly makes the install scope clear and keeps the README aligned with the actual skills exposed by this repository.

QA
--
Ran:

```bash
node /Users/miguel.tullalizardi/.npm/_npx/ac0ed6aa23b37c1e/node_modules/skills/bin/cli.mjs add . --list --full-depth
git diff --check -- README.md dd-llmo/llm-obs-session-classify/SKILL.md
```

The `skills` CLI found 26 skills, including `llm-obs-session-classify`.