### PR TITLE
feat(software-delivery): add unblock-pr and triage-flaky-test workflow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-llmo** | LLM Observability: experiments, eval RCA, evaluator generation, session classification |
 | **dd-browser-sdk** | Browser SDK: RUM, Logs, Session Replay, profiling, product analytics, error tracking, version migration |
 | **dd-audit** | Audit Trail investigations: who changed what, key compromise, cost spike root cause, compliance evidence (SOC 2/PCI), AI activity auditing |
+| **dd-software-delivery** | CI/CD workflow skills — unblock PR pipelines, triage flaky tests (MCP + pup) |
 | **dd-software-delivery** | CI/CD workflow skills — unblock failing PR pipelines, triage flaky tests |
 
 ## Install
@@ -142,6 +143,72 @@ Look at the errors on <ml_app> over the last 24h
 
 # Classify a session
 /eval-session-classify <session_id>
+```
+
+### Software Delivery (dd-software-delivery)
+
+The `dd-software-delivery` directory contains workflow skills for CI/CD visibility and test reliability:
+
+| Skill | Purpose |
+|-------|---------|
+| `unblock-pr` | Investigate a failing PR CI pipeline — classify each failure as flaky, infra, or regression; fetch code coverage and PR quality/security insights; propose targeted actions |
+| `triage-flaky-test` | Deep-dive on a specific flaky test — get history, blast radius, root cause category, and recommend a code fix or quarantine |
+
+**Workflow:**
+
+```
+unblock-pr → (if flaky failure) → triage-flaky-test → quarantine or fix
+```
+
+#### Backend
+
+Both skills auto-detect the available backend at runtime:
+- **MCP mode** (preferred): uses the Datadog software-delivery MCP tools (`search_datadog_ci_pipeline_events`, `get_datadog_flaky_tests`, `retry_datadog_ci_job`, etc.). Enables PR quality/security insights and native GitHub Actions retry.
+- **pup mode** (fallback): uses the `pup` CLI. PR quality/security data is not available; GitHub Actions retry falls back to `gh run rerun`.
+
+Pass `--backend pup` to force pup mode regardless of MCP availability.
+
+#### MCP Requirements
+
+Connect the Datadog MCP server with the `software-delivery` toolset:
+
+```bash
+claude mcp add --scope user --transport http "datadog-mcp" \
+  'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core,software-delivery'
+```
+
+#### Prerequisites
+
+Requires `pup` CLI for pup mode (and as a fallback). See [Setup Pup](#setup-pup).
+
+#### Install
+
+```bash
+# Claude Code — copy any or all skills
+cp -r dd-software-delivery/unblock-pr ~/.claude/skills
+cp -r dd-software-delivery/triage-flaky-test ~/.claude/skills
+```
+
+Or via `npx`:
+
+```bash
+npx skills add datadog-labs/agent-skills \
+  --skill dd-software-delivery/unblock-pr \
+  --skill dd-software-delivery/triage-flaky-test \
+  --full-depth -y
+```
+
+#### Usage
+
+```
+# Investigate a failing PR
+unblock-pr                                     # auto-detects branch and repo from git
+unblock-pr my-feature-branch                   # explicit branch
+unblock-pr my-feature-branch github.com/org/repo
+
+# Triage a specific flaky test
+triage-flaky-test TestMyFunc
+triage-flaky-test com.example.MyTest github.com/org/repo
 ```
 
 ### Audit Trail (dd-audit)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-llmo** | LLM Observability: experiments, eval RCA, evaluator generation, session classification |
 | **dd-browser-sdk** | Browser SDK: RUM, Logs, Session Replay, profiling, product analytics, error tracking, version migration |
 | **dd-audit** | Audit Trail investigations: who changed what, key compromise, cost spike root cause, compliance evidence (SOC 2/PCI), AI activity auditing |
+| **dd-software-delivery** | CI/CD workflow skills — unblock failing PR pipelines, triage flaky tests |
 
 ## Install
 
@@ -199,6 +200,57 @@ Create a PCI DSS Requirement 10 report for the last 90 days
 # AI activity
 What did the Bits AI assistant do in my org this week?
 Show me a governance report for AI tool calls in April
+```
+
+### Software Delivery (dd-software-delivery)
+
+The `dd-software-delivery` directory contains workflow skills for CI/CD visibility and test reliability:
+
+| Skill | Purpose |
+|-------|---------|
+| `unblock-pr` | Investigate a failing PR CI pipeline — classify each failure as flaky, infra, or regression; fetch code coverage; propose targeted actions |
+| `triage-flaky-test` | Deep-dive on a specific flaky test — get history, blast radius, root cause category, and recommend a code fix or quarantine |
+
+**Workflow:**
+
+```
+unblock-pr → (if flaky failure) → triage-flaky-test → quarantine or fix
+```
+
+Run `unblock-pr` when CI is red on a PR to attribute each failing job. If a failure is classified as **flaky**, the skill hands off to `triage-flaky-test` for deeper investigation and a targeted fix or quarantine via `pup test-optimization flaky-tests update`.
+
+#### Prerequisites
+
+Requires `pup` CLI installed and authenticated (`pup auth login`). See [Setup Pup](#setup-pup).
+
+#### Install
+
+```bash
+# Claude Code — copy any or all skills
+cp -r dd-software-delivery/unblock-pr ~/.claude/skills
+cp -r dd-software-delivery/triage-flaky-test ~/.claude/skills
+```
+
+Or via `npx`:
+
+```bash
+npx skills add datadog-labs/agent-skills \
+  --skill dd-software-delivery/unblock-pr \
+  --skill dd-software-delivery/triage-flaky-test \
+  --full-depth -y
+```
+
+#### Usage
+
+```
+# Investigate a failing PR
+unblock-pr                                    # auto-detects branch and repo from git
+unblock-pr my-feature-branch                  # explicit branch
+unblock-pr my-feature-branch github.com/org/repo
+
+# Triage a specific flaky test
+triage-flaky-test TestMyFunc
+triage-flaky-test com.example.MyTest github.com/org/repo
 ```
 
 ## Quick Reference

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: agent-skills
 description: Datadog skills for AI agents. Essential monitoring, logging, tracing and observability.
 metadata:
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 # Datadog Skills
@@ -20,6 +20,7 @@ Essential Datadog skills for AI agents.
 | **dd-docs** | Search Datadog documentation |
 | **dd-llmo** | LLM Observability traces, experiments, evals |
 | **dd-browser-sdk** | Browser SDK setup, RUM, Logs, Session Replay, version migration |
+| **dd-software-delivery** | CI/CD workflow skills — unblock PR, triage flaky tests |
 
 ## Install
 
@@ -31,6 +32,12 @@ npx skills add datadog-labs/agent-skills \
   --skill dd-logs \
   --skill dd-apm \
   --skill dd-docs \
+  --full-depth -y
+
+# Install CI/CD workflow skills
+npx skills add datadog-labs/agent-skills \
+  --skill dd-software-delivery/unblock-pr \
+  --skill dd-software-delivery/triage-flaky-test \
   --full-depth -y
 ```
 

--- a/dd-software-delivery/triage-flaky-test/SKILL.md
+++ b/dd-software-delivery/triage-flaky-test/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: triage-flaky-test
+description: Load when investigating a specific flaky test. Gets history, failure pattern, and category, then recommends fix, quarantine, or escalate.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,ci,cicd,flaky,flaky-tests,test-optimization
+  alwaysApply: "false"
+---
+
+# Triage Flaky Test
+
+One-line summary: Investigate a specific flaky test — get history, failure pattern, and category, then recommend fix, quarantine, or escalate.
+
+Requires: `dd-pup` skill (pup CLI installed and authenticated).
+
+---
+
+## Input
+
+| Parameter | Description |
+|---|---|
+| Test name | Fully qualified test name (e.g. `TestMyFunc` or `com.example.MyTest`) |
+| Repository | Lowercase, no-schema URL (e.g. `github.com/org/repo`). Derive from `git remote get-url origin` if not provided. |
+
+---
+
+## Workflow
+
+### STEP 0 — Parse Input
+
+Derive repository ID from git if not provided:
+```bash
+git remote get-url origin
+# Strip protocol and trailing .git, then lowercase the result
+# e.g. https://github.com/DataDog/my-repo.git → github.com/datadog/my-repo
+```
+
+**Validation fallback:** If STEP 1 returns no results, confirm the correct repository by searching without a repo filter:
+```bash
+pup cicd tests search \
+  --query "@test.name:\"<test-name>\"" \
+  --from 30d \
+  --limit 5
+```
+Extract `@git.repository.id_v2` from results and retry STEP 1 with the confirmed value.
+
+### STEP 1 — Get Flaky Test Details
+
+**Preferred — use `fingerprint_fqn` if known** (`fingerprint_fqn` is a valid CI Visibility search facet, distinct from `flaky_state`):
+```bash
+pup cicd flaky-tests search \
+  --query "fingerprint_fqn:<fqn>" \
+  --sort="-last_flaked" \
+  --limit 5
+```
+
+**Fallback — use name + suite + repo:**
+```bash
+pup cicd flaky-tests search \
+  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @git.repository.id_v2:\"<repo>\"" \
+  --sort="-last_flaked" \
+  --limit 10
+```
+Omit `@test.suite` if unknown; if the same test name appears in multiple suites, pick the entry whose suite matches the failing test.
+
+Do not filter by `flaky_test_state` — return the test regardless of state.
+
+Note: the query filter facet is `flaky_test_state`; the returned response attribute is `flaky_state` — these are different names for the same concept; do not use `flaky_state:active` as a query filter.
+
+Extract from results:
+- `fingerprint_fqn` — unique test identifier; used as the `id` in STEP 5 write call. **If absent, do not proceed to quarantine — see STEP 5.**
+- `flaky_state` — current state (active / quarantined / disabled / fixed)
+- `test_stats.failure_rate_pct` — percentage of runs that fail
+- `flaky_category` — root cause category
+- `codeowners` — owning team
+- `pipeline_stats.total_lost_time_ms` — total CI time lost
+
+### STEP 2 — Get Recent Failure History
+
+```bash
+pup cicd tests search \
+  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @test.status:fail @git.repository.id_v2:\"<repo>\"" \
+  --from 7d \
+  --limit 20
+```
+
+Extract:
+- Error messages and stack traces (`@error.message`, `@error.stack`)
+- Failing branches (`@git.branch`) — branch-specific vs. widespread
+- Frequency pattern — random timing or specific conditions
+- Unique `@ci.pipeline.id` values for blast radius (STEP 3)
+
+### STEP 3 — Check Blast Radius
+
+Count distinct pipelines impacted using pipeline IDs from STEP 2:
+
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.pipeline.id:(<id1> OR <id2> OR ...) @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --group-by "@ci.pipeline.name" \
+  --from 7d
+```
+
+Use the first 10 pipeline IDs from STEP 2 (cap at 10; if more are available, run a second batch and merge results by summing counts per `@ci.pipeline.name` across batches). Report blast radius as: total number of unique pipelines impacted and whether failures are branch-specific or widespread.
+
+Note: a pipeline failure is not necessarily caused solely by this flaky test — treat blast radius as a signal, not a definitive count.
+
+### STEP 4 — Recommend Fix or Quarantine
+
+Use `flaky_category` from STEP 1 and error messages from STEP 2.
+
+**Root cause first:**
+- Read the full error trace from bottom to top — chained errors hide the real cause; the innermost error is the root cause, not the first line.
+- Identify the exact source of nondeterminism (race, ordering, stale state, timing).
+- If the root cause is a CI infrastructure problem (runner unavailable, Docker daemon failure, network outage) → do NOT propose a code fix; classify as `infra` and recommend retry instead.
+- If root cause is uncertain and cannot be confirmed from the stack trace → skip fix, go to quarantine.
+
+**Fix at the correct layer:**
+- Test issue → fix in test or test helper only.
+- Production bug exposed by the test → fix in production code.
+- Shared helper used by multiple tests → fix the helper AND update all call sites; never patch a single test when the root cause is in shared code.
+
+**Forbidden — do not propose these:**
+- Timing hacks: increasing timeouts, adding sleeps, widening time windows, adding retries. A fix that only reduces flake probability without eliminating the root cause is invalid.
+- Masking: relaxing assertions (e.g., exact match → at least 1), dropping validations.
+- Partial fixes: touching one call site when multiple share the root cause.
+
+**Fix patterns by category:**
+
+| Category | Approach |
+|---|---|
+| `timeout` | Identify the slow operation and make it synchronous or deterministic — do NOT simply raise the timeout constant |
+| `concurrency` | Add deterministic synchronization (barriers, channels, locks); remove shared mutable state between tests |
+| `network` | Mock or stub network calls at the boundary; if the test requires a real connection, isolate it with a test server |
+| `time` | Inject a controllable clock; replace wall-clock assertions with relative or event-driven checks |
+| `order_dependency` | Isolate test state with setup/teardown; eliminate dependencies on execution order or global state |
+| `environment_dependency` | Mock env variables and external config; use test-local fixtures, not shared directories or singletons |
+| `resource_leak` | Ensure every resource opened in a test is closed in teardown; use cleanup hooks that run even on failure |
+| `randomness` | Fix the random seed for the test run; use deterministic inputs instead of random generation |
+| `asynchronous_wait` | Replace fixed sleeps with condition polling or event/signal-driven waits with a hard timeout |
+| `io` | Use temp files/dirs cleaned up in teardown; mock or stub filesystem interactions |
+| `unknown` | Skip fix attempt → go to quarantine |
+
+**Before proposing code changes, verify all of the following — if any fails, skip fix and recommend quarantine:**
+- The root cause is the innermost error in the trace, not a surface-level symptom.
+- The failure is a code problem, not a CI infrastructure problem.
+- The fix eliminates the root cause (not just reduces flake probability).
+- The fix is at the correct layer (test vs. production vs. shared helper).
+- All call sites of any shared code are updated.
+- No timing hacks or relaxed assertions introduced.
+
+**Decision:**
+- If category is `unknown` OR verification above fails → skip fix, recommend quarantine
+- If category is known AND root cause is confirmed AND fix is valid → propose specific code change
+
+### STEP 5 — Produce Triage Brief and Act
+
+```
+Flaky Test Triage Brief
+=======================
+Test:           <fully qualified test name>
+Service:        <@test.service>
+Category:       <flaky_category>
+Failure Rate:   <test_stats.failure_rate_pct>%
+Duration Lost:  <pipeline_stats.total_lost_time_ms>ms
+Codeowners:     <codeowners>
+Blast Radius:   <N> pipelines (<branch-specific | widespread>) [approximate — other failures in the same pipeline runs may not be related]
+
+Evidence:
+  <1-2 key error message lines from STEP 2>
+
+Recommendation: <fix | quarantine | escalate>
+Confidence:     <high | medium | low>
+Action:         <specific next step>
+```
+
+**Decision thresholds:**
+- `failure_rate_pct > 10` OR blast radius > 5 pipelines → **quarantine**
+- `failure_rate_pct ≤ 10` AND known category AND clear fix → **fix**
+- `failure_rate_pct ≤ 10` AND category `unknown` → **escalate** to codeowners with triage brief
+
+**If recommending quarantine**, present and require explicit user approval before writing:
+
+```
+Proposed action: quarantine "<test-name>"
+  id (fingerprint_fqn): <fingerprint_fqn from STEP 1>
+  Effect: test still runs but failures are suppressed (CI will not be blocked)
+  Reversible: yes — update new_state to active to restore
+
+Approve? (yes/no)
+```
+
+**If `fingerprint_fqn` was not returned in STEP 1** (test not yet in FTM or query returned no results): do not attempt the write. Surface an error and ask the user to open the Flaky Test Management UI directly to quarantine manually.
+
+Only after explicit approval and a confirmed `fingerprint_fqn`, write the body file and run:
+```bash
+cat > /tmp/flaky-update.json <<'EOF'
+{
+  "data": {
+    "type": "UpdateFlakyTestsRequest",
+    "attributes": {
+      "tests": [{"id": "<fingerprint_fqn>", "new_state": "quarantined"}]
+    }
+  }
+}
+EOF
+pup test-optimization flaky-tests update --file /tmp/flaky-update.json
+```
+
+To undo: repeat with `"new_state": "active"`.

--- a/dd-software-delivery/triage-flaky-test/SKILL.md
+++ b/dd-software-delivery/triage-flaky-test/SKILL.md
@@ -17,6 +17,26 @@ Requires: `dd-pup` skill (pup CLI installed and authenticated).
 
 ---
 
+## Backend
+
+**Detection** — At the start of every invocation, before taking any action, determine which backend to use:
+
+1. If the user passed `--backend pup` anywhere → use **pup mode** immediately. Skip steps 2–4.
+2. Check whether `get_datadog_flaky_tests` appears in your available tools.
+3. If present → use **MCP mode** throughout. Call tools exactly as named in this skill's workflow sections.
+4. If absent → check whether `pup` is executable: run `pup --version` via Bash. A JSON response containing `"version"` confirms pup is available.
+5. If pup responds → use **pup mode** throughout. Translate every tool call using the Tool Reference appendix at the bottom of this file.
+6. If neither is available → stop and tell the user:
+   > "Neither the Datadog MCP server nor the pup CLI is available. Connect the MCP server or install pup (`brew install datadog-labs/pack/pup`)."
+
+**pup invocation rules:**
+- Invoke via Bash. pup always outputs JSON — parse directly.
+- Repository IDs passed to pup must be fully lowercase (the API rejects mixed-case).
+- Sort values starting with `-` require `=` syntax: `--sort="-last_flaked"` (not `--sort "-last_flaked"`).
+- If pup returns a 401/403, tell the user to run `pup auth refresh` or `pup auth login`.
+
+---
+
 ## Input
 
 | Parameter | Description |
@@ -38,36 +58,34 @@ git remote get-url origin
 ```
 
 **Validation fallback:** If STEP 1 returns no results, confirm the correct repository by searching without a repo filter:
-```bash
-pup cicd tests search \
-  --query "@test.name:\"<test-name>\"" \
-  --from 30d \
-  --limit 5
+```
+Tool: search_datadog_test_events
+query: @test.name:"<test-name>"
+from: now-30d
+test_level: test
 ```
 Extract `@git.repository.id_v2` from results and retry STEP 1 with the confirmed value.
 
 ### STEP 1 — Get Flaky Test Details
 
-**Preferred — use `fingerprint_fqn` if known** (`fingerprint_fqn` is a valid CI Visibility search facet, distinct from `flaky_state`):
-```bash
-pup cicd flaky-tests search \
-  --query "fingerprint_fqn:<fqn>" \
-  --sort="-last_flaked" \
-  --limit 5
+**Preferred — use `fingerprint_fqn` if known** (`fingerprint_fqn` is a valid CI Visibility search facet):
+```
+Tool: get_datadog_flaky_tests
+query: fingerprint_fqn:<fqn>
+sort_field: last_flaked
+sort_order: desc
 ```
 
 **Fallback — use name + suite + repo:**
-```bash
-pup cicd flaky-tests search \
-  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @git.repository.id_v2:\"<repo>\"" \
-  --sort="-last_flaked" \
-  --limit 10
 ```
-Omit `@test.suite` if unknown; if the same test name appears in multiple suites, pick the entry whose suite matches the failing test.
+Tool: get_datadog_flaky_tests
+query: @test.name:"<test-name>" @test.suite:"<suite>" @git.repository.id_v2:"<repo>"
+sort_field: last_flaked
+sort_order: desc
+```
+Omit `@test.suite` if unknown. Do not filter by `flaky_test_state` — return the test regardless of state.
 
-Do not filter by `flaky_test_state` — return the test regardless of state.
-
-Note: the query filter facet is `flaky_test_state`; the returned response attribute is `flaky_state` — these are different names for the same concept; do not use `flaky_state:active` as a query filter.
+Note: the query filter facet is `flaky_test_state`; the returned response attribute is `flaky_state` — do not use `flaky_state:active` as a query filter.
 
 Extract from results:
 - `fingerprint_fqn` — unique test identifier; used as the `id` in STEP 5 write call. **If absent, do not proceed to quarantine — see STEP 5.**
@@ -79,11 +97,11 @@ Extract from results:
 
 ### STEP 2 — Get Recent Failure History
 
-```bash
-pup cicd tests search \
-  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @test.status:fail @git.repository.id_v2:\"<repo>\"" \
-  --from 7d \
-  --limit 20
+```
+Tool: search_datadog_test_events
+query: @test.name:"<test-name>" @test.suite:"<suite>" @test.status:fail @git.repository.id_v2:"<repo>"
+from: now-7d
+test_level: test
 ```
 
 Extract:
@@ -96,12 +114,13 @@ Extract:
 
 Count distinct pipelines impacted using pipeline IDs from STEP 2:
 
-```bash
-pup cicd events aggregate \
-  --query "@ci.status:error @ci.pipeline.id:(<id1> OR <id2> OR ...) @git.repository.id_v2:\"<repo>\"" \
-  --compute count \
-  --group-by "@ci.pipeline.name" \
-  --from 7d
+```
+Tool: aggregate_datadog_ci_pipeline_events
+query: @ci.status:error @ci.pipeline.id:(<id1> OR <id2> OR ...) @git.repository.id_v2:"<repo>"
+ci_level: pipeline
+aggregation: count
+group_by: ["@ci.pipeline.name"]
+from: now-7d
 ```
 
 Use the first 10 pipeline IDs from STEP 2 (cap at 10; if more are available, run a second batch and merge results by summing counts per `@ci.pipeline.name` across batches). Report blast radius as: total number of unique pipelines impacted and whether failures are branch-specific or widespread.
@@ -121,10 +140,10 @@ Use `flaky_category` from STEP 1 and error messages from STEP 2.
 **Fix at the correct layer:**
 - Test issue → fix in test or test helper only.
 - Production bug exposed by the test → fix in production code.
-- Shared helper used by multiple tests → fix the helper AND update all call sites; never patch a single test when the root cause is in shared code.
+- Shared helper used by multiple tests → fix the helper AND update all call sites.
 
 **Forbidden — do not propose these:**
-- Timing hacks: increasing timeouts, adding sleeps, widening time windows, adding retries. A fix that only reduces flake probability without eliminating the root cause is invalid.
+- Timing hacks: increasing timeouts, adding sleeps, widening time windows, adding retries.
 - Masking: relaxing assertions (e.g., exact match → at least 1), dropping validations.
 - Partial fixes: touching one call site when multiple share the root cause.
 
@@ -188,14 +207,23 @@ Action:         <specific next step>
 Proposed action: quarantine "<test-name>"
   id (fingerprint_fqn): <fingerprint_fqn from STEP 1>
   Effect: test still runs but failures are suppressed (CI will not be blocked)
-  Reversible: yes — update new_state to active to restore
+  Reversible: yes — set new_state: active to restore
 
 Approve? (yes/no)
 ```
 
 **If `fingerprint_fqn` was not returned in STEP 1** (test not yet in FTM or query returned no results): do not attempt the write. Surface an error and ask the user to open the Flaky Test Management UI directly to quarantine manually.
 
-Only after explicit approval and a confirmed `fingerprint_fqn`, write the body file and run:
+Only after explicit approval and a confirmed `fingerprint_fqn`:
+
+**MCP mode:**
+```
+Tool: update_datadog_flaky_test_states
+test_ids: ["<fingerprint_fqn>"]
+new_state: quarantined
+```
+
+**pup mode:**
 ```bash
 cat > /tmp/flaky-update.json <<'EOF'
 {
@@ -210,4 +238,19 @@ EOF
 pup test-optimization flaky-tests update --file /tmp/flaky-update.json
 ```
 
-To undo: repeat with `"new_state": "active"`.
+To undo: repeat with `new_state: active` / `"new_state": "active"`.
+
+---
+
+## Tool Reference
+
+This appendix applies only in **pup mode**. In MCP mode, use the tool names in the workflow sections directly.
+
+| MCP Tool | pup Command |
+|---|---|
+| `get_datadog_flaky_tests` (by fingerprint_fqn) | `pup cicd flaky-tests search --query "fingerprint_fqn:<fqn>" --sort="-last_flaked" --limit 5` |
+| `get_datadog_flaky_tests` (by name + suite + repo) | `pup cicd flaky-tests search --query "@test.name:\"...\" @test.suite:\"...\" @git.repository.id_v2:\"...\"" --sort="-last_flaked" --limit 10` |
+| `search_datadog_test_events` (validation fallback) | `pup cicd tests search --query "@test.name:\"<test-name>\"" --from 30d --limit 5` |
+| `search_datadog_test_events` (failure history) | `pup cicd tests search --query "@test.name:\"...\" @test.suite:\"...\" @test.status:fail @git.repository.id_v2:\"...\"" --from 7d --limit 20` |
+| `aggregate_datadog_ci_pipeline_events` (blast radius) | `pup cicd events aggregate --query "@ci.status:error @ci.pipeline.id:(...) @git.repository.id_v2:\"...\"" --compute count --group-by "@ci.pipeline.name" --from 7d` |
+| `update_datadog_flaky_test_states` | Write body to `/tmp/flaky-update.json`, then `pup test-optimization flaky-tests update --file /tmp/flaky-update.json` |

--- a/dd-software-delivery/unblock-pr/SKILL.md
+++ b/dd-software-delivery/unblock-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unblock-pr
-description: Load when investigating a failing PR CI pipeline or checking PR health. Attributes each CI failure as flaky, infra, or regression, proposes a targeted action, and reports code coverage.
+description: Load when investigating a failing PR CI pipeline or checking PR health. Attributes each CI failure as flaky, infra, or regression, proposes a targeted action, and reports code coverage and quality/security status.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -14,6 +14,25 @@ metadata:
 One-line summary: Investigate a failing PR CI pipeline — attribute each failure as flaky, infra, or regression and propose a targeted action.
 
 Requires: `dd-pup` skill (pup CLI installed and authenticated), `triage-flaky-test` skill (for flaky failure deep investigation).
+
+---
+
+## Backend
+
+**Detection** — At the start of every invocation, before taking any action, determine which backend to use:
+
+1. If the user passed `--backend pup` anywhere → use **pup mode** immediately. Skip steps 2–4.
+2. Check whether `search_datadog_ci_pipeline_events` appears in your available tools.
+3. If present → use **MCP mode** throughout. Call tools exactly as named in this skill's workflow sections.
+4. If absent → check whether `pup` is executable: run `pup --version` via Bash. A JSON response containing `"version"` confirms pup is available.
+5. If pup responds → use **pup mode** throughout. Translate every tool call using the Tool Reference appendix at the bottom of this file.
+6. If neither is available → stop and tell the user:
+   > "Neither the Datadog MCP server nor the pup CLI is available. Connect the MCP server or install pup (`brew install datadog-labs/pack/pup`)."
+
+**pup invocation rules:**
+- Invoke via Bash. pup always outputs JSON — parse directly.
+- Repository IDs passed to pup must be fully lowercase (the API rejects mixed-case): `github.com/datadog/my-repo`, not `github.com/DataDog/my-repo`.
+- If pup returns a 401/403, tell the user to run `pup auth refresh` or `pup auth login`.
 
 ---
 
@@ -43,42 +62,54 @@ git symbolic-ref refs/remotes/origin/HEAD
 # Strip refs/remotes/origin/ prefix — fall back to main if unset
 ```
 
-### STEP 1 — Get PR CI Summary (run both in parallel)
+### STEP 1 — Get PR CI Summary (run in parallel)
 
-**Pipeline failures (job level):**
-```bash
-pup cicd events search \
-  --query "@ci.status:error @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
-  --level job \
-  --from 24h \
-  --limit 50
+**Pipeline failures:**
+```
+Tool: search_datadog_ci_pipeline_events
+query: @ci.status:error @git.branch:<branch> @git.repository.id_v2:"<repo>"
+ci_level: job
+from: now-24h
 ```
 
-**Test failures:**
-```bash
-pup cicd tests search \
-  --query "@test.status:fail @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
-  --from 24h \
-  --limit 50
+**Test failures** (only if pipeline results include test-runner jobs):
+```
+Tool: search_datadog_test_events
+query: @test.status:fail @git.branch:<branch> @git.repository.id_v2:"<repo>"
+from: now-24h
+test_level: test
 ```
 
-Run both queries in parallel. Collect all distinct `@test.service` values from test event results. If more than one distinct service is found, note each separately in the triage brief — do not collapse them into a single service filter. If pipeline results contain only infrastructure job types (build, lint, deploy) with no test-runner output, discard test search results and skip to STEP 3.
+Run both in parallel. Collect all distinct `@test.service` values from test event results. If more than one distinct service is found, note each separately in the triage brief — do not collapse them into a single service filter. If pipeline results contain only infrastructure job types (build, lint, deploy) with no test-runner output, discard test results and skip to STEP 3.
 
-### STEP 1.5 — Fetch Code Coverage (run in parallel with STEP 1)
+### STEP 1.5 — Fetch PR Health (run in parallel with STEP 1)
 
-This step runs unconditionally — coverage context is valuable whether CI is red or green.
+This step runs unconditionally — PR health context is valuable whether CI is red or green.
 
-The `--repo` value must be fully lowercase (the API rejects mixed-case). Normalize before calling:
-```bash
-repo_lower=$(echo "<repo>" | tr '[:upper:]' '[:lower:]')
-pup code-coverage branch-summary \
-  --repo "$repo_lower" \
-  --branch "<branch>"
+**Code coverage** (both modes):
+```
+Tool: get_datadog_code_coverage_branch_summary
+repository_id: <repo>
+branch: <branch>
 ```
 
-If the command returns no data or exits with an error, report "No data available" for Coverage in the PR Health section.
+**PR number resolution** (MCP mode only — skip if PR number already provided as input):
+```
+Tool: get_prs_by_head_branch
+repo_url: https://<repo>
+head_branch: <branch>
+```
+Use the first open PR returned. If no open PR is found, skip the quality/security fetch and report "No data available" for Quality and Security.
 
-Note: Code quality and security violation counts are not available in pup — those lines always show "No data available".
+**Code quality and security** (MCP mode only — only if PR number is available):
+```
+Tool: search_pr_insights
+repo_url: https://<repo>
+pr_number: <pr_number>
+```
+Extract only `code_quality` and `code_security` from `products_status`. Ignore `failed_tests`, `flaky_tests`, and `failed_jobs` — CI data comes from STEP 1–3.
+
+> **pup mode note:** PR number resolution and `search_pr_insights` are not available in pup. Quality and Security always show "No data available" in pup mode.
 
 ### STEP 2 — Blame Guard per Failing Job
 
@@ -87,20 +118,22 @@ First check whether `@error_classification.domain` / `@error_classification.type
 For each failing job where classification is still needed, run both checks in parallel:
 
 **Default branch check** — was this job already failing before this PR?
-```bash
-pup cicd events aggregate \
-  --query "@ci.status:error @ci.job.name:\"<job>\" @git.branch:<default-branch> @git.repository.id_v2:\"<repo>\"" \
-  --compute count \
-  --from 24h
+```
+Tool: aggregate_datadog_ci_pipeline_events
+query: @ci.status:error @ci.job.name:"<job>" @git.branch:<default-branch> @git.repository.id_v2:"<repo>"
+ci_level: job
+aggregation: count
+from: now-24h
 ```
 
 **Blast radius check** — is this job failing on other branches too?
-```bash
-pup cicd events aggregate \
-  --query "@ci.status:error @ci.job.name:\"<job>\" @git.repository.id_v2:\"<repo>\"" \
-  --compute count \
-  --group-by "@git.branch" \
-  --from 24h
+```
+Tool: aggregate_datadog_ci_pipeline_events
+query: @ci.status:error @ci.job.name:"<job>" @git.repository.id_v2:"<repo>"
+ci_level: job
+aggregation: count
+group_by: ["@git.branch"]
+from: now-24h
 ```
 
 Performance fallback: if the blast radius query is slow or times out, skip it and rely on the default branch check alone.
@@ -109,12 +142,7 @@ Performance fallback: if the blast radius query is slow or times out, skip it an
 
 **Priority order:**
 1. If `@error_classification.domain` / `@error_classification.type` present → use as primary signal
-2. If test failure AND test appears in flaky tests with `flaky_test_state:active`:
-   ```bash
-   pup cicd flaky-tests search \
-     --query "flaky_test_state:active @test.name:\"<test-name>\" @git.repository.id_v2:\"<repo>\""
-   ```
-   → **flaky**
+2. If test failure AND test in `get_datadog_flaky_tests` with `flaky_test_state:active` → **flaky**
 3. Use blame guard results:
 
 | Failing on default branch? | Failing on ≥3 other branches? | Classification |
@@ -148,11 +176,11 @@ Overall: <N> failures — <e.g. "1 regression, 1 flaky, 1 infra">
 PR Health
 =========
 Coverage:   <X>% on <branch> | No data available
-Quality:    No data available
-Security:   No data available
+Quality:    <N violations (X high, Y medium)> | No violations | No data available
+Security:   <N violations> | No violations | No data available
 ```
 
-All three lines always appear.
+All three lines always appear. Use "No data available" when a tool returned no data or is unavailable (pup mode for Quality/Security).
 
 ### STEP 5 — Propose Actions
 
@@ -160,17 +188,49 @@ All three lines always appear.
 
 **flaky** → Load `triage-flaky-test` skill for deep investigation. That skill will:
 - Attempt an agent-native fix using `flaky_category` + stack trace
-- Propose quarantine via `pup test-optimization flaky-tests update` if a quick fix isn't possible
+- Propose quarantine via `update_datadog_flaky_test_states` if a quick fix isn't possible
 
 **infra** → Before proposing a retry, assess whether the failure is transient:
-- Check `@error_classification.type` and error message for signals like `timeout`, `runner unavailable`, `network error`, `quota exceeded` — these indicate transient failures where a retry is likely to help
-- If the error is deterministic (build misconfiguration, missing secret, explicit test assertion failure), a retry is unlikely to help — note this and suggest investigating the root cause
+- Check `@error_classification.type` and error message for signals like `timeout`, `runner unavailable`, `network error`, `quota exceeded` — transient failures where a retry is likely to help
+- If the error is deterministic (build misconfiguration, missing secret, explicit test assertion failure), a retry is unlikely to help — suggest investigating the root cause
 - If the failure is pre-existing on the default branch, inform the user — a retry will likely fail again; await the upstream fix instead
 
-If transient and GitHub Actions: extract the run ID from `@ci.pipeline.url` (e.g. `https://github.com/org/repo/actions/runs/<run_id>`):
+If transient:
+
+**MCP mode — GitHub Actions:** use `retry_datadog_ci_job`. From the failing job event, collect:
+- `@ci.provider.name` → ci_provider ("github")
+- `@git.repository.id_v2` → repository_id
+- `@ci.job.id` → job_id
+- event `id` field → event_uuid (optional)
+
+For `pipeline_id`: use `@ci.pipeline.id` if it contains a dash (e.g. `26027867390-1`). If bare, combine with `@github.run_attempt`: `"{@ci.pipeline.id}-{@github.run_attempt}"`. Fallback: parse `@ci.pipeline.url` for `runs/{run_id}/attempts/{attempt}`.
+
+After retry returns, confirm via `search_datadog_ci_pipeline_events` (`query: @ci.job.name:"<job>" @git.branch:<branch>`, from: now-5m) that a new run appears.
+
+**Fallback / pup mode — GitHub Actions:** extract the run ID from `@ci.pipeline.url`:
 ```bash
 gh run rerun <run_id> --failed
 ```
-For other providers, share `@ci.pipeline.url` and direct to the provider UI for retry.
+
+**GitLab / other providers** (both modes): share `@ci.pipeline.url` and direct to the provider UI.
 
 **unknown** → Suggest checking raw job logs via the CI provider UI or `@ci.pipeline.url` from the pipeline event.
+
+---
+
+## Tool Reference
+
+This appendix applies only in **pup mode**. In MCP mode, use the tool names in the workflow sections directly.
+
+| MCP Tool | pup Command |
+|---|---|
+| `search_datadog_ci_pipeline_events` (ci_level: job) | `pup cicd events search --query "..." --level job --from 24h --limit 50` |
+| `aggregate_datadog_ci_pipeline_events` (count, group_by branch) | `pup cicd events aggregate --query "..." --compute count --group-by "@git.branch" --from 24h` |
+| `aggregate_datadog_ci_pipeline_events` (count, no group_by) | `pup cicd events aggregate --query "..." --compute count --from 24h` |
+| `search_datadog_test_events` | `pup cicd tests search --query "..." --from 24h --limit 50` |
+| `get_datadog_flaky_tests` | `pup cicd flaky-tests search --query "flaky_test_state:active ..."` |
+| `update_datadog_flaky_test_states` | Write body to `/tmp/flaky-update.json`, then `pup test-optimization flaky-tests update --file /tmp/flaky-update.json` |
+| `get_datadog_code_coverage_branch_summary` | `repo_lower=$(echo "<repo>" \| tr '[:upper:]' '[:lower:]') && pup code-coverage branch-summary --repo "$repo_lower" --branch "<branch>"` |
+| `get_prs_by_head_branch` | Not available in pup — skip; report "No data available" for Quality/Security |
+| `search_pr_insights` | Not available in pup — skip; report "No data available" for Quality/Security |
+| `retry_datadog_ci_job` | Not available in pup — use `gh run rerun <run_id> --failed` instead |

--- a/dd-software-delivery/unblock-pr/SKILL.md
+++ b/dd-software-delivery/unblock-pr/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: unblock-pr
+description: Load when investigating a failing PR CI pipeline or checking PR health. Attributes each CI failure as flaky, infra, or regression, proposes a targeted action, and reports code coverage.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,ci,cicd,flaky,flaky-tests,pipeline
+  alwaysApply: "false"
+---
+
+# Unblock PR
+
+One-line summary: Investigate a failing PR CI pipeline — attribute each failure as flaky, infra, or regression and propose a targeted action.
+
+Requires: `dd-pup` skill (pup CLI installed and authenticated), `triage-flaky-test` skill (for flaky failure deep investigation).
+
+---
+
+## Input
+
+| Parameter | Description |
+|---|---|
+| PR branch | The branch under investigation (e.g. `my-feature-branch`) |
+| Repository | Lowercase, no-schema URL (e.g. `github.com/org/repo`). Derive from `git remote get-url origin` if not provided. |
+
+---
+
+## Workflow
+
+### STEP 0 — Parse Input
+
+Derive repository ID and default branch from git if not provided:
+
+```bash
+# Repository ID: fully lowercase, no-schema URL (the API rejects mixed-case)
+git remote get-url origin
+# Strip protocol and trailing .git, then lowercase the result
+# e.g. https://github.com/DataDog/my-repo.git → github.com/datadog/my-repo
+
+# Default branch
+git symbolic-ref refs/remotes/origin/HEAD
+# Strip refs/remotes/origin/ prefix — fall back to main if unset
+```
+
+### STEP 1 — Get PR CI Summary (run both in parallel)
+
+**Pipeline failures (job level):**
+```bash
+pup cicd events search \
+  --query "@ci.status:error @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
+  --level job \
+  --from 24h \
+  --limit 50
+```
+
+**Test failures:**
+```bash
+pup cicd tests search \
+  --query "@test.status:fail @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
+  --from 24h \
+  --limit 50
+```
+
+Run both queries in parallel. Collect all distinct `@test.service` values from test event results. If more than one distinct service is found, note each separately in the triage brief — do not collapse them into a single service filter. If pipeline results contain only infrastructure job types (build, lint, deploy) with no test-runner output, discard test search results and skip to STEP 3.
+
+### STEP 1.5 — Fetch Code Coverage (run in parallel with STEP 1)
+
+This step runs unconditionally — coverage context is valuable whether CI is red or green.
+
+The `--repo` value must be fully lowercase (the API rejects mixed-case). Normalize before calling:
+```bash
+repo_lower=$(echo "<repo>" | tr '[:upper:]' '[:lower:]')
+pup code-coverage branch-summary \
+  --repo "$repo_lower" \
+  --branch "<branch>"
+```
+
+If the command returns no data or exits with an error, report "No data available" for Coverage in the PR Health section.
+
+Note: Code quality and security violation counts are not available in pup — those lines always show "No data available".
+
+### STEP 2 — Blame Guard per Failing Job
+
+First check whether `@error_classification.domain` / `@error_classification.type` are present on job events from STEP 1 — if populated, use them as primary classification signals.
+
+For each failing job where classification is still needed, run both checks in parallel:
+
+**Default branch check** — was this job already failing before this PR?
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.job.name:\"<job>\" @git.branch:<default-branch> @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --from 24h
+```
+
+**Blast radius check** — is this job failing on other branches too?
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.job.name:\"<job>\" @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --group-by "@git.branch" \
+  --from 24h
+```
+
+Performance fallback: if the blast radius query is slow or times out, skip it and rely on the default branch check alone.
+
+### STEP 3 — Classify Each Failure
+
+**Priority order:**
+1. If `@error_classification.domain` / `@error_classification.type` present → use as primary signal
+2. If test failure AND test appears in flaky tests with `flaky_test_state:active`:
+   ```bash
+   pup cicd flaky-tests search \
+     --query "flaky_test_state:active @test.name:\"<test-name>\" @git.repository.id_v2:\"<repo>\""
+   ```
+   → **flaky**
+3. Use blame guard results:
+
+| Failing on default branch? | Failing on ≥3 other branches? | Classification |
+|---|---|---|
+| Yes | Yes | **infra** (pre-existing, widespread) |
+| Yes | No | **infra** (pre-existing on default branch) |
+| No | No | **regression** (introduced by this PR) |
+| No | Yes | **flaky** (intermittent, cross-branch) |
+| Insufficient data | — | **unknown** |
+
+### STEP 4 — Produce Triage Brief
+
+One entry per failing job:
+
+```
+PR CI Triage Brief
+==================
+Branch:   <branch>
+Repo:     <repo>
+
+Job: <job-name>
+  Classification:  <flaky | infra | regression | unknown>
+  Evidence:        <1 key data point — error message, pipeline count, or test result>
+  Confidence:      <high | medium | low>
+  Recommended:     <action>
+
+[repeat for each failing job]
+
+Overall: <N> failures — <e.g. "1 regression, 1 flaky, 1 infra">
+
+PR Health
+=========
+Coverage:   <X>% on <branch> | No data available
+Quality:    No data available
+Security:   No data available
+```
+
+All three lines always appear.
+
+### STEP 5 — Propose Actions
+
+**regression** → Prompt user to investigate their code changes. No write action available.
+
+**flaky** → Load `triage-flaky-test` skill for deep investigation. That skill will:
+- Attempt an agent-native fix using `flaky_category` + stack trace
+- Propose quarantine via `pup test-optimization flaky-tests update` if a quick fix isn't possible
+
+**infra** → Before proposing a retry, assess whether the failure is transient:
+- Check `@error_classification.type` and error message for signals like `timeout`, `runner unavailable`, `network error`, `quota exceeded` — these indicate transient failures where a retry is likely to help
+- If the error is deterministic (build misconfiguration, missing secret, explicit test assertion failure), a retry is unlikely to help — note this and suggest investigating the root cause
+- If the failure is pre-existing on the default branch, inform the user — a retry will likely fail again; await the upstream fix instead
+
+If transient and GitHub Actions: extract the run ID from `@ci.pipeline.url` (e.g. `https://github.com/org/repo/actions/runs/<run_id>`):
+```bash
+gh run rerun <run_id> --failed
+```
+For other providers, share `@ci.pipeline.url` and direct to the provider UI for retry.
+
+**unknown** → Suggest checking raw job logs via the CI provider UI or `@ci.pipeline.url` from the pipeline event.


### PR DESCRIPTION
## Summary

Adds two pup-based CI/CD workflow skills under `dd-software-delivery/`, following the same grouping pattern as `dd-llmo/` and `dd-audit/`. Both skills are adapted for shell execution via the pup CLI, mirroring the equivalent MCP skill designs.

## Changes

- `dd-software-delivery/unblock-pr/SKILL.md` — Investigate a failing PR CI pipeline: searches job-level failures and test failures in parallel, runs per-job blame-guard aggregations (default-branch check + blast radius), classifies each failure as flaky/infra/regression/unknown, fetches code coverage via `pup code-coverage branch-summary`, and proposes targeted actions with transience-aware retry for infra failures.
- `dd-software-delivery/triage-flaky-test/SKILL.md` — Deep-dive on a specific flaky test: fetches pre-computed FTM stats, recent failure history, and blast radius. Recommends a category-specific code fix (with fix patterns and pre-fix verification checklist) or quarantine with explicit user approval gate before any write.
- `SKILL.md` — Bumped version to `1.0.3`, added `dd-software-delivery` to the Core Skills table, added CI/CD workflow skills install snippet.
- `README.md` — Added `dd-software-delivery` to the skills table and a dedicated section documenting sub-skills, install instructions, and usage examples.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)