### PR TITLE
fix(readme): correct skill names for triage-flaky-test and unblock-pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npx skills add datadog-labs/agent-skills \
   --skill llm-obs-eval-pipeline \
   --skill llm-obs-session-classify \
   --skill k9-ownership-byod-setup \
+  --skill unblock-pr \
+  --skill triage-flaky-test \
   --full-depth -y
 ```
 
@@ -219,8 +221,8 @@ Or via `npx`:
 
 ```bash
 npx skills add datadog-labs/agent-skills \
-  --skill dd-software-delivery/unblock-pr \
-  --skill dd-software-delivery/triage-flaky-test \
+  --skill unblock-pr \
+  --skill triage-flaky-test \
   --full-depth -y
 ```
 
@@ -328,8 +330,8 @@ Or via `npx`:
 
 ```bash
 npx skills add datadog-labs/agent-skills \
-  --skill dd-software-delivery/unblock-pr \
-  --skill dd-software-delivery/triage-flaky-test \
+  --skill unblock-pr \
+  --skill triage-flaky-test \
   --full-depth -y
 ```
 


### PR DESCRIPTION
## Summary

- Remove the `dd-software-delivery/` prefix from the `npx skills add` install commands for `unblock-pr` and `triage-flaky-test` — the CLI discovers skills by their directory name, not their path relative to the repo root
- Add `--skill unblock-pr` and `--skill triage-flaky-test` to the "install all" command block

## Test plan

- [x] Verified correct skill names via `npx skills add datadog-labs/agent-skills --list --full-depth` — both appear as `unblock-pr` and `triage-flaky-test` (no prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)