### PR TITLE
feat: expose dd-apm skill content as a Rust crate (dd-agent-skills)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: cargo check / test / fmt / clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: cargo fmt --check
+        run: cargo fmt --check
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: cargo check
+        run: cargo check --all-targets
+      - name: cargo test
+        run: cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .*
 !.gitignore
+!.github
+!.github/**
+
+# Rust build artifacts (Cargo.lock is ignored because this crate is a library).
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dd-agent-skills"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Datadog Agent Skills (SKILL.md content) exposed as Rust constants for embedding into Rust-based tools like pup."
+repository = "https://github.com/datadog-labs/agent-skills"
+readme = "README.md"
+
+[lib]
+path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,85 @@
+//! Datadog Agent Skills exposed as Rust constants.
+//!
+//! Each `<NAME>_SKILL` is the root `SKILL.md` content for that skill.
+//! Each `<NAME>_SUB_SKILLS` is a slice of `(relative_path, content)` tuples
+//! for any nested `SKILL.md` files the skill ships (e.g. `dd-apm` ships
+//! `service-remapping/`, `k8s-ssi/*/`, and `linux-ssi/*/`).
+//!
+//! Consumers like [pup](https://github.com/datadog-labs/pup) read these
+//! constants at compile time and write the bytes to disk during install.
+
+pub const DD_APM_SKILL: &str = include_str!("../dd-apm/SKILL.md");
+
+pub static DD_APM_SUB_SKILLS: &[(&str, &str)] = &[
+    (
+        "service-remapping/SKILL.md",
+        include_str!("../dd-apm/service-remapping/SKILL.md"),
+    ),
+    (
+        "k8s-ssi/agent-install/SKILL.md",
+        include_str!("../dd-apm/k8s-ssi/agent-install/SKILL.md"),
+    ),
+    (
+        "k8s-ssi/enable-ssi/SKILL.md",
+        include_str!("../dd-apm/k8s-ssi/enable-ssi/SKILL.md"),
+    ),
+    (
+        "k8s-ssi/verify-ssi/SKILL.md",
+        include_str!("../dd-apm/k8s-ssi/verify-ssi/SKILL.md"),
+    ),
+    (
+        "k8s-ssi/troubleshoot-ssi/SKILL.md",
+        include_str!("../dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md"),
+    ),
+    (
+        "k8s-ssi/onboarding-summary/SKILL.md",
+        include_str!("../dd-apm/k8s-ssi/onboarding-summary/SKILL.md"),
+    ),
+    (
+        "linux-ssi/agent-install/SKILL.md",
+        include_str!("../dd-apm/linux-ssi/agent-install/SKILL.md"),
+    ),
+    (
+        "linux-ssi/enable-ssi/SKILL.md",
+        include_str!("../dd-apm/linux-ssi/enable-ssi/SKILL.md"),
+    ),
+    (
+        "linux-ssi/verify-ssi/SKILL.md",
+        include_str!("../dd-apm/linux-ssi/verify-ssi/SKILL.md"),
+    ),
+    (
+        "linux-ssi/troubleshoot-ssi/SKILL.md",
+        include_str!("../dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md"),
+    ),
+    (
+        "linux-ssi/onboarding-summary/SKILL.md",
+        include_str!("../dd-apm/linux-ssi/onboarding-summary/SKILL.md"),
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dd_apm_skill_has_frontmatter_and_is_non_empty() {
+        assert!(
+            DD_APM_SKILL.starts_with("---"),
+            "expected YAML frontmatter at start of DD_APM_SKILL"
+        );
+        assert!(!DD_APM_SKILL.trim().is_empty());
+    }
+
+    #[test]
+    fn dd_apm_sub_skills_are_well_formed() {
+        assert_eq!(DD_APM_SUB_SKILLS.len(), 11);
+        for (rel, body) in DD_APM_SUB_SKILLS {
+            assert!(
+                rel.ends_with("/SKILL.md"),
+                "unexpected relative path: {rel}"
+            );
+            assert!(body.starts_with("---"), "{rel} missing YAML frontmatter");
+            assert!(!body.trim().is_empty(), "{rel} body is empty");
+        }
+    }
+}


### PR DESCRIPTION
Adds a minimal top-level Cargo crate so Rust tools (pup et al.) can embed Datadog Agent Skill content via a normal `cargo` dependency instead of pulling this repo as a git submodule.

The crate exposes two constants for now:

  pub const  DD_APM_SKILL: &str          — dd-apm/SKILL.md (router)
  pub static DD_APM_SUB_SKILLS: &[(...)] — 11 nested SKILL.md files
                                           (service-remapping, k8s-ssi,
                                            linux-ssi sub-trees)

Both are produced via `include_str!` against the existing markdown. No files are moved; the `npx skills add datadog-labs/agent-skills` flow keeps working unchanged.

Additional skills (dd-logs, dd-monitors, dd-pup, …) can be added later as further `*_SKILL` / `*_SUB_SKILLS` constants — each is roughly two lines per file.

Also:
- .gitignore: whitelist .github/ and ignore /target + /Cargo.lock (Cargo.lock is intentionally ignored: this is a library crate)
- .github/workflows/rust.yml: cargo fmt + clippy + check + test on every push / PR so the crate doesn't silently rot if markdown is moved