### PR TITLE
fix(dd-apm): remove inline curl|bash install from linux-ssi skills

### DIFF
--- a/dd-apm/linux-ssi/agent-install/SKILL.md
+++ b/dd-apm/linux-ssi/agent-install/SKILL.md
@@ -120,14 +120,18 @@ Run for each host that does not already have the agent installed.
 
 ### Claude runs
 
-```bash
-ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
-  "DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
-```
+Direct the user to install the Datadog Agent on each target host by following
+the canonical Linux SSI install instructions:
+https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/
 
-`DD_APM_INSTRUMENTATION_ENABLED=host` causes the install script to also install `datadog-apm-inject` and language library packages under `/opt/datadog-packages/` in one pass.
+Before the documented install command is run, set on each host:
 
-If the script completes without errors — proceed to Phase 2.
+- `DD_API_KEY` (from Phase 0)
+- `DD_SITE` (from Phase 0)
+- `DD_APM_INSTRUMENTATION_ENABLED=host` — also installs `datadog-apm-inject` and language library packages under `/opt/datadog-packages/` in one pass
+
+Do not embed the install script inline; have the user run it from the trusted
+Datadog source. If the install completes without errors — proceed to Phase 2.
 
 ERROR: `curl: command not found`:
 ```bash
@@ -177,12 +181,13 @@ ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
 
 If `/opt/datadog-packages/datadog-apm-inject` exists — injection is available.
 
-ERROR: Directory missing or empty — `datadog-installer status` may show the package as registered while its directory is actually empty (stale registration). Reinstall:
+ERROR: Directory missing or empty — `datadog-installer status` may show the package as registered while its directory is actually empty (stale registration). Remove the stale registration:
 ```bash
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
-  "sudo datadog-installer remove datadog-apm-inject && \
-   DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
+  "sudo datadog-installer remove datadog-apm-inject"
 ```
+
+Then have the user re-run the SSI install from the canonical docs with `DD_API_KEY`, `DD_SITE`, and `DD_APM_INSTRUMENTATION_ENABLED=host` set in the environment: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/
 
 **Verify hostname registration** — the Agent must resolve and register its hostname for the host to appear in Datadog. DNS lookup failures are common in containers and minimal VMs:
 

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -350,11 +350,9 @@ If the conclusion doesn't hold up, return to Step 2 with new hypotheses.
 # Remove the stale registration first
 ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
   "sudo datadog-installer remove datadog-apm-library-<LANG>"
-
-# Re-run install — now it will actually download and extract
-ssh -o StrictHostKeyChecking=no -i <SSH_KEY> <SSH_USER>@<SSH_HOST> \
-  "DD_API_KEY=${DD_API_KEY} DD_SITE=${DD_SITE} DD_APM_INSTRUMENTATION_ENABLED=host bash -c \"\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
 ```
+
+Then have the user re-run the SSI install from the canonical docs — it will actually download and extract this time — with `DD_API_KEY`, `DD_SITE`, and `DD_APM_INSTRUMENTATION_ENABLED=host` set in the environment: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/
 
 If re-running the install script is sufficient (package files are intact), use `remove` first only if the script reports success but the problem persists.
 


### PR DESCRIPTION
Replace the three `bash -c "$(curl -L install.datadoghq.com/…)"` blocks in linux-ssi/agent-install/SKILL.md (Phase 2 install and stale-package reinstall) and linux-ssi/troubleshoot-ssi/SKILL.md (remediation reinstall) with directives pointing the user at the canonical Datadog SSI install docs.

The script URL itself was the official Datadog Agent installer, but embedding a `curl … | bash` pattern in a skill makes the skill an executable attack surface and trips security scans at medium severity. Having the user run the documented install from the trusted source removes both concerns.