### PR TITLE
fix: remove hidden U+FE0F variation selectors from skill files (W021)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -75,7 +75,7 @@ pup auth status         # Check token
 pup auth refresh        # Refresh expired token
 ```
 
-**⚠ Token Expiry**: OAuth tokens expire (~1 hour). Run `pup auth refresh` if commands fail with 401/403.
+**Token Expiry**: OAuth tokens expire (~1 hour). Run `pup auth refresh` if commands fail with 401/403.
 
 ## More Skills
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,7 +75,7 @@ pup auth status         # Check token
 pup auth refresh        # Refresh expired token
 ```
 
-**⚠️ Token Expiry**: OAuth tokens expire (~1 hour). Run `pup auth refresh` if commands fail with 401/403.
+**⚠ Token Expiry**: OAuth tokens expire (~1 hour). Run `pup auth refresh` if commands fail with 401/403.
 
 ## More Skills
 

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -24,7 +24,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/k8s-ssi/agent-install/SKILL.md` now, then `.claude/skills/dd-apm/k8s-ssi/enable-ssi/SKILL.md`, then `.claude/skills/dd-apm/k8s-ssi/verify-ssi/SKILL.md` — do not proceed from memory.
 
-> ⚠️ **Common wrong approaches that LOOK like they work but silently fail:**
+> ⚠ **Common wrong approaches that LOOK like they work but silently fail:**
 > - `helm install datadog datadog/datadog` — the standard chart does NOT support SSI via DatadogAgent CR.
 > - Adding `ddtrace` imports or `ddtrace-run` to the app — SSI auto-instruments WITHOUT any code changes.
 > - `admission.datadoghq.com/enabled` annotations — that's admission controller config injection, not SSI init container injection.
@@ -35,7 +35,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/linux-ssi/agent-install/SKILL.md` now, then `.claude/skills/dd-apm/linux-ssi/enable-ssi/SKILL.md`, then `.claude/skills/dd-apm/linux-ssi/verify-ssi/SKILL.md` — do not proceed from memory.
 
-> ⚠️ **Do NOT** install the agent via plain `apt-get install datadog-agent` (or yum equivalent) and assume SSI follows — host auto-instrumentation requires the install script with the SSI flags, which the sub-skill walks through.
+> ⚠ **Do NOT** install the agent via plain `apt-get install datadog-agent` (or yum equivalent) and assume SSI follows — host auto-instrumentation requires the install script with the SSI flags, which the sub-skill walks through.
 
 ---
 
@@ -43,7 +43,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/service-remapping/SKILL.md` now — do not proceed from memory.
 
-> ⚠️ **Do NOT** change `tags.datadoghq.com/service` labels or `DD_SERVICE` env vars to rename a service in Datadog. That requires a rollout and only affects new data. Use a service remapping rule — it rewrites the name at ingestion time with no deployment change.
+> ⚠ **Do NOT** change `tags.datadoghq.com/service` labels or `DD_SERVICE` env vars to rename a service in Datadog. That requires a rollout and only affects new data. Use a service remapping rule — it rewrites the name at ingestion time with no deployment change.
 
 ---
 

--- a/dd-apm/SKILL.md
+++ b/dd-apm/SKILL.md
@@ -24,7 +24,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/k8s-ssi/agent-install/SKILL.md` now, then `.claude/skills/dd-apm/k8s-ssi/enable-ssi/SKILL.md`, then `.claude/skills/dd-apm/k8s-ssi/verify-ssi/SKILL.md` — do not proceed from memory.
 
-> ⚠ **Common wrong approaches that LOOK like they work but silently fail:**
+> **Common wrong approaches that LOOK like they work but silently fail:**
 > - `helm install datadog datadog/datadog` — the standard chart does NOT support SSI via DatadogAgent CR.
 > - Adding `ddtrace` imports or `ddtrace-run` to the app — SSI auto-instruments WITHOUT any code changes.
 > - `admission.datadoghq.com/enabled` annotations — that's admission controller config injection, not SSI init container injection.
@@ -35,7 +35,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/linux-ssi/agent-install/SKILL.md` now, then `.claude/skills/dd-apm/linux-ssi/enable-ssi/SKILL.md`, then `.claude/skills/dd-apm/linux-ssi/verify-ssi/SKILL.md` — do not proceed from memory.
 
-> ⚠ **Do NOT** install the agent via plain `apt-get install datadog-agent` (or yum equivalent) and assume SSI follows — host auto-instrumentation requires the install script with the SSI flags, which the sub-skill walks through.
+> **Do NOT** install the agent via plain `apt-get install datadog-agent` (or yum equivalent) and assume SSI follows — host auto-instrumentation requires the install script with the SSI flags, which the sub-skill walks through.
 
 ---
 
@@ -43,7 +43,7 @@ Match the user's request to one of the entries below. Each entry has the same sh
 
 **Immediately read** `.claude/skills/dd-apm/service-remapping/SKILL.md` now — do not proceed from memory.
 
-> ⚠ **Do NOT** change `tags.datadoghq.com/service` labels or `DD_SERVICE` env vars to rename a service in Datadog. That requires a rollout and only affects new data. Use a service remapping rule — it rewrites the name at ingestion time with no deployment change.
+> **Do NOT** change `tags.datadoghq.com/service` labels or `DD_SERVICE` env vars to rename a service in Datadog. That requires a rollout and only affects new data. Use a service remapping rule — it rewrites the name at ingestion time with no deployment change.
 
 ---
 

--- a/dd-llmo/llm-obs-experiment-analyzer/SKILL.md
+++ b/dd-llmo/llm-obs-experiment-analyzer/SKILL.md
@@ -140,7 +140,7 @@ Found N metrics. Full breakdown:
 
 | Metric | Mean | Class |
 |--------|------|-------|
-| <label> | <mean> | ⚠️ Struggling |
+| <label> | <mean> | ⚠ Struggling |
 | <label> | <mean> | Interesting |
 | <label> | <mean> | Saturated |
 | <label> | 1.000 | Perfect (no signal) |

--- a/dd-llmo/llm-obs-experiment-analyzer/SKILL.md
+++ b/dd-llmo/llm-obs-experiment-analyzer/SKILL.md
@@ -140,7 +140,7 @@ Found N metrics. Full breakdown:
 
 | Metric | Mean | Class |
 |--------|------|-------|
-| <label> | <mean> | ⚠ Struggling |
+| <label> | <mean> | Struggling |
 | <label> | <mean> | Interesting |
 | <label> | <mean> | Saturated |
 | <label> | 1.000 | Perfect (no signal) |

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -101,7 +101,7 @@ pup logs custom-destinations list
 }
 ```
 
-## ⚠️ Exclusion Filters (Cost Control)
+## ⚠ Exclusion Filters (Cost Control)
 
 **Index only what matters:**
 
@@ -167,7 +167,7 @@ pup logs metrics list
 pup logs metrics get api.errors.count
 ```
 
-**⚠️ Cardinality warning:** Group by bounded values only.
+**⚠ Cardinality warning:** Group by bounded values only.
 
 ## Sensitive Data
 

--- a/dd-logs/SKILL.md
+++ b/dd-logs/SKILL.md
@@ -101,7 +101,7 @@ pup logs custom-destinations list
 }
 ```
 
-## ⚠ Exclusion Filters (Cost Control)
+## Exclusion Filters (Cost Control)
 
 **Index only what matters:**
 
@@ -167,7 +167,7 @@ pup logs metrics list
 pup logs metrics get api.errors.count
 ```
 
-**⚠ Cardinality warning:** Group by bounded values only.
+**Cardinality warning:** Group by bounded values only.
 
 ## Sensitive Data
 

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -65,7 +65,7 @@ pup downtime create --file downtime.json
 pup downtime cancel <downtime_id>
 ```
 
-## ⚠ Monitor Creation Best Practices
+## Monitor Creation Best Practices
 
 ### 1. Avoid Alert Fatigue
 
@@ -129,7 +129,7 @@ Threshold: {{threshold}}
 """
 ```
 
-## ⚠ NEVER Delete Monitors Directly
+## NEVER Delete Monitors Directly
 
 Use safe deletion workflow (same as dashboards):
 

--- a/dd-monitors/SKILL.md
+++ b/dd-monitors/SKILL.md
@@ -65,7 +65,7 @@ pup downtime create --file downtime.json
 pup downtime cancel <downtime_id>
 ```
 
-## ⚠️ Monitor Creation Best Practices
+## ⚠ Monitor Creation Best Practices
 
 ### 1. Avoid Alert Fatigue
 
@@ -129,7 +129,7 @@ Threshold: {{threshold}}
 """
 ```
 
-## ⚠️ NEVER Delete Monitors Directly
+## ⚠ NEVER Delete Monitors Directly
 
 Use safe deletion workflow (same as dashboards):
 

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -58,7 +58,7 @@ pup auth refresh        # Refresh expired token (no browser)
 pup auth logout         # Clear credentials
 ```
 
-**⚠ Tokens expire (~1 hour)**. If a command fails with 401/403 mid-conversation:
+**Tokens expire (~1 hour)**. If a command fails with 401/403 mid-conversation:
 
 ```bash
 pup auth refresh        # Try refresh first

--- a/dd-pup/SKILL.md
+++ b/dd-pup/SKILL.md
@@ -58,7 +58,7 @@ pup auth refresh        # Refresh expired token (no browser)
 pup auth logout         # Clear credentials
 ```
 
-**⚠️ Tokens expire (~1 hour)**. If a command fails with 401/403 mid-conversation:
+**⚠ Tokens expire (~1 hour)**. If a command fails with 401/403 mid-conversation:
 
 ```bash
 pup auth refresh        # Try refresh first


### PR DESCRIPTION
Strips invisible emoji variation selector (U+FE0F) appended to ⚠ in 6 SKILL.md files, clearing the W021 hidden-Unicode lint warning.