### PR TITLE
feat(dd-llmo/llm-obs-eval-bootstrap): add session-level online evaluator support

### DIFF
--- a/dd-llmo/llm-obs-eval-bootstrap/SKILL.md
+++ b/dd-llmo/llm-obs-eval-bootstrap/SKILL.md
@@ -35,7 +35,7 @@ Given a sample of production LLM traces, analyze input/output patterns and quali
 
 - **`sdk_code`** *(default)* — Python `.py` file using the Datadog Evals SDK (`BaseEvaluator` / `LLMJudge`) for **offline** experiments.
 - **`data_only`** — self-contained JSON spec, framework-agnostic.
-- **`publish`** — write **online** LLM-judge evaluators directly to Datadog via `create_or_update_llmobs_evaluator`. These run automatically on matching production spans or traces (no dataset, no task function). The skill **auto-classifies** each proposed evaluator as **span-scoped** or **trace-scoped** based on what the judgment requires (a per-LLM-call tone check vs. an agent goal completion that needs the whole trace) — the user accepts or overrides the classification at the proposal checkpoint.
+- **`publish`** — write **online** LLM-judge evaluators directly to Datadog via `create_or_update_llmobs_evaluator`. These run automatically on matching production spans, traces, or sessions (no dataset, no task function). The skill **auto-classifies** each proposed evaluator as **span-scoped**, **trace-scoped**, or **session-scoped** based on what the judgment requires (a per-LLM-call tone check vs. an agent goal completion that needs the whole trace vs. user satisfaction across a whole multi-trace conversation) — the user accepts or overrides the classification at the proposal checkpoint. Session-scoped evaluators are only proposed when the app's spans carry a `session_id` (verified by a probe in Phase 1).
 
 ## Usage
 
@@ -89,6 +89,8 @@ Use the `path` parameter to extract targeted data without fetching full payloads
 Additional filters combine with space (AND): `@status:error @ml_app:my-app`. Dedicated params (`span_kind`, `root_spans_only`, `ml_app`) work alongside `query`, but `query` takes precedence over `tags`.
 
 To find spans with a specific eval: `@evaluations.custom.<eval_name>:*` — you can only query for eval *presence*, not specific results.
+
+To detect whether the app uses **sessions**: `session_id:*` matches any span carrying a `session_id` (`session_id` is a first-class field — no `@` prefix). The Phase 1 session probe uses this to gate session-scope evaluators.
 
 ### Parallelization Rules
 
@@ -338,6 +340,10 @@ If you have access to dd-trace-py locally, verify the API surface by reading the
 
 1. **Sample the app**: `search_llmobs_spans(query="@ml_app:\"<ml_app>\" @status:ok", root_spans_only=true, limit=50, from=<timeframe>)`. Filter by `@status:ok` — error spans have no output to evaluate.
 
+   **Session probe** *(gates session-scope proposals; `publish` mode)*: in the same message, also call `search_llmobs_spans(query="@ml_app:\"<ml_app>\" session_id:*", limit=20, from=<timeframe>)`.
+   - **≥ 1 result** → set `sessions_present = true`. Note the distinct `session_id` values and, critically, whether the same `session_id` appears across **multiple `trace_id`s** — that cross-trace span is the real signal that a session carries context worth a session-scope evaluator. (A `session_id` that only ever maps to one trace adds nothing over trace scope.)
+   - **0 results** → `sessions_present = false`. Do **not** propose any session-scope evaluator; record a one-line "session scope skipped — no `session_id` on sampled spans" note for the proposal.
+
 2. **Profile the app and identify evaluation target spans**: Call `get_llmobs_span_details` for span_ids grouped by trace_id. Inspect `content_info` to classify:
 
    | Signal | App Profile |
@@ -347,13 +353,14 @@ If you have access to dd-trace-py locally, verify the API surface by reading the
    | Spans include `agent` kind | Agent app |
    | `content_info` has `metadata` | Has custom metadata |
    | Multiple span kinds in one trace (`agent` + `tool` / `retrieval` + `llm` from `get_llmobs_trace`) | Multi-step app — at least one trace-scope evaluator likely belongs in the suite (`publish` mode) |
+   | Same `session_id` across **multiple `trace_id`s** (from the session probe) | Multi-trace sessions — at least one session-scope evaluator likely belongs in the suite (`publish` mode, gated on `sessions_present`) |
 
    For agent/multi-step apps, also call `get_llmobs_trace` on 2-3 traces to see the full span hierarchy. Compare `content_info` between the root span and its sub-spans. Then ask **two** questions for each candidate quality dimension, in this order:
 
    1. **Does the verdict depend on more than one span?** (e.g., faithfulness depends on a `retrieval` span's documents AND an `llm` span's answer; goal completion depends on the chain of `tool` calls AND the final response.) If yes → **trace scope** in `publish` mode. Don't try to compress this into a single span.
    2. **Only if the answer to (1) is no**: pick the single span with the richest signal for that dimension (root has the summary; LLM sub-spans have the full system prompt + tool call results + reasoning chain).
 
-   Record the span-kind histogram (agent + tool + llm + retrieval) — multiple kinds under one root is a strong signal you'll have at least one trace-scope evaluator in the suite. See Phase 2's "Span vs. Trace Scope Classification" for the mandatory walk-through of canonical trace-scope use cases.
+   Record the span-kind histogram (agent + tool + llm + retrieval) — multiple kinds under one root is a strong signal you'll have at least one trace-scope evaluator in the suite. See Phase 2's "Span vs. Trace vs. Session Scope Classification" for the mandatory walk-through of canonical trace-scope use cases (and, when `sessions_present`, the canonical session-scope use cases).
 
 3. **Extract content and identify targets**: Call `get_llmobs_span_content` for representative spans. Fetch fields based on app profile:
 
@@ -379,7 +386,7 @@ If you have access to dd-trace-py locally, verify the API surface by reading the
 
 #### From RCA Path
 
-1. Extract the failure taxonomy from the RCA report. Each failure mode with High or Medium severity becomes an eval target.
+1. Extract the failure taxonomy from the RCA report. Each failure mode with High or Medium severity becomes an eval target. Also run the Phase 1 **session probe** (`query="session_id:*"`) to set `sessions_present` — a failure that only manifests across a multi-trace conversation (lost context, repeated mistakes, mounting frustration) is a session-scope target.
 
 2. **Check root cause categories for infrastructure failures.** Before proposing evaluators, scan the Root Cause column of the taxonomy for any of: `Instrumentation Deficiency`, `Harness Deficiency`, `Runtime Error`, `Upstream Data Issue`, or any other root cause that points to infrastructure/environment rather than model behavior. If any are present, pause and ask:
 
@@ -403,12 +410,12 @@ If you have access to dd-trace-py locally, verify the API surface by reading the
 
 **Goal**: Present a concrete evaluator proposal for user confirmation.
 
-Each evaluator judges **one data point** — it receives input and output for a single record/span, not a full trace or batch. Design evaluators accordingly.
+In `sdk_code` / `data_only` mode — and for `eval_scope: span` in `publish` mode — each evaluator judges **one data point**: input and output for a single record/span, not a full trace or batch. In `publish` mode, `eval_scope: trace` judges a whole trace and `eval_scope: session` a whole multi-trace session — design those against the trace / session payload instead (see "Span vs. Trace vs. Session Scope Classification" below). Design evaluators accordingly for their scope.
 
 **Targeting depends on `output_mode`:**
 
 - `sdk_code` / `data_only` → **offline experiments**. Template variables use `EvaluatorContext` fields (`{{input_data}}`, `{{output_data}}`). The actual data shape depends on the user's dataset and task function (see EvaluatorContext note in SDK Reference).
-- `publish` → **online evaluation on production spans**. Template variables resolve against the **full span JSON** via dot-paths (`{{meta.input.value}}`, `{{meta.output.messages[*].content}}`, …) or the built-in span-kind-aware aliases (`{{span_input}}`, `{{span_output}}`). See "Online Template Variables" under Publishing Conventions for the full syntax. Each evaluator also needs `eval_scope`, `sampling_percentage`, and (optionally) `filter` — surface these in the proposal table so the user can confirm before publishing.
+- `publish` → **online evaluation on production spans**. Template variables resolve against the **full span JSON** via dot-paths (`{{meta.input.value}}`, `{{meta.output.messages[*].content}}`, …) or the built-in span-kind-aware aliases (`{{span_input}}`, `{{span_output}}`). For `eval_scope: trace` and `eval_scope: session`, templates resolve against the trace payload (`{{spans[...]}}`) or the session payload (`{{traces[*].spans[...]}}`) instead. See "Online Template Variables" under Publishing Conventions for the full syntax. Each evaluator also needs `eval_scope`, `sampling_percentage`, and (optionally) `filter` — surface these in the proposal table so the user can confirm before publishing. Session scope is only used when the Phase 1 probe set `sessions_present`.
 
 Order proposals from broadest signal to most granular. **Propose broadly, let the user curate** — see "How many evaluators to propose" below.
 
@@ -440,13 +447,13 @@ The default `4-6` cap from the older skill version was too tight — it pushed t
 
 **In `data_only` mode**: skip this section entirely (coverage map was not built in Phase 0). Proceed directly to the proposal table.
 
-Before building the proposal, apply the coverage map from Phase 0. **Coverage is keyed on `(dimension, scope)` — not on dimension alone**: every OOTB evaluator runs at span scope, and an enabled OOTB eval does NOT preclude proposing a trace-scope evaluator for the same dimension. The two answer different questions.
+Before building the proposal, apply the coverage map from Phase 0. **Coverage is keyed on `(dimension, scope)` — not on dimension alone**: every OOTB evaluator runs at span scope, and an enabled OOTB eval does NOT preclude proposing a trace-scope **or session-scope** evaluator for the same dimension. The three scopes answer different questions.
 
 1. **Enabled span-scope eval (OOTB or custom)** for dimension D:
    - Do NOT propose a new **span-scope** evaluator for D — that dimension is already covered at span scope.
-   - DO propose a **trace-scope** evaluator for D when the trace shape calls for it (multi-step app, judgment depends on cross-span context). Note the relationship in the rationale: e.g., "OOTB `Goal Completeness` evaluates each LLM span in isolation; this trace-scope `goal_completion` checks whether the agent's full sequence of steps achieved the user's request — different question."
+   - DO propose a **trace-scope** or **session-scope** evaluator for D when the trace or session shape calls for it (multi-step app, or multi-trace session — judgment depends on cross-span or cross-trace context). Note the relationship in the rationale: e.g., "OOTB `Goal Completeness` evaluates each LLM span in isolation; this trace-scope `goal_completion` checks whether the agent's full sequence of steps achieved the user's request, and a session-scope `session_goal_completion` checks it across the whole conversation — three different questions."
 
-2. **Enabled trace-scope custom eval** for dimension D: do NOT propose another trace-scope evaluator for the same dimension; that's a real duplicate. Span-scope on the same dimension is still fair game if the data also fits a single span.
+2. **Enabled trace-scope custom eval** for dimension D: do NOT propose another trace-scope evaluator for the same dimension; that's a real duplicate. Span-scope on the same dimension is still fair game if the data also fits a single span, and session-scope is fair game if the dimension also needs cross-trace context. Likewise, an enabled **session-scope** custom eval for D blocks only another session-scope eval for D — span and trace scope remain fair game.
 
 3. **Disabled OOTB eval**: Do NOT propose a new custom span-scope evaluator for that dimension. Instead, surface it in a short note within the proposal and suggest enabling it in the Datadog UI rather than creating a duplicate. Example:
 
@@ -454,7 +461,7 @@ Before building the proposal, apply the coverage map from Phase 0. **Coverage is
 
 4. **Gap identification**: Open the proposal with a coverage summary line: "Existing coverage: N evaluator(s) already configured ({names}, all span-scope unless noted). Proposing evaluators for uncovered dimensions and uncovered scopes."
 
-5. **All dimensions covered**: A dimension is "fully covered" only when **both** scopes are present (or the scope doesn't apply to the app shape). If the coverage map accounts for every identified quality dimension at the appropriate scope(s), surface this explicitly and ask the user what they want: (a) review/improve existing eval prompts, (b) add coverage for additional dimensions, or (c) proceed anyway.
+5. **All dimensions covered**: A dimension is "fully covered" only when the relevant scopes are present (span, plus trace and/or session where the app shape calls for them). If the coverage map accounts for every identified quality dimension at the appropriate scope(s), surface this explicitly and ask the user what they want: (a) review/improve existing eval prompts, (b) add coverage for additional dimensions, or (c) proceed anyway.
 
 For each proposed evaluator:
 
@@ -468,7 +475,7 @@ For each proposed evaluator:
 - **Publish-only fields** *(only in `publish` mode)*: `integration_provider` (default `openai`), `model_name` (default `gpt-5.4-mini`), `sampling_percentage` (default `10`), `eval_scope` (default `span`), and any `filter` query needed to scope to the right spans. Surface defaults in the proposal so the user can override before publishing.
 - **`integration_account_id`** *(only in `publish` mode)*: the integration account the judge LLM is called through. Auto-detected from existing evaluators in the same ml_app (Phase 0 coverage map). Never asked from the user as a raw UUID. If no existing evaluator has one, the field is omitted and the user picks an account in the UI before activating. **All evaluators are published with `enabled: false` regardless** — see "Always publish as draft" in Phase 3C for the full activation workflow.
 
-#### Span vs. Trace Scope Classification (`publish` mode)
+#### Span vs. Trace vs. Session Scope Classification (`publish` mode)
 
 **Don't ask the user; classify per evaluator and let them override at the checkpoint.**
 
@@ -483,27 +490,46 @@ If Phase 1 found multi-step traces (≥ 2 span kinds, or any `tool` / `retrieval
 | `rag_faithfulness` — answer grounded in retrieved documents? | Trace contains `retrieval` kind spans. |
 | `conversation_quality` — coherence across multi-turn LLM calls? | Trace contains ≥ 2 `llm` spans, or app instruments multi-turn sessions. |
 
-For other proposed evaluators (e.g. tone, format, safety), apply this two-question test:
+##### Mandatory: walk the canonical session-scope use cases (only when `sessions_present`)
+
+**Gate:** perform this walk-through **only if** the Phase 1 session probe set `sessions_present = true`. If sessions are absent, skip session scope entirely and note "session scope skipped — no `session_id` on sampled spans" in the proposal.
+
+When `sessions_present`, you **MUST** walk through the four canonical session-scope use cases below. For each, decide explicitly: **applies** (include with `eval_scope: session`) or **does not apply** (one-line reason in a "Skipped session-scope candidates" subsection). Session scope answers questions that span **more than one trace** under the same `session_id` — a single trace cannot see prior or later turns.
+
+| Canonical session use case | Triggers when |
+|---|---|
+| `session_goal_completion` — were the user's goals met across the whole session? | A `session_id` spans ≥ 2 traces. Almost always applies for multi-trace sessions. |
+| `multi_turn_conversation_quality` — coherence, memory, and consistent tone across turns | Multi-trace chat / assistant sessions. |
+| `user_frustration_signals` — frustration, confusion, repetition, or abandonment over the session | Any multi-turn session (repeated or rephrased asks across traces). |
+| `agent_consistency_across_session` — did the agent stay consistent and recover from errors across traces? | Agent app whose sessions span ≥ 2 traces. |
+
+For other proposed evaluators (e.g. tone, format, safety), apply this scope test in order:
 
 1. Can the judgment be answered correctly from **one** span's `meta.input` + `meta.output`, where "correctly" means the verdict cannot change if you considered other spans in the trace? → **`eval_scope: span`**.
-2. Otherwise → **`eval_scope: trace`**. In particular, default to trace when the evaluator name contains *grounding*, *faithfulness*, *hallucination*, *completeness*, *correctness across steps*, *consistency*, or *workflow* — these almost always need cross-span context.
+2. Otherwise, if it is answerable from the spans of a **single trace** → **`eval_scope: trace`**. Default to trace when the evaluator name contains *grounding*, *faithfulness*, *hallucination*, *completeness*, *correctness across steps*, *consistency*, or *workflow* — these almost always need cross-span context.
+3. Otherwise, if the verdict needs context from **more than one trace** in the same `session_id` (overall satisfaction, behavior over time, multi-turn coherence) **and** `sessions_present` → **`eval_scope: session`**. Default to session when the name contains *session*, *conversation*, *across turns*, *over time*, *satisfaction*, *frustration*, or *abandonment*. If `sessions_present` is false, fall back to trace scope and note the limitation.
 
 ##### Trade-offs (don't let these dominate the choice)
 
-Trace scope costs more than span scope: one judgment per **completed** trace (vs. per matching span), larger prompt payloads, and a 3-minute trigger latency (Datadog waits 3 minutes of inactivity before considering a trace complete; later spans are excluded). These are **cost-control** levers — handle with `sampling_percentage` and `filter`, not by demoting scope. The *correctness* of the eval is what picks the scope.
+Trace scope costs more than span scope: one judgment per **completed** trace (vs. per matching span), larger prompt payloads, and a 3-minute trigger latency (Datadog waits 3 minutes of inactivity before considering a trace complete; later spans are excluded). Session scope costs the most: one judgment per **completed session** (a `session_id` is complete after **30 minutes of inactivity** — vs. 3 minutes for a trace — and spans arriving > 30 min after the prior span are excluded), with the largest payloads (every span of every trace in the session, capped at 10,000 spans). These are **cost-control** levers — handle with `sampling_percentage` and `filter`, not by demoting scope. The *correctness* of the eval is what picks the scope.
 
 ##### Surface the classification
 
-Add a **Scope** column to the proposal table and a one-sentence rationale per evaluator. If you skipped a canonical trace-scope use case, list it under a "Skipped trace-scope candidates" subsection with the reason — the user will see and can override.
+Add a **Scope** column to the proposal table and a one-sentence rationale per evaluator. If you skipped a canonical trace-scope **or session-scope** use case, list it under the matching "Skipped …-scope candidates" subsection with the reason — the user will see and can override.
 
 > Example rationales:
 > - `tone_check` — **span**. Judging "is this single response polite" needs only one LLM span's `meta.output.messages[*].content`; no other span in the trace can change that verdict.
 > - `goal_completion` — **trace**. Whether the agent finished the user's request depends on the sequence of tool calls and the final LLM response together — `meta.output` of any single span only shows that step's output.
 > - `tool_use_correctness` — **trace**. Comparing tool inputs against the request and the final response requires correlating ≥ 3 spans (root, tool, final LLM).
 > - `rag_faithfulness` — **trace**. Grounding pairs the `retrieval` span's documents with the LLM span's answer.
+> - `session_goal_completion` — **session**. Whether the user's overall goals were met depends on every trace in the `session_id`, not just the last one — only session scope sees the full conversation.
+> - `user_frustration_signals` — **session**. Frustration surfaces as repeated or rephrased asks across traces; a single trace can't reveal the pattern.
 >
 > Example "Skipped trace-scope candidates" entry:
 > - `conversation_quality` — skipped: traces contain a single LLM call (no multi-turn signal in this app's instrumentation).
+>
+> Example "Skipped session-scope candidates" entry:
+> - `session_goal_completion` — skipped: every `session_id` maps to a single trace (no cross-trace context — trace scope already covers it).
 
 #### MANDATORY CHECKPOINT
 
@@ -519,7 +545,8 @@ Add a **Scope** column to the proposal table and a one-sentence rationale per ev
 |---|------|------|-------|----------|---------------|
 | 1 | task_completion | LLMJudge (Boolean) | span | Whether the task was completed on this span | pass_when=True |
 | 2 | tool_use_correctness | LLMJudge (Categorical) | trace | Right tool with right arguments across the agent run | pass_values=["correct"] |
-| 3 | ... | ... | ... | ... | ... |
+| 3 | session_goal_completion | LLMJudge (Categorical) | session | Whether the user's goals were met across the whole multi-trace session | pass_values=["completed"] |
+| 4 | ... | ... | ... | ... | ... |
 
 (Drop the **Scope** column when not in `publish` mode.)
 
@@ -527,13 +554,22 @@ For each evaluator:
 - **{name}**: {what it measures}
   - Target span: {which span's data it was designed for}
   - Rationale: {which quality dimension it covers and why}
-  - {Only in publish mode:} Scope: {span | trace} — {one-sentence rationale}
+  - {Only in publish mode:} Scope: {span | trace | session} — {one-sentence rationale}
   - Evidence: [Trace {id_short}](https://app.datadoghq.com/llm/traces?query=trace_id:{full_id})
 
 {Only in publish mode, for multi-step apps. Required if any of the four canonical trace-scope use cases was not included above:}
 
 **Skipped trace-scope candidates:**
 - `{canonical_use_case}` — {one-line reason it does not apply to this app}
+
+{Only in publish mode, when `sessions_present`. Required if any of the four canonical session-scope use cases was not included above:}
+
+**Skipped session-scope candidates:**
+- `{canonical_use_case}` — {one-line reason it does not apply, e.g. "every `session_id` maps to a single trace"}
+
+{Only in publish mode, when the session probe found no sessions:}
+
+**Session scope skipped** — no `session_id` on sampled spans; session-scope evaluators not proposed.
 
 {Only in publish mode, when the suite contains code-based evaluators (JSONEvaluator, RegexMatchEvaluator, LengthEvaluator, StringCheckEvaluator, BaseEvaluator). Required when any code-based proposal exists.}
 
@@ -868,8 +904,8 @@ For every proposed `eval_name`, call `get_llmobs_evaluator(eval_name=...)`:
 | `model_name` | `gpt-5.4-mini` |
 | `temperature` | `0` |
 | `parsing_type` | `structured_output` |
-| `sampling_percentage` | `10` for span scope, `5` for trace scope |
-| `eval_scope` | `span` (auto-promoted to `trace` per the classification rule in Phase 2) |
+| `sampling_percentage` | `10` for span scope, `5` for trace scope, `5` for session scope (the heaviest — consider lowering) |
+| `eval_scope` | `span` (auto-promoted to `trace` or `session` per the classification rule in Phase 2) |
 
 **Prompt template**: convert the LLMJudge prompt into the MCP shape — an ordered array of `{role, content}` messages. The system prompt becomes `{role: "system"}`, the user prompt becomes `{role: "user"}`. Use **span-data placeholders** (see below) — **not** the offline `{{input_data}}` / `{{output_data}}` form, which only exists in `EvaluatorContext`.
 
@@ -879,7 +915,7 @@ Online evaluator prompts run through the dd-source `template` library (`domains/
 
 - **`eval_scope: span`** *(default)* — placeholders resolve against a **single span's JSON** (the `llmobs.Span` JSON-marshaled to a map). Use the span aliases / dot-paths below directly.
 - **`eval_scope: trace`** — placeholders resolve against the **trace payload** `{ spans: [...] }`. Use `{{spans[N]...}}`, `{{spans[*]...}}`, or `{{spans[field.path:value]...}}` to select span(s) before applying field paths. The `{{span_input}}` / `{{span_output}}` aliases are **not available** in trace scope — reference span data through the `spans` array instead.
-- **`eval_scope: session`** — not supported by this skill; classify as `span` and surface the limitation to the user.
+- **`eval_scope: session`** — placeholders resolve against the **session payload** `{ session_id, traces: [ { trace_id, root_span_id, spans: [...] }, … ] }`. Reach spans through `{{traces[*].spans[*]...}}` (nested one level deeper than trace scope) plus the array selectors below. The `{{span_input}}` / `{{span_output}}` aliases **and** trace scope's top-level `{{spans[...]}}` are **not available** — spans live under `traces[*].spans`. Only used when `sessions_present` (Phase 1 probe).
 
 ###### Span-scope (`eval_scope: span`)
 
@@ -917,7 +953,25 @@ Online evaluator prompts run through the dd-source `template` library (`domains/
 | `{{spans[meta.span.kind:retrieval].meta.output.documents[*].text}}` | Text of every retrieved document — useful for RAG faithfulness |
 | `{{*}}` | Entire trace payload as JSON (debug fallback) |
 
-###### Array selector syntax (applies to both scopes)
+###### Session-scope (`eval_scope: session`)
+
+| Pattern | What you get |
+|---------|--------------|
+| `{{traces}}` | JSON of every trace in the session, each `{ trace_id, root_span_id, spans: [...] }` |
+| `{{session_id}}` | The session's ID |
+| `{{traces[*].trace_id}}` | Every trace ID in the session, newline-joined |
+| `{{traces[0].spans[0].meta.input.value}}` | First span of the first trace |
+| `{{traces[*].spans[*].name}}` | Every span name across the whole session |
+| `{{traces[*].spans[*].meta.output.value}}` | Every span's output across the session |
+| `{{traces[*].spans[meta.span.kind:llm].meta.input.messages[*].content}}` | All LLM-span input messages across the session — the user turns |
+| `{{traces[*].spans[meta.span.kind:llm].meta.output.messages[*].content}}` | All assistant responses across the session |
+| `{{traces[*].spans[meta.span.kind:tool]}}` | Every tool span (paired in/out) across the session |
+| `{{traces[*].spans[meta.span.kind:retrieval].meta.output.documents[*].text}}` | Text of every retrieved document across the session (RAG) |
+| `{{*}}` | Entire session payload as JSON (debug fallback) |
+
+Note: the filter selector applies to the **`spans`** array (`traces[*].spans[meta.span.kind:llm]`), not to `traces` — a trace object has only `trace_id`, `root_span_id`, and `spans`, so there is nothing to filter on at the trace level.
+
+###### Array selector syntax (applies to all scopes)
 
 - `[N]` — index (0-based)
 - `[START,END]` — inclusive range, `END` is clamped to slice length
@@ -936,6 +990,7 @@ Online evaluator prompts run through the dd-source `template` library (`domains/
 - **LLM-span-specific evaluator** (e.g. `system_prompt_adherence`) → reach for explicit `meta.input.messages[*].content` / `meta.output.messages[*].content` so you can split system vs. user vs. assistant turns.
 - **Span-scope RAG evaluator** (single retrieval+generation span) → combine `{{meta.input.documents}}` with `{{span_output}}`.
 - **Trace-scope evaluator** → see "Trace-scope evaluator examples" below for the four canonical patterns (goal completion, tool-use correctness, RAG faithfulness, conversation quality).
+- **Session-scope evaluator** → see "Session-scope evaluator examples" below for the four canonical patterns (session goal completion, multi-turn conversation quality, user frustration signals, agent consistency across the session).
 - **Metadata-aware evaluator** → reference `{{meta.metadata.<key>}}` directly.
 
 If the user has existing custom evaluators in the same ml_app (Phase 0 coverage map), match their convention when there is no strong reason to deviate.
@@ -952,6 +1007,19 @@ Concrete user-prompt bodies for the four canonical trace-scope use cases, drawn 
 | **Conversation quality** — coherence and consistency across turns | `@parent_id:undefined` | `Conversation:\n{{spans[meta.span.kind:llm].meta.input.messages[*].content}}\n\nAssistant responses:\n{{spans[meta.span.kind:llm].meta.output.messages[*].content}}` |
 
 Use these as starting points. Adapt the `filter` and span paths to the actual span names / kinds the app emits (observed during Phase 1).
+
+###### Session-scope evaluator examples
+
+Concrete user-prompt bodies for the four canonical session-scope use cases (adapted from the public [Session-Level Evaluations](https://docs.datadoghq.com/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/session_level_evaluations/) docs). Each goes alongside a static System prompt that describes the rubric (no placeholders). The `filter` is matched against the **session's root span** (not every span), so scope it with root-span attributes; there is no `@parent_id:undefined` requirement beyond that.
+
+| Use case | `filter` | User prompt body |
+|---|---|---|
+| **Session goal completion** — user's goals met across the session | `@meta.span.kind:agent` (or the app's root span kind) | `Session traces (chronological):\n{{traces}}` |
+| **Multi-turn conversation quality** — coherence and memory across turns | `@meta.span.kind:agent` | `User messages:\n{{traces[*].spans[meta.span.kind:llm].meta.input.messages[*].content}}\n\nAssistant responses:\n{{traces[*].spans[meta.span.kind:llm].meta.output.messages[*].content}}` |
+| **User frustration signals** — frustration / abandonment over the session | `@meta.span.kind:agent` | `Full session:\n{{traces}}` |
+| **Agent consistency across the session** — consistent and recovers across traces | `@meta.span.kind:agent` | `Session traces (chronological):\n{{traces}}` |
+
+Adapt the `filter` and span paths to the actual span kinds the app emits (observed in Phase 1).
 
 **`output_schema` wrapper format (required for all providers)**
 
@@ -1049,6 +1117,13 @@ Note: categorical uses `"type": "string"` alongside `anyOf` (each `const` is a s
 - The `filter` query must match the trace's **root span only** — always include `@parent_id:undefined` (or `root_spans_only: true`) to avoid double-firing across descendants. Combine with `@meta.span.kind:agent` (or whatever kind the app uses for root spans, observed in Phase 1) for narrowing.
 - Sampling at trace scope is heavier than at span scope (one trace = many spans on the judge's side). Default `sampling_percentage` to **`5`** for trace-scope evaluators (instead of the span default `10`); the user can raise it after a manual review pass.
 
+**For `eval_scope: session`:**
+
+- Only publish session-scope evaluators when `sessions_present` (Phase 1 probe). Otherwise the evaluator never fires — no span carries a `session_id`.
+- The evaluator triggers once per **completed session**. A `session_id` is complete after **30 minutes of inactivity** (vs. 3 minutes for a trace); spans arriving > 30 min after the prior span are **excluded**. Surface both the latency and the exclusion — long-running or sparse sessions may be split or truncated, and very large sessions are capped at 10,000 spans.
+- The `filter` is matched against the session's **root span** (the same prefilter trace scope uses), so scope it with root-span attributes — e.g. `@meta.span.kind:agent` (or the app's root span kind, observed in Phase 1). You do **not** need `@parent_id:undefined`: the session root is already a root span.
+- Sampling at session scope is the heaviest of all (one session = many traces = many spans on the judge's side). Default `sampling_percentage` to **`5`** (matching trace) and flag it as the heaviest scope; the user can lower it further after a manual review pass.
+
 #### Always publish as draft (`enabled: false`)
 
 **Always create / update evaluators with `enabled: false`** — regardless of whether `integration_account_id` was auto-detected from existing evaluators. The UI is the source of truth for activation; the skill should never auto-enable evaluators on the user's behalf. The user reviews each draft in the UI, confirms the integration account is correct (the auto-detected ID may belong to a different judge LLM than the one they want for this app), and flips the toggle when they're satisfied.
@@ -1086,6 +1161,7 @@ Wrote {N} online evaluators to ml_app `{ml_app}`. **All published as drafts (`en
 | 2 | response_groundedness | overwrote (draft) | openai/gpt-5.4-mini | 10% | span | yes | ok |
 | 3 | scope_adherence | renamed (`_v2`) (draft) | openai/gpt-5.4-mini | 10% | span | no — pick in UI | ok |
 | 4 | citation_format | failed | openai/gpt-5.4-mini | 10% | span | — | error |
+| 5 | session_goal_completion | created (draft) | openai/gpt-5.4-mini | 5% | session | yes | ok |
 
 {If any failed:}
 **Errors**:
@@ -1102,10 +1178,10 @@ The drafts are intentionally not running yet. Walk through each one in the Datad
 1. **Open the drafts**: Datadog → LLM Observability → Evaluations → filter by ml_app `{ml_app}` (the new drafts appear with status `Disabled`).
 2. **For each draft**:
    - **Verify the integration account** in the Provider section. If the column above shows `auto-detected: yes`, confirm it's the correct account for the judge LLM you want this evaluator to call through. If `no`, pick an account from the dropdown.
-   - **Skim the prompt template** and the structured-output schema — make sure the spans-vs-trace scope, filter, and sampling match what you actually want to measure.
+   - **Skim the prompt template** and the structured-output schema — make sure the span / trace / session scope, filter, and sampling match what you actually want to measure.
    - **Click into a sample span/trace** and use the test pane to dry-run the prompt against real data. Confirm the result matches your expectation.
 3. **Enable**: once each draft passes review, toggle it to enabled. Datadog starts scoring incoming spans immediately.
-4. **Wait for first scores**: with `sampling_percentage=10` (span scope) or `5` (trace scope), expect first results within minutes for high-traffic apps.
+4. **Wait for first scores**: with `sampling_percentage=10` (span scope) or `5` (trace / session scope), expect first results within minutes for high-traffic apps — except **session scope**, where the first result appears only after the session's 30-minute inactivity window closes.
 5. **Tune sampling/filter**: if results are noisy or volume is too high, reduce `sampling_percentage` or tighten the `filter` from the UI. Re-running `/eval-bootstrap {ml_app} --publish` will round-trip the existing config before overwriting — your manual tweaks survive across reruns.
 ```
 
@@ -1122,6 +1198,7 @@ Same logic as Phase 3A — offer to append to the RCA notebook if `rca_notebook_
 - **Show your work**: Every proposed evaluator cites at least one trace as evidence with a clickable link: `[Trace {first_8}...](https://app.datadoghq.com/llm/traces?query=trace_id:{full_32_char_id})`.
 - **New file only**: Never modify existing evaluator code or experiment configurations.
 - **Honest about uncertainty**: If fewer than 5 traces support a proposed evaluator, flag it as tentative.
+- **Session scope is gated**: only propose or publish `eval_scope: session` evaluators when the Phase 1 probe confirmed `sessions_present` (spans carry a `session_id`, ideally one that spans multiple traces). If sessions are absent, skip session scope and say so — never publish a session evaluator that can't fire.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **session-level** online LLM-judge evaluators to the canonical `llm-obs-eval-bootstrap` skill, making session a first-class scope alongside span and trace. Single file: `dd-llmo/llm-obs-eval-bootstrap/SKILL.md`.

Session evals are **gated on `session_id` presence** — the skill never proposes an evaluator that can't fire.

- **Phase 1:** a `session_id:*` probe sets `sessions_present` and checks for a `session_id` spanning multiple traces; skip session scope when absent.
- **Phase 2:** mandatory walk-through of four canonical session use cases (goal completion, multi-turn quality, frustration, consistency) + a span → trace → session scope test, with coverage dedup keyed on `(dimension, scope)`.
- **Phase 3C:** session template syntax (`{{traces[*].spans[...]}}`), root-span `filter` matching, 30-min completion window, 10k-span cap, 5% sampling, and session evaluator examples.