### PR TITLE
feat(dd-llmo/experiment-py-bootstrap): introspect task_fn + .env autoload + scripts/references split

### DIFF
--- a/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
@@ -12,7 +12,7 @@ The SDK handles lazy project/experiment creation, dataset push diffing, the 5 MB
 ## Usage
 
 ```
-/llm-obs-experiment-py-bootstrap [--format py|ipynb] [--dataset <path>] [--dataset-name <name>] [--dataset-version <int>] [--project-name <name>] [--evaluator-style function|class|remote] [--jobs <n>] [--output <path>] [--task-source <module:function>] [--placeholder-task] [--app-root <path>]
+/llm-obs-experiment-py-bootstrap [--purpose <free text>] [--format py|ipynb] [--dataset <path>] [--dataset-name <name>] [--dataset-version <int>] [--project-name <name>] [--evaluator-style function|class|remote] [--jobs <n>] [--output <path>] [--task-source <module:function>] [--placeholder-task] [--app-root <path>] [--env-file <path>]
 ```
 
 Arguments: $ARGUMENTS
@@ -35,6 +35,7 @@ All inputs are optional. If the user omits a flag, fall back to the default — 
 | `--placeholder-task` | off | Opt out of application introspection and emit the generic `# TODO(user)` placeholder task. Use when scaffolding without a real app, in tests, or when the user explicitly wants to fill in the task themselves. |
 | `--app-root` | resolved from `pyproject.toml` / `setup.cfg` / `setup.py` / cwd | Root directory the introspection scan is restricted to. Skipped if `--placeholder-task` or `--task-source` is set. |
 | `--env-file` | none — generated file auto-discovers `.env` files at runtime (see Workflow step 4, section 1) | Explicit absolute path to a `.env`-style file. Generated code preloads this path **first** before the auto-discovery walk. Use when your credentials live in a non-standard location (e.g. `~/.config/dd/staging.env`). |
+| `--purpose` | auto — prompted via `AskUserQuestion` in Workflow step 2.0 if not set or inferable from the invocation message | Free-form string describing what the experiment is meant to validate (e.g. `"test that the agent picks the right tool for ambiguous user requests"`, `"verify SQL output always parses"`, `"regression-test prompt v3 against prod baseline"`). Used as reasoning context — biases candidate ranking in Workflow step 2.5, shapes the wrapper return type in 2.5d, seeds evaluator selection in step 3, and is embedded in the generated file's header comment. NOT a fixed taxonomy — Claude reads the string and decides effects dynamically per invocation. |
 
 ---
 
@@ -111,14 +112,16 @@ experiment = LLMObs.experiment(
         # does not surface as chips — config is what users actually see.
         "generated_by": "claude-code",
         "skill": "llm-obs-experiment-py-bootstrap",
+        "purpose": "<one-line purpose from step 2.4>",
     },
-    description="<optional>",
+    description="<one-line purpose from step 2.4>",
     tags={
         # Same provenance, sent to experiment metadata.tags for any future
         # tag-filter UI / API consumers. Always emitted alongside the
         # config copy — never one without the other.
         "generated_by": "claude-code",
         "skill": "llm-obs-experiment-py-bootstrap",
+        "purpose": "<one-line purpose from step 2.4>",
     },
 )
 
@@ -165,6 +168,7 @@ Do **not** load all three. Each reference file is self-contained — code templa
 The same section sequence in both formats. In `.py` these become comment banners; in `.ipynb` each becomes one markdown cell + one code cell.
 
 ```
+0. File header docstring — name, generated_at, purpose (from step 2.4), provider, wired task source.
 1. Env setup           — auto-discover .env files (cwd, app root, parent walk,
                          ~/.datadog/credentials), then os.getenv reads + hard-assert
                          required keys. NO python-dotenv dependency. Shell env wins
@@ -176,8 +180,8 @@ The same section sequence in both formats. In `.py` these become comment banners
                          introspection) and adapted to the SDK signature. Only falls back to a
                          placeholder OpenAI call with # TODO(user) if --placeholder-task is set or
                          no LLM call site was found in the project.
-5. Evaluators          — 2-3 in the requested style
-6. Experiment          — LLMObs.experiment(config={..., "generated_by": "claude-code", ...}, tags={"generated_by": "claude-code", ...})
+5. Evaluators          — 2-3 in the requested style, semantics seeded by the purpose (step 3)
+6. Experiment          — LLMObs.experiment(config={..., "generated_by": "claude-code", "purpose": "...", ...}, tags={...})
 7. Run                 — experiment.run(jobs=N); print(experiment.url)
 8. Results inspection  — experiment.as_dataframe() if pandas, else print
 ```
@@ -217,6 +221,46 @@ The same section sequence in both formats. In `.py` these become comment banners
 
    **Note on dataset IDs.** The public SDK's `LLMObs.pull_dataset(...)` takes a name, not an ID — so there's no `--dataset-id` flag. If a user only has a dataset ID from a Datadog UI URL (`/llm/datasets/<id>`), the workflow is: open that URL in the UI, copy the dataset name, and pass it as `--dataset-name`. The skill must not import `ddtrace.llmobs._experiment` or any other underscore module to work around this.
 
+2.4. **Determine the experiment's purpose.** Capture a one-sentence statement of what the experiment is meant to validate. This becomes a *reasoning input* that biases every downstream step (introspection ranking in 2.5, wrapper shape in 2.5d, evaluator selection in step 3, file header in step 4). It is **not** a fixed taxonomy — the user types whatever describes their goal, and Claude reads it and applies judgment per invocation.
+
+   **Resolution order**:
+
+   1. If `--purpose "<text>"` was passed → use it verbatim. Skip to 2.5.
+   2. If the user's original invocation message contains a clear purpose statement (e.g. *"set up an experiment to test my tool selection logic"*, *"validate that SQL output is always parseable"*, *"regression-test prompt v3"*), extract it and present it back for confirmation via `AskUserQuestion` with the extracted text as a single option labeled "Use the purpose I described" plus "Pick a different purpose" and "Other". If confirmed, use the extracted text. Skip to 2.5.
+   3. Otherwise, prompt with `AskUserQuestion`. The options are **seed prompts**, not a constrained taxonomy — they exist to give the user something to react to. Each "label" maps to a starter sentence that the user can refine; selecting an option uses its starter sentence as `purpose` unless the user provides notes/free text instead.
+
+   **`AskUserQuestion` payload** (use these 5 options verbatim — they cover the common cases without locking the user into them):
+
+   ```
+   question: "What is this experiment meant to validate?"
+   header:   "Purpose"
+   options:
+     - label: "Output accuracy / answer quality"
+       description: "Verify the model produces correct answers compared to expected outputs. Most common starting point."
+     - label: "Tool call correctness"
+       description: "For agent apps — validate the agent picks the right tool with the right arguments. Useful when tool routing is the failure surface."
+     - label: "Structured output / schema validity"
+       description: "Verify the output always conforms to a required shape (JSON, SQL, citation format, etc.)."
+     - label: "Retrieval / RAG faithfulness"
+       description: "Verify the answer is grounded in retrieved documents — no hallucinations beyond the retrieved context."
+     - label: "Refactor / regression test"
+       description: "Check whether a prompt or code change preserves observed behavior. Uses the dataset's expected_output as the ground-truth baseline."
+   ```
+
+   The user picks an option (which becomes the starter sentence), or picks "Other" and writes their own. Either way, the resulting string is the `purpose` carried forward.
+
+   **What to do with the purpose downstream** — Claude reads it and reasons about effects, no static mapping:
+
+   - **In step 2.5 (introspection ranking)**: read the purpose; if it mentions tools / agents → boost candidates with `@LLMObs.agent`, `@workflow`, LangChain `ReActAgent`, or tool-using shapes. If it mentions retrieval / RAG / grounding → boost candidates that import vector stores or call `retrieve`/`query_engine`. If it mentions schema / JSON / SQL → boost candidates that use `response_format`, pydantic, or structured-output APIs. Apply judgment — there's no hardcoded mapping.
+   - **In step 2.5d (wrapper generation)**: if the purpose needs richer signal than just the final output (tool calls, retrieved docs, intermediate state), emit a wrapper that captures it *if the user's function exposes it*. Otherwise emit a `# Note:` comment explaining what the wrapper would ideally return and why a richer return shape would help — do not refactor the user's actual function.
+   - **In step 3 (evaluator template)**: read the purpose and seed the evaluator list to match. Accuracy → standard `exact_match` + LLMJudge. Tool calls → an LLMJudge with a tool-correctness rubric, or a `RemoteEvaluator` if the user has one configured. Schema → `JSONEvaluator(required_keys=[...])` or `RegexMatchEvaluator`. Retrieval → an LLMJudge for groundedness. Regression → `exact_match` + a near-match check. The `--evaluator-style` flag (function / class / remote) still picks the SURFACE; the purpose picks the SEMANTICS.
+   - **In step 4 (file emission)**: include the purpose as a `# Purpose:` comment in the file's docstring header so the user (and reviewers) can see what the experiment was scaffolded for.
+   - **In Output (next-steps)**: surface the resolved purpose in the next-steps block so it's part of the run-summary record.
+
+   **If the user is silent / picks the default option without notes**, use the starter sentence as-is. Never block on this step — there should always be a `purpose` string moving forward, even if it's a generic "Output accuracy / answer quality".
+
+---
+
 2.5. **Discover the task function from the user's application code.** This step replaces the old "placeholder `task_fn`" behavior — an onboarding-grade experiment needs to actually exercise the user's real LLM logic. The skill must do the work, not push it onto the user.
 
    **Skip this entire step if** `--placeholder-task` is set, OR if `--task-source <module>:<function>` is set (in which case use the provided source directly — jump to substep 2.5d). Otherwise:
@@ -255,6 +299,8 @@ The same section sequence in both formats. In `.py` these become comment banners
    | Function file is under `examples/`, `scripts/`, `notebooks/` | **−2** |
    | Function uses LLM SDK at multiple lines (looks like a multi-step orchestration, not just a single call) | **+1** |
 
+   **Apply the experiment purpose from step 2.4 as an additional soft bias on top of these scores.** Read the purpose string and bump candidates whose shape matches what the user is trying to test — agent / tool-using functions for tool-correctness purposes; retrieval / vector-store users for RAG / grounding purposes; structured-output users for schema purposes; etc. Use judgment, not a hardcoded mapping. A purpose-aligned candidate should typically beat a generically-better-named one (+3 to +5 effective bias is reasonable). See step 2.4 "What to do with the purpose downstream" for examples.
+
    Pick the **top 3** candidates and present them to the user as a single short prompt (no `AskUserQuestion` — just a checkpoint prompt in chat):
 
    ```
@@ -287,16 +333,24 @@ The same section sequence in both formats. In `.py` these become comment banners
      - If the user's function takes `**kwargs` or a single dict, pass `input_data` through unmodified.
      - If the user's function is `async`, wrap with `asyncio.run(...)` inside a sync `task_fn` (simplest path; lets `LLMObs.experiment(...).run()` stay sync). Alternative: emit an `async def task_fn` and use `LLMObs.async_experiment(...)` — only do this if the rest of the experiment is already async.
    - **Config passthrough**: never silently drop the `config` argument. If the user's function takes a `config` / `model` / `temperature` parameter, wire `config.get("...")` into it.
-   - **Comment header**: emit a comment block above `task_fn` that names the source function, file, line, and notes any adaptation choices, e.g.:
+   - **Comment header**: emit a comment block above `task_fn` that names the source function, file, line, the experiment purpose (from step 2.4), and any adaptation choices, e.g.:
 
      ```python
      # Task function wired to: <module.path>:<function_name>
-     #   source: <file>:<line>
+     #   source:  <file>:<line>
+     #   purpose: <one-line purpose from step 2.4>
      #   adapter: input_data["<key>"] -> <function_name>(<key>=...)
      #
      # To experiment with prompt / model variants without editing your app, inline
      # the call here instead of importing.
      ```
+
+   - **Richer-return shape when the purpose demands it**: read the purpose from step 2.4. If validating just the final output string is too lossy for what the user is testing (e.g. they're checking tool-call selection — the final string says "I'll book that for you" but the *interesting* signal is which tool was called with which args), emit a wrapper that captures the richer signal **only if the user's function exposes it**. Two cases:
+
+     - **The function already returns richer data** (e.g. `{"output": str, "tool_calls": [...]}`, or a LangChain `AgentExecutor.invoke()` result with `intermediate_steps`): wire `task_fn` to return that shape directly. Evaluators in step 3 will receive it as `output_data`.
+     - **The function returns just a string** but the purpose needs more: emit a `# Note:` comment above `task_fn` explaining what richer shape would help, and how the user could expose it (e.g. *"To capture tool calls for evaluation, refactor `respond(query)` to also return the `intermediate_steps` from your AgentExecutor."*). **Do not refactor the user's function** — emit a note, ship the simple wrapper, let the user choose.
+
+   Never invent a richer return shape that the user's function doesn't actually provide. The wrapper is plumbing, not surgery.
 
    - **Side-effect warning**: scan the chosen function (and its immediate calls within the same module) for these patterns. If any are present, print a `WARNING:` line in the next-steps output, but do NOT alter the import:
 
@@ -338,10 +392,24 @@ The same section sequence in both formats. In `.py` these become comment banners
 
    The template's discovery walk (env file → script dir → cwd → parent dirs → `~/.datadog/credentials`) and shell-overrides-file contract are stable — they live in the template, not in this skill body. If you need to change discovery semantics, edit `scripts/env_setup_template.py` directly; do not re-derive them in-prose here.
 
-3. **Pick evaluator template** based on `--evaluator-style`:
+3. **Pick evaluator template** based on `--evaluator-style` AND the purpose from step 2.4.
+
+   `--evaluator-style` decides the **surface** (function / class / remote — see `references/evaluator-styles/<style>.md` for the syntax shape). The purpose decides the **semantics** — what each evaluator actually measures. Both inputs apply together.
+
+   Default shape (purpose: accuracy / unspecified):
    - `function`: 3 plain functions — one trivial boolean (`exact_match`-style, bare `bool` OK), one richer rule-based check returning `EvaluatorResult` with `reasoning` + `assessment`, and one LLM-as-Judge surrogate. If `--dataset` had structured `expected_output`, add a JSON-shape check (also returning `EvaluatorResult`).
    - `class`: 2 `BaseEvaluator` subclasses with `evaluate(self, context: EvaluatorContext) -> EvaluatorResult`. Always return `EvaluatorResult` (never a bare value) — state-bearing evaluators have richer signal to surface.
    - `remote`: 1-2 `RemoteEvaluator(eval_name=...)` instances with a comment instructing the user to create the judge in the Datadog UI first.
+
+   **Purpose-driven amendments** (read the purpose string from step 2.4 and adjust the default seed accordingly — use natural-language judgment, not a hardcoded lookup):
+
+   - If the purpose mentions **tool calls / agent routing / tool selection**: replace the LLM-as-Judge surrogate with a `tool_calls_correct` LLMJudge whose rubric checks the right-tool-with-right-args question. The rubric should reference `output_data["tool_calls"]` if the wrapper from 2.5d captured them; otherwise check the textual output for the tool name.
+   - If the purpose mentions **groundedness / faithfulness / RAG**: add a `groundedness` LLMJudge that takes `input_data` (the question + retrieved docs) and `output_data` (the answer) and checks that every claim in the answer traces to the docs. Make the rubric explicit about hallucinations being a fail.
+   - If the purpose mentions **structured output / JSON / SQL / schema**: lean into `JSONEvaluator(required_keys=[...])` or `RegexMatchEvaluator(pattern=r"...")` from the built-in set. Add a richer `EvaluatorResult` check for semantic schema-fit if the user's structured output has constraints beyond shape (e.g. enum values, numeric ranges).
+   - If the purpose mentions **regression / refactor / preserve behavior**: prefer `exact_match` as the primary signal, plus a near-match check (`difflib.SequenceMatcher.ratio()` ≥ 0.95 returning `EvaluatorResult` with assessment="partial" between 0.7 and 0.95). Drop the LLMJudge surrogate — regression tests want determinism, not model judgment.
+   - For purposes the SKILL.md doesn't recognize verbatim: read the user's purpose string, reason about what evaluator shape would best measure it, and write the evaluator from scratch. Cite the purpose in a comment above the evaluator so the user can see the link. Never invent a `RemoteEvaluator(eval_name=...)` for a name that may not exist in their Datadog org — when in doubt emit an LLMJudge with an inline rubric instead.
+
+   Whatever you emit, the **count of evaluators stays 2–3** to keep the generated file lean. The user can add more after the first run.
 
    **In all styles**: any evaluator with non-trivial logic must return `EvaluatorResult` populating at minimum `value` + `reasoning` + `assessment` (see the "Return `EvaluatorResult`, not bare values" section). The compare UI uses `reasoning` for per-record drill-downs and `assessment` to determine whether a metric trend is an improvement.
 
@@ -405,19 +473,25 @@ Generated SDK experiment: <format>
 Path: <path>
 Lines: <count>   (or Cells: <count> for .ipynb)
 
+Purpose:
+  "<resolved purpose string from step 2.4>"
+  (sourced via: --purpose flag | extracted from invocation message | AskUserQuestion default | AskUserQuestion + free text)
+
 SDK calls used:
   ✓ LLMObs.enable(...)                       (line/cell ~<N>)
   ✓ LLMObs.<create_dataset|create_dataset_from_csv|pull_dataset>(...)  (line/cell ~<N>)
   ✓ task_fn(input_data, config)              (line/cell ~<N>)
-  ✓ <N> evaluators (style: <function|class|remote>)
+  ✓ <N> evaluators (style: <function|class|remote>, semantics seeded by purpose)
   ✓ LLMObs.experiment(...).run(jobs=<N>)     (line/cell ~<N>)
-  ✓ Provenance (in config + tags): generated_by=claude-code, skill=llm-obs-experiment-py-bootstrap
+  ✓ Provenance (in config + tags): generated_by=claude-code, skill=llm-obs-experiment-py-bootstrap, purpose=...
 
 Task function source:
   ✓ Wired to: <module.path>:<function_name>   (source: <file>:<line>)
   ✓ Adapter: <one line describing the input_data → call shape mapping>
+  ✓ Return shape: <plain string | {output, tool_calls} | {answer, retrieved_docs} | etc.>
   ✓ Sync/async: <sync | async (wrapped with asyncio.run)>
   [WARNING lines from the side-effect scan in Workflow step 2.5d, if any]
+  [Note line if the purpose requested richer return shape but the function only exposes a string]
 
 (If --placeholder-task was used or introspection found nothing:)
 Task function source:
@@ -455,9 +529,13 @@ Run:
 Next steps:
 1. Confirm the wired task_fn matches the entry point you want to evaluate (see "Task function source" above).
    Edit the import in section 4 of the generated file if you'd rather inline the call or pick a different function.
-2. Adjust the evaluators (or wire up RemoteEvaluator names you created in the Datadog UI).
-3. Run it. The script prints experiment.url at the end.
-4. Watch the experiment: https://app.datadoghq.com/llm/experiments
+2. Confirm the purpose ("<purpose string>") matches what you actually want to measure — section 0 of the
+   file documents it, section 5's evaluators were seeded against it, and section 6's experiment carries
+   it as a config tag. Re-run this skill with `--purpose "<new text>"` to regenerate against a different
+   target without changing your code.
+3. Adjust the evaluators if needed (or wire up RemoteEvaluator names you created in the Datadog UI).
+4. Run it. The script prints experiment.url at the end.
+5. Watch the experiment: https://app.datadoghq.com/llm/experiments
 ```
 
 ---
@@ -521,11 +599,13 @@ Never invent symbols or behaviors not present in this skill body or the docs abo
 - **Provider-key asserts must match the wired task.** Generate the assert for `OPENAI_API_KEY` only if the task imports / calls OpenAI; same for Anthropic / Gemini / Bedrock / etc. Per the Workflow step 2.6 table. Never emit asserts for provider keys the task does not actually need — they're confusing and cause spurious "missing key" failures.
 - **Always pass `site=` to `LLMObs.enable()`.** Read it from `os.getenv("DD_SITE", "datadoghq.com")`. Omitting `site=` silently defaults to US1 prod, which breaks every non-prod org (e.g. staging `datad0g.com`, `datadoghq.eu`). The canonical signature already includes it — never drop it.
 - **Per-record `tags` are `"key:value"` strings.** When inlining records (whether from `--dataset` JSON, CSV, or the default sample), each entry in a record's `"tags"` list must be a `"key:value"` string like `"env:prod"`, `"source:traces"`, `"category:geography"`. Bare strings (`"smoke"`, `"baseline"`) trigger `ValueError: Tag '<name>' is malformed.` at `Dataset.append()` time. If the source data has bare-string tags, namespace them — e.g. wrap `"smoke"` as `"tag:smoke"` rather than dropping it.
+- **Always resolve a purpose before generating.** Step 2.4 must produce a non-empty `purpose` string before steps 2.5 / 3 / 4 run. If the user provides one via `--purpose` or in their invocation, use it. Otherwise prompt via `AskUserQuestion` with the 5 seed options + Other. Never skip the prompt; never proceed with a blank purpose. A weak purpose ("test it") is still better than no purpose — generic accuracy semantics will at least seed reasonable defaults.
+- **Treat the purpose as reasoning input, not a switch statement.** There is no hardcoded mapping from purpose strings to evaluator code or wrapper shape. Read the purpose, reason about what's being measured, and emit appropriately. The same purpose string may produce different output for two different apps (a tool-call purpose in a LangChain app generates different wrapper code than in a raw OpenAI app) — that's expected.
 - **Introspect first, placeholder last.** The default behavior is Workflow step 2.5 — scan the user's app, find the LLM entry point, wire `task_fn` to it. A `# TODO(user)` marker in the task section is only acceptable when introspection genuinely found nothing or the user passed `--placeholder-task`. Never emit a placeholder task when a real candidate exists in the project — that's the failure mode this skill exists to fix.
 - **`# TODO(user)` markers on at least one evaluator** so reviewers can't ship un-customized evaluators by accident. (Evaluators stay user-owned even when the task is auto-wired.)
 - **Introspection is bounded.** The scan in Workflow step 2.5 must respect `--app-root` (or its default-resolved value), `.gitignore` if present, and the directory blocklist (`node_modules`, `.venv`, `__pycache__`, etc.). Refuse to scan `/` or `~`. If a scan would touch more than ~10k Python files, narrow the root or ask the user to point at the relevant subdirectory.
 - **Match notebook conventions.** Plain function evaluators by default; class-based only when the user opts in. Print `experiment.url` at the end of every generated file.
-- **Tag every experiment with provenance — in both `config` and `tags`.** Every `LLMObs.experiment(...)` call **must** carry `"generated_by": "claude-code"` and `"skill": "llm-obs-experiment-py-bootstrap"` as keys in **both** the `config={...}` dict (so they render in the experiment's Configuration view, which is where users actually look) **and** the `tags={...}` dict (which the SDK serializes into `metadata.tags` for future tag-filter consumers). The `tags=` path alone is not enough: the current LLM Experiments UI does not surface `metadata.tags` as filterable chips, so users won't see the provenance unless it's also in `config`. If a user later edits the generated file to add their own keys, they extend both dicts — never replace the provenance keys silently.
+- **Tag every experiment with provenance + purpose — in both `config` and `tags`.** Every `LLMObs.experiment(...)` call **must** carry `"generated_by": "claude-code"`, `"skill": "llm-obs-experiment-py-bootstrap"`, AND `"purpose": "<step 2.4 string>"` as keys in **both** the `config={...}` dict (so they render in the experiment's Configuration view, which is where users actually look) **and** the `tags={...}` dict (which the SDK serializes into `metadata.tags` for future tag-filter consumers). The `tags=` path alone is not enough: the current LLM Experiments UI does not surface `metadata.tags` as filterable chips, so users won't see the values unless they're also in `config`. The `purpose` field is what makes future runs of the same experiment discoverable by intent — without it, users see ten experiments with cryptic names and no idea what each was testing. Also set `description="<purpose>"` on the experiment so the UI list view shows it.
 - **PII scrub at the door.** If `--dataset` is given, scrub before inlining into the generated file. Never embed a record that contains an unmasked email/phone/SSN/API-key pattern.
 - **Don't generate `requirements.txt` or `pyproject.toml`.** Print the `pip install` command in the next-steps message instead — most users already have a venv.
 - **No silent fallbacks.** If `--format` is unsupported, error out with the valid choices.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
@@ -3,6 +3,29 @@ name: llm-obs-experiment-py-bootstrap
 description: Generates a self-contained Python experiment client that uses the ddtrace.llmobs SDK. Emits either a runnable .py script or a Jupyter .ipynb notebook matching the canonical DataDog reference notebook style. Use when the user says "generate Python experiment", "write an SDK experiment", "create a ddtrace experiment", "Python notebook experiment", "use the LLM Obs SDK", or has `ddtrace` installed and wants idiomatic SDK code.
 ---
 
+## Backend
+
+**Detection** — At the start of every invocation, before taking any action, determine which backend (if any) to use for the startup beacon call:
+
+1. If the user passed `--backend pup` anywhere in their invocation → use **pup mode** for the beacon. Skip steps 2–3.
+2. Check whether MCP tools are present in your active tool list. The canonical signal is whether `mcp__datadog-llmo-mcp__list_llmobs_evals` appears in your available tools. If present → use **MCP mode**.
+3. If MCP tools are absent → check whether `pup` is executable via `pup --version`. If responding → use **pup mode**.
+4. If neither is available → **skip the beacon silently** and proceed to codegen. This skill is primarily local (introspection + file emission) and does not require backend access; the beacon is for usage attribution only.
+
+**Invocation ID:** At the very start of each invocation, before any MCP/pup call, generate an 8-character hex invocation ID (e.g., `3a9f1c2b`). Keep it constant for the entire invocation.
+
+**Intent tagging:** On every MCP tool call, prefix `telemetry.intent` with `skill:llm-obs-experiment-py-bootstrap[<inv_id>] — ` followed by a description of why the tool is being called. On the **first MCP tool call only** (the startup beacon below), use `skill:llm-obs-experiment-py-bootstrap:start[<inv_id>] — ` instead (note the `:start` suffix).
+
+**Startup beacon:** Immediately after parsing arguments (workflow step 1, before dataset resolution in step 2), issue exactly one beacon call to register skill usage and validate backend connectivity. This is fire-and-forget — surface any error as a one-line `Note:` to the user but do not block codegen.
+
+- **MCP mode:** call `mcp__datadog-llmo-mcp__list_llmobs_evals` with `telemetry.intent = "skill:llm-obs-experiment-py-bootstrap:start[<inv_id>] — Skill startup: register usage and verify Datadog connectivity"`. Discard the response payload; the call's purpose is the telemetry tag.
+- **pup mode:** run `pup llm-obs evals list --limit 1` via Bash. Pup carries its own telemetry; no intent prefix needed.
+- **No backend:** print one line `(Telemetry beacon skipped — no Datadog backend detected; this is informational only and does not affect codegen.)` and proceed.
+
+The beacon **must not** fail the skill. If the call errors (auth, network, etc.), surface a one-line note and continue.
+
+---
+
 # LLM Obs Experiment (Python) Bootstrap — Generate a Python Experiment Using `ddtrace.llmobs`
 
 Produce a single self-contained Python experiment that uses the official **`ddtrace.llmobs` SDK**. Output is either a `.py` script or an `.ipynb` notebook. The generated code mirrors the patterns shown in DataDog's reference notebooks at <https://github.com/DataDog/llm-observability/tree/main/experiments/notebooks>.
@@ -202,6 +225,8 @@ The same section sequence in both formats. In `.py` these become comment banners
    The final project name is `experiment-<service-name>`. Strip a leading `experiment-` from `<service-name>` if it already starts with one (so a package literally named `experiment-foo` yields `experiment-foo`, not `experiment-experiment-foo`). If none of the five sources resolve to a non-empty string, fall back to `experiment-sdk-default` and emit a warning in the next-steps output that the user should set `--project-name` explicitly.
 
    Embed the resolved name as a string literal in the generated `PROJECT_NAME = "..."` line — don't emit runtime `os.getcwd()` lookups, since the user may run the file from a different directory than where the skill resolved it.
+
+1.5. **Startup beacon.** Per the **Backend** section above: generate an 8-character hex invocation ID, then issue the single beacon call (MCP `list_llmobs_evals` tagged with `skill:llm-obs-experiment-py-bootstrap:start[<inv_id>] — Skill startup: ...`, or pup equivalent, or skip if no backend). Surface any error as a one-line `Note:` and proceed regardless — the beacon is for usage attribution and connectivity validation only; it never blocks codegen.
 
 2. **Resolve the dataset source.** Error out if both `--dataset` and `--dataset-name` are passed — they're mutually exclusive.
 

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md
@@ -12,7 +12,7 @@ The SDK handles lazy project/experiment creation, dataset push diffing, the 5 MB
 ## Usage
 
 ```
-/llm-obs-experiment-py-bootstrap [--format py|ipynb] [--dataset <path>] [--dataset-name <name>] [--dataset-version <int>] [--project-name <name>] [--evaluator-style function|class|remote] [--jobs <n>] [--output <path>]
+/llm-obs-experiment-py-bootstrap [--format py|ipynb] [--dataset <path>] [--dataset-name <name>] [--dataset-version <int>] [--project-name <name>] [--evaluator-style function|class|remote] [--jobs <n>] [--output <path>] [--task-source <module:function>] [--placeholder-task] [--app-root <path>]
 ```
 
 Arguments: $ARGUMENTS
@@ -31,6 +31,10 @@ All inputs are optional. If the user omits a flag, fall back to the default — 
 | `--evaluator-style` | `function` | `function` (plain functions — notebook default), `class` (`BaseEvaluator` subclasses), or `remote` (`RemoteEvaluator` instances). |
 | `--jobs` | `10` | Passed to `experiment.run(jobs=N)`. |
 | `--output` | `./experiments/experiment.<ext>` | File extension derives from `--format`: `.py` or `.ipynb`. |
+| `--task-source` | auto — discovered by application introspection (see Workflow step 2.5) | Explicit override: `<dotted.module.path>:<function_name>` for the function to wrap as `task_fn`. Use when you already know the entry point and want to skip the introspection scan. |
+| `--placeholder-task` | off | Opt out of application introspection and emit the generic `# TODO(user)` placeholder task. Use when scaffolding without a real app, in tests, or when the user explicitly wants to fill in the task themselves. |
+| `--app-root` | resolved from `pyproject.toml` / `setup.cfg` / `setup.py` / cwd | Root directory the introspection scan is restricted to. Skipped if `--placeholder-task` or `--task-source` is set. |
+| `--env-file` | none — generated file auto-discovers `.env` files at runtime (see Workflow step 4, section 1) | Explicit absolute path to a `.env`-style file. Generated code preloads this path **first** before the auto-discovery walk. Use when your credentials live in a non-standard location (e.g. `~/.config/dd/staging.env`). |
 
 ---
 
@@ -84,7 +88,9 @@ dataset = LLMObs.pull_dataset(
 )
 
 def task_fn(input_data: dict, config: dict):
-    # TODO(user): replace with your actual LLM call
+    # In real output, this is wired to the user's discovered LLM call site via
+    # Workflow step 2.5. Only emits as a generic placeholder (with # TODO(user))
+    # when --placeholder-task is set or introspection found nothing.
     ...
 
 # Plain function evaluator (default style)
@@ -124,7 +130,7 @@ print(experiment.url)
 
 ## Evaluator Styles
 
-Generated code uses **one** of three evaluator surfaces, picked by `--evaluator-style`. Whichever style is chosen, **prefer returning `EvaluatorResult` over a bare `bool`/`float`** whenever the evaluator has any signal beyond the raw value — see "Return EvaluatorResult, not bare values" below.
+Generated code uses **one** of three evaluator surfaces, picked by `--evaluator-style`. The detail for each lives in `references/evaluator-styles/<style>.md` and is loaded on demand — only the chosen style is consulted at generation time. The single piece of guidance that applies to all three is the `EvaluatorResult` rule below.
 
 ### Return `EvaluatorResult`, not bare values
 
@@ -138,79 +144,19 @@ Plain functions are allowed to return `bool` / `float` / `dict`, and `BaseEvalua
 | `metadata` | `dict[str, JSONType]` | Free-form per-record context (e.g. `{"confidence": 0.95}`); shown in record drill-down. |
 | `tags` | `dict[str, JSONType]` | Used to slice experiment results in the UI (e.g. `{"category": "accuracy"}`). |
 
-The generated code should default to `EvaluatorResult` for any evaluator richer than a one-line equality check. The trivial `exact_match` and `length_under_500` shown below are the only cases where a bare `bool` is acceptable.
+Default to `EvaluatorResult` for any evaluator richer than a one-line equality check. Trivial checks like `exact_match` and `length_under_500` are the only cases where a bare `bool` is acceptable.
 
-### `function` (default — what the notebooks use)
+### Style router
 
-Plain Python functions with the signature `(input_data, output_data, expected_output)`. Always emit at least three: a trivial boolean (returns `bool`), a richer rule-based one (returns `EvaluatorResult`), and an LLM-as-Judge surrogate (a `RemoteEvaluator` reference or a placeholder).
+When `--evaluator-style` is resolved (default `function`), read the matching reference file from `<this-skill-dir>/references/evaluator-styles/` and emit section 5 of the generated file using the code template it contains:
 
-```python
-from ddtrace.llmobs import EvaluatorResult
+| `--evaluator-style` value | Read | Best for |
+|---|---|---|
+| `function` *(default)* | `references/evaluator-styles/function.md` | Most cases — matches the canonical notebook style |
+| `class` | `references/evaluator-styles/class.md` | Evaluators that need persistent state or an async client |
+| `remote` | `references/evaluator-styles/remote.md` | Server-side LLM-as-Judge configured in the Datadog UI, reused across experiments |
 
-# Trivial check — bare bool is fine here, the result has no extra signal.
-def exact_match(input_data, output_data, expected_output) -> bool:
-    return output_data == expected_output
-
-# Richer check — use EvaluatorResult so reasoning/assessment surface in the UI.
-def response_well_formed(input_data, output_data, expected_output) -> EvaluatorResult:
-    if not isinstance(output_data, str):
-        return EvaluatorResult(
-            value=False,
-            reasoning=f"output_data was {type(output_data).__name__}, expected str",
-            assessment="fail",
-        )
-    if len(output_data) > 500:
-        return EvaluatorResult(
-            value=False,
-            reasoning=f"output exceeded 500 chars (was {len(output_data)})",
-            assessment="fail",
-            metadata={"length": len(output_data)},
-        )
-    return EvaluatorResult(value=True, assessment="pass")
-```
-
-### `class` (advanced — for evaluators that need state or async I/O)
-
-Always return `EvaluatorResult` from `evaluate()` — never a bare value. State-bearing evaluators usually have richer reasoning to surface anyway.
-
-```python
-from ddtrace.llmobs import BaseEvaluator, EvaluatorContext, EvaluatorResult
-
-class FaithfulnessJudge(BaseEvaluator):
-    def __init__(self):
-        super().__init__(name="faithfulness")
-        # TODO(user): initialize any client or state here
-
-    def evaluate(self, context: EvaluatorContext) -> EvaluatorResult:
-        # context exposes: input_data, output_data, expected_output, metadata
-        # TODO(user): replace placeholder logic with your faithfulness check
-        passed = context.output_data is not None
-        return EvaluatorResult(
-            value=1.0 if passed else 0.0,
-            reasoning="placeholder — replace with your faithfulness rubric",
-            assessment="pass" if passed else "fail",
-            metadata={"evaluator_version": "v1"},
-        )
-```
-
-### `remote` (LLM-as-Judge running server-side)
-
-```python
-from ddtrace.llmobs import RemoteEvaluator
-
-# Create the judge in Datadog UI first: LLM Observability → Evaluations → New Evaluator
-quality_judge = RemoteEvaluator(eval_name="<name-from-datadog-ui>")
-
-# Optional: customize the payload the judge receives
-custom_judge = RemoteEvaluator(
-    eval_name="<name>",
-    transform_fn=lambda ctx: {
-        "question": ctx.input_data.get("question"),
-        "answer": ctx.output_data,
-        "reference": ctx.expected_output,
-    },
-)
-```
+Do **not** load all three. Each reference file is self-contained — code template + when-to-use + when-not-to-use guidance.
 
 ---
 
@@ -219,10 +165,17 @@ custom_judge = RemoteEvaluator(
 The same section sequence in both formats. In `.py` these become comment banners; in `.ipynb` each becomes one markdown cell + one code cell.
 
 ```
-1. Env setup           — load_dotenv(), os.getenv reads, hard assert keys present
+1. Env setup           — auto-discover .env files (cwd, app root, parent walk,
+                         ~/.datadog/credentials), then os.getenv reads + hard-assert
+                         required keys. NO python-dotenv dependency. Shell env wins
+                         over file-loaded values. Only the provider keys actually
+                         needed by the wired task_fn are asserted (see step 2.5).
 2. LLMObs.enable()     — explicit api_key/app_key/project_name/agentless_enabled
 3. Dataset             — inline records OR create_dataset_from_csv
-4. Task function       — placeholder OpenAI call with # TODO(user) marker
+4. Task function       — REAL task function imported from the user's app (via Workflow step 2.5
+                         introspection) and adapted to the SDK signature. Only falls back to a
+                         placeholder OpenAI call with # TODO(user) if --placeholder-task is set or
+                         no LLM call site was found in the project.
 5. Evaluators          — 2-3 in the requested style
 6. Experiment          — LLMObs.experiment(config={..., "generated_by": "claude-code", ...}, tags={"generated_by": "claude-code", ...})
 7. Run                 — experiment.run(jobs=N); print(experiment.url)
@@ -263,6 +216,127 @@ The same section sequence in both formats. In `.py` these become comment banners
      - Fall back to the inline 3-record sample described under `--dataset`'s default, so the generated file remains runnable as-is.
 
    **Note on dataset IDs.** The public SDK's `LLMObs.pull_dataset(...)` takes a name, not an ID — so there's no `--dataset-id` flag. If a user only has a dataset ID from a Datadog UI URL (`/llm/datasets/<id>`), the workflow is: open that URL in the UI, copy the dataset name, and pass it as `--dataset-name`. The skill must not import `ddtrace.llmobs._experiment` or any other underscore module to work around this.
+
+2.5. **Discover the task function from the user's application code.** This step replaces the old "placeholder `task_fn`" behavior — an onboarding-grade experiment needs to actually exercise the user's real LLM logic. The skill must do the work, not push it onto the user.
+
+   **Skip this entire step if** `--placeholder-task` is set, OR if `--task-source <module>:<function>` is set (in which case use the provided source directly — jump to substep 2.5d). Otherwise:
+
+   **2.5a — Resolve the app root.** If `--app-root <path>` was supplied, use it. Otherwise use the directory containing whichever of these resolved during step 1 (in order): `pyproject.toml`, `setup.cfg`, `setup.py`, `package.json`. If none of those resolved, use the current working directory. **Hard cap** the scan to that directory tree; do **not** traverse `node_modules`, `.venv`, `venv`, `__pycache__`, `.git`, `dist`, `build`, `target`, `vendor`, `third_party`, or any directory matched by `.gitignore` if present. Refuse to scan if the resolved root is `/` or `~` — that means resolution failed; treat as no candidate found.
+
+   **2.5b — Candidate discovery.** Use Grep / Bash to find Python files inside the app root and identify call sites of these LLM SDKs (the union of common LLM clients):
+
+   | Module / call pattern | Signal |
+   |---|---|
+   | `openai.ChatCompletion.create`, `openai.chat.completions.create`, `client.chat.completions.create` | OpenAI chat |
+   | `openai.completions.create`, `client.completions.create` | OpenAI text |
+   | `anthropic.messages.create`, `client.messages.create`, `Anthropic(...).messages.create` | Anthropic |
+   | `litellm.completion`, `litellm.acompletion` | LiteLLM (router) |
+   | `langchain.*.invoke`, `ChatOpenAI(...)`, `ChatAnthropic(...)`, `LLMChain(...)` | LangChain |
+   | `from llama_index`, `as_query_engine`, `as_chat_engine` | LlamaIndex |
+   | `google.generativeai.GenerativeModel(...).generate_content` | Vertex/Gemini |
+   | `boto3.client("bedrock-runtime").invoke_model` | AWS Bedrock |
+   | `@LLMObs.llm`, `@LLMObs.agent`, `@LLMObs.workflow`, `@LLMObs.task`, `@workflow`, `@agent` | Already instrumented |
+
+   For each match, walk **up** to the enclosing function (`def` / `async def`) — call it the *call-site function*. Record `{file, line, function_name, is_async, signature, enclosing_class}`.
+
+   **Skip** files matching `test_*.py`, `*_test.py`, `tests/**`, `conftest.py`, `*_fixtures.py`. Skip private helpers (`def _foo` where the function is the *only* one in the file and looks like a utility — judge by whether it has a typed string input).
+
+   **2.5c — Score and rank candidates.** Score each candidate; higher is more likely to be the "core" entry point:
+
+   | Signal | Score delta |
+   |---|---|
+   | Function name in {`generate`, `chat`, `complete`, `respond`, `answer`, `handle_request`, `process_query`, `process_message`, `run`, `predict`, `infer`, `call_llm`, `query`, `agent_loop`, `main`} | **+5** |
+   | Function takes exactly one or two parameters, at least one being a `str` or `dict` | **+3** |
+   | Function is decorated with any `@LLMObs.*` / `@workflow` / `@agent` decorator | **+5** (this is the *intended* instrumentation point) |
+   | Function is at the top of its module (first non-import block) | **+2** |
+   | Module path matches `**/{main,app,api,handlers,server,routes,agent,bot,chat}.py` | **+3** |
+   | Function is a class method (`self` first arg) but the class name matches `*Agent`, `*Bot`, `*Handler`, `*Service` | **+2** |
+   | Function name starts with `_` and module has other non-underscore candidates | **−3** (likely a helper) |
+   | Function file is under `examples/`, `scripts/`, `notebooks/` | **−2** |
+   | Function uses LLM SDK at multiple lines (looks like a multi-step orchestration, not just a single call) | **+1** |
+
+   Pick the **top 3** candidates and present them to the user as a single short prompt (no `AskUserQuestion` — just a checkpoint prompt in chat):
+
+   ```
+   ## Task function discovery
+
+   Scanned `<app_root>` and found <N> LLM-calling functions. Top candidates:
+
+   1. `<module.path>:<function_name>`   score <S>   (<file>:<line>, args=<sig>)
+   2. ...
+   3. ...
+
+   I'll wire candidate **1** as the experiment's task function unless you say otherwise.
+   Reply with the number to pick a different candidate, or "placeholder" to emit a
+   generic placeholder task instead.
+   ```
+
+   Wait for confirmation. If the user is silent / says "go" / says "1", use #1. If they pick another number, use that. If they say "placeholder", set `--placeholder-task` semantics and skip to step 3. If the user supplies a different `module:function`, validate it exists, then use it.
+
+   **If zero candidates were found**, do not block the user — print a one-line note ("No LLM call sites detected under `<app_root>`. Emitting a generic placeholder task — replace it before running.") and fall through with placeholder semantics.
+
+   **2.5d — Generate the task function wrapper.** Once a target `<module>:<function>` is locked in, emit a real `task_fn` that imports and calls the user's function. This is **section 4** of the generated file ("Task function") and must NOT include `# TODO(user)` markers if introspection succeeded — the whole point is to remove that burden.
+
+   Wrapper construction rules:
+
+   - **Import**: emit `from <module> import <function_name>` at the top of section 4 (NOT at the top of the file — keeping it local makes the section self-contained and easy to swap). If the function is a class method, also import the class and instantiate it lazily inside `task_fn` (default `__init__()`, with a `# TODO: pass constructor args if needed` comment only if the constructor takes required arguments).
+   - **Signature adaptation**: the SDK's task function signature is `task_fn(input_data: dict, config: dict) -> Any`. The user's function probably has a different signature. Build a small adapter:
+
+     - If the user's function takes one parameter and the dataset's `input_data` looks like `{"<key>": <value>}` with one key, call `<function_name>(input_data["<key>"])`.
+     - If the user's function takes multiple parameters, map them by name from `input_data` keys. If a name doesn't match, fall back to positional via `input_data.values()` order but emit a one-line comment flagging the assumption.
+     - If the user's function takes `**kwargs` or a single dict, pass `input_data` through unmodified.
+     - If the user's function is `async`, wrap with `asyncio.run(...)` inside a sync `task_fn` (simplest path; lets `LLMObs.experiment(...).run()` stay sync). Alternative: emit an `async def task_fn` and use `LLMObs.async_experiment(...)` — only do this if the rest of the experiment is already async.
+   - **Config passthrough**: never silently drop the `config` argument. If the user's function takes a `config` / `model` / `temperature` parameter, wire `config.get("...")` into it.
+   - **Comment header**: emit a comment block above `task_fn` that names the source function, file, line, and notes any adaptation choices, e.g.:
+
+     ```python
+     # Task function wired to: <module.path>:<function_name>
+     #   source: <file>:<line>
+     #   adapter: input_data["<key>"] -> <function_name>(<key>=...)
+     #
+     # To experiment with prompt / model variants without editing your app, inline
+     # the call here instead of importing.
+     ```
+
+   - **Side-effect warning**: scan the chosen function (and its immediate calls within the same module) for these patterns. If any are present, print a `WARNING:` line in the next-steps output, but do NOT alter the import:
+
+     | Pattern | Warning |
+     |---|---|
+     | `os.environ[...]` reads beyond LLM API keys | "Task reads env vars beyond LLM credentials — make sure they're set when running the experiment." |
+     | `requests.`, `httpx.`, `aiohttp.` calls to non-LLM-provider URLs | "Task makes external HTTP calls — running the experiment will hit those endpoints." |
+     | DB drivers (`psycopg2`, `sqlalchemy`, `pymongo`, `redis`, `boto3` ≠ bedrock) | "Task hits a database — point at a non-prod instance before running." |
+     | File I/O writes (`open(..., 'w')`, `Path.write_*`) | "Task writes to disk — make sure the path is safe in your experiment env." |
+
+   - **Fallback to placeholder**: if `--placeholder-task` is set OR the introspection picked nothing, emit the original placeholder block (generic OpenAI call with `# TODO(user)`). This is the only path where `TODO(user)` is allowed in the task section.
+
+2.6. **Determine required credentials and emit the env-setup section.** The generated experiment must work without the user pre-exporting anything in their shell, *as long as* a discoverable `.env` lives in a standard location. Don't push setup work onto the user that the file can do itself.
+
+   **Required Datadog keys** (always): `DD_API_KEY` AND (`DD_APPLICATION_KEY` OR `DD_APP_KEY`). `DD_SITE` is optional (defaults to `datadoghq.com`).
+
+   **Required provider keys** — depend on what step 2.5 picked. Inspect the imported call site to identify the provider, then **read the matching reference file** for the exact assert lines, adapter notes, and gotchas. Only load the one that applies; do not load all of them.
+
+   | Detected SDK in task | Read |
+   |---|---|
+   | OpenAI (`openai.*`, `client.chat.completions.create`) — also the placeholder fallback | `references/providers/openai.md` |
+   | Azure OpenAI (`AzureOpenAI(...)`, `azure_endpoint=`) | `references/providers/openai.md` (Azure section) |
+   | Anthropic (`anthropic.*`, `Anthropic().messages.create`) | `references/providers/anthropic.md` |
+   | LiteLLM (`litellm.completion`, `litellm.acompletion`) | `references/providers/litellm.md` |
+   | LangChain (`ChatOpenAI` / `ChatAnthropic` / etc.) | `references/providers/langchain.md` (walks one level deeper to the underlying provider) |
+   | LlamaIndex | `references/providers/llamaindex.md` |
+   | Google Gemini (`google.generativeai`) / Vertex AI | `references/providers/gemini.md` |
+   | AWS Bedrock (`boto3.client("bedrock-runtime")`) | `references/providers/bedrock.md` |
+   | Custom / not-recognized SDK | No reference file — emit a `# TODO(user): set the API key(s) your task_fn needs in your .env or shell.` comment instead of an assert. Do NOT fabricate provider keys. |
+
+   **Emit section 1 by reading the shipped template at `<this-skill-dir>/scripts/env_setup_template.py` and substituting two placeholders.** The template ships alongside this SKILL.md (`cp -r` install handles it) and is the canonical source for the loader + assert shape — do **not** re-derive it inline. Read the file, perform the substitutions below, and emit the result verbatim as section 1 of the generated experiment file.
+
+   | Placeholder | Replacement | Example |
+   |---|---|---|
+   | `{{ENV_FILE_OVERRIDE_LIST}}` | A Python list literal of absolute paths from `--env-file` (repeatable; empty list if not passed) | `[]` or `["/Users/me/.config/dd/staging.env"]` |
+   | `{{PROVIDER_ASSERTS}}` | Zero or more `assert os.getenv(...)` lines derived from what step 2.5 wired — per the SDK-to-key table above. One line per required provider key. Empty string if the task uses LiteLLM (which auto-routes) or a custom/unrecognized SDK. | `assert os.getenv("ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY is required for the wired task_fn."` |
+
+   The exact assert line(s) to substitute into `{{PROVIDER_ASSERTS}}` live in each provider's reference file under the `## {{PROVIDER_ASSERTS}} substitution` heading. Read only the file that matches the detected SDK from the table above.
+
+   The template's discovery walk (env file → script dir → cwd → parent dirs → `~/.datadog/credentials`) and shell-overrides-file contract are stable — they live in the template, not in this skill body. If you need to change discovery semantics, edit `scripts/env_setup_template.py` directly; do not re-derive them in-prose here.
 
 3. **Pick evaluator template** based on `--evaluator-style`:
    - `function`: 3 plain functions — one trivial boolean (`exact_match`-style, bare `bool` OK), one richer rule-based check returning `EvaluatorResult` with `reasoning` + `assessment`, and one LLM-as-Judge surrogate. If `--dataset` had structured `expected_output`, add a JSON-shape check (also returning `EvaluatorResult`).
@@ -339,23 +413,48 @@ SDK calls used:
   ✓ LLMObs.experiment(...).run(jobs=<N>)     (line/cell ~<N>)
   ✓ Provenance (in config + tags): generated_by=claude-code, skill=llm-obs-experiment-py-bootstrap
 
+Task function source:
+  ✓ Wired to: <module.path>:<function_name>   (source: <file>:<line>)
+  ✓ Adapter: <one line describing the input_data → call shape mapping>
+  ✓ Sync/async: <sync | async (wrapped with asyncio.run)>
+  [WARNING lines from the side-effect scan in Workflow step 2.5d, if any]
+
+(If --placeholder-task was used or introspection found nothing:)
+Task function source:
+  ⚠ Placeholder task emitted (no real LLM call site found / opted out).
+    Replace `task_fn` with your actual LLM call before running.
+
 Syntax check: <pass | skipped: toolchain missing | fail with details>
 
 Install:
-  pip install "ddtrace>=4.7" python-dotenv openai
+  pip install "ddtrace>=4.7" <provider-sdk-if-needed>
+  # python-dotenv is NOT required — the generated file ships its own .env loader.
 
-Environment variables (required at runtime):
-  export DD_API_KEY=...
-  export DD_APPLICATION_KEY=...
-  export DD_SITE=datadoghq.com
-  export OPENAI_API_KEY=...   # only if you keep the placeholder task
+Credentials:
+  The generated file auto-discovers .env files at runtime. Discovery order
+  (first non-empty value wins per key; shell env always overrides files):
+    1. --env-file path baked in as ENV_FILE_OVERRIDE (if --env-file was passed)
+    2. <output-file's-directory>/.env
+    3. <output-file's-directory>/.env.local
+    4. <cwd>/.env  and  <cwd>/.env.local
+    5. parent-walk from cwd up to /
+    6. ~/.datadog/credentials
+
+  Drop a .env at any of those locations with at minimum:
+    DD_API_KEY=...
+    DD_APPLICATION_KEY=...
+    DD_SITE=datadoghq.com           # only if not the US1 prod site
+    <PROVIDER>_API_KEY=...           # the provider key the wired task needs
+  Or override on a per-run basis by exporting them in your shell — the loader
+  never overwrites a value that is already in os.environ.
 
 Run:
   python <path>                  # for --format py
   jupyter notebook <path>        # for --format ipynb
 
 Next steps:
-1. Replace the placeholder task_fn with your actual LLM call.
+1. Confirm the wired task_fn matches the entry point you want to evaluate (see "Task function source" above).
+   Edit the import in section 4 of the generated file if you'd rather inline the call or pick a different function.
 2. Adjust the evaluators (or wire up RemoteEvaluator names you created in the Datadog UI).
 3. Run it. The script prints experiment.url at the end.
 4. Watch the experiment: https://app.datadoghq.com/llm/experiments
@@ -418,9 +517,13 @@ Never invent symbols or behaviors not present in this skill body or the docs abo
 - **SDK only.** No `requests.post`, no manual JSON:API envelope construction, no manual ID generation. If a feature seems to require those, you're solving the wrong problem — the SDK already covers it.
 - **Public imports only.** `from ddtrace.llmobs import ...`. Never `_experiment`, `_llmobs`, or any underscore-prefixed module.
 - **Env vars, not literals.** Credentials always read from `os.environ`. The generated `main()` (or the env-setup cell) must `assert` they're set with a clear message.
+- **Auto-discover, don't push setup work onto the user.** Section 1 always emits the `_load_env_files` helper (no `python-dotenv` dependency). It walks the discovery order documented in Workflow step 2.6 and prints which file(s) it loaded. Never substitute `load_dotenv()` from the third-party `python-dotenv` package — the inline helper has zero dependencies and is identical in behavior. Shell env vars always win over file-loaded values so the user can override any auto-discovered value by `export <KEY>=...` before re-running.
+- **Provider-key asserts must match the wired task.** Generate the assert for `OPENAI_API_KEY` only if the task imports / calls OpenAI; same for Anthropic / Gemini / Bedrock / etc. Per the Workflow step 2.6 table. Never emit asserts for provider keys the task does not actually need — they're confusing and cause spurious "missing key" failures.
 - **Always pass `site=` to `LLMObs.enable()`.** Read it from `os.getenv("DD_SITE", "datadoghq.com")`. Omitting `site=` silently defaults to US1 prod, which breaks every non-prod org (e.g. staging `datad0g.com`, `datadoghq.eu`). The canonical signature already includes it — never drop it.
 - **Per-record `tags` are `"key:value"` strings.** When inlining records (whether from `--dataset` JSON, CSV, or the default sample), each entry in a record's `"tags"` list must be a `"key:value"` string like `"env:prod"`, `"source:traces"`, `"category:geography"`. Bare strings (`"smoke"`, `"baseline"`) trigger `ValueError: Tag '<name>' is malformed.` at `Dataset.append()` time. If the source data has bare-string tags, namespace them — e.g. wrap `"smoke"` as `"tag:smoke"` rather than dropping it.
-- **`# TODO(user)` markers** on the placeholder task and on at least one evaluator so reviewers can't ship the placeholder by accident.
+- **Introspect first, placeholder last.** The default behavior is Workflow step 2.5 — scan the user's app, find the LLM entry point, wire `task_fn` to it. A `# TODO(user)` marker in the task section is only acceptable when introspection genuinely found nothing or the user passed `--placeholder-task`. Never emit a placeholder task when a real candidate exists in the project — that's the failure mode this skill exists to fix.
+- **`# TODO(user)` markers on at least one evaluator** so reviewers can't ship un-customized evaluators by accident. (Evaluators stay user-owned even when the task is auto-wired.)
+- **Introspection is bounded.** The scan in Workflow step 2.5 must respect `--app-root` (or its default-resolved value), `.gitignore` if present, and the directory blocklist (`node_modules`, `.venv`, `__pycache__`, etc.). Refuse to scan `/` or `~`. If a scan would touch more than ~10k Python files, narrow the root or ask the user to point at the relevant subdirectory.
 - **Match notebook conventions.** Plain function evaluators by default; class-based only when the user opts in. Print `experiment.url` at the end of every generated file.
 - **Tag every experiment with provenance — in both `config` and `tags`.** Every `LLMObs.experiment(...)` call **must** carry `"generated_by": "claude-code"` and `"skill": "llm-obs-experiment-py-bootstrap"` as keys in **both** the `config={...}` dict (so they render in the experiment's Configuration view, which is where users actually look) **and** the `tags={...}` dict (which the SDK serializes into `metadata.tags` for future tag-filter consumers). The `tags=` path alone is not enough: the current LLM Experiments UI does not surface `metadata.tags` as filterable chips, so users won't see the provenance unless it's also in `config`. If a user later edits the generated file to add their own keys, they extend both dicts — never replace the provenance keys silently.
 - **PII scrub at the door.** If `--dataset` is given, scrub before inlining into the generated file. Never embed a record that contains an unmasked email/phone/SSN/API-key pattern.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/class.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/class.md
@@ -1,0 +1,35 @@
+# `--evaluator-style class` (advanced — for evaluators that need state or async I/O)
+
+`BaseEvaluator` subclasses with `evaluate(self, context: EvaluatorContext) -> EvaluatorResult`. Always return `EvaluatorResult` — never a bare value. State-bearing evaluators usually have richer reasoning to surface anyway.
+
+## Code to emit
+
+```python
+from ddtrace.llmobs import BaseEvaluator, EvaluatorContext, EvaluatorResult
+
+class FaithfulnessJudge(BaseEvaluator):
+    def __init__(self):
+        super().__init__(name="faithfulness")
+        # TODO(user): initialize any client or state here
+
+    def evaluate(self, context: EvaluatorContext) -> EvaluatorResult:
+        # context exposes: input_data, output_data, expected_output, metadata
+        # TODO(user): replace placeholder logic with your faithfulness check
+        passed = context.output_data is not None
+        return EvaluatorResult(
+            value=1.0 if passed else 0.0,
+            reasoning="placeholder — replace with your faithfulness rubric",
+            assessment="pass" if passed else "fail",
+            metadata={"evaluator_version": "v1"},
+        )
+```
+
+## Rules
+
+- Call `super().__init__(name=...)` in `__init__`. The `name` is the column header in the Datadog Experiments UI.
+- `evaluate()` runs in the experiment's worker pool. Do NOT mutate `self` from `evaluate()` (thread safety) — state set in `__init__` should be read-only thereafter.
+- For async work (e.g., calling an LLM judge over the network), prefer wrapping with `asyncio.run(...)` inside `evaluate()` rather than making `evaluate` itself async. Keeps the experiment runner sync.
+
+## When NOT to use this style
+
+If the evaluator is a one-line check (`exact_match`, `length_under_500`), use `function` style — the class boilerplate adds noise. See `references/evaluator-styles/function.md`.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/function.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/function.md
@@ -1,0 +1,39 @@
+# `--evaluator-style function` (default — what the notebooks use)
+
+Plain Python functions with the signature `(input_data, output_data, expected_output)`. Always emit at least three: a trivial boolean (returns `bool`), a richer rule-based one (returns `EvaluatorResult`), and an LLM-as-Judge surrogate (a `RemoteEvaluator` reference or a placeholder).
+
+## Code to emit
+
+```python
+from ddtrace.llmobs import EvaluatorResult
+
+# Trivial check — bare bool is fine here, the result has no extra signal.
+def exact_match(input_data, output_data, expected_output) -> bool:
+    return output_data == expected_output
+
+# Richer check — use EvaluatorResult so reasoning/assessment surface in the UI.
+def response_well_formed(input_data, output_data, expected_output) -> EvaluatorResult:
+    if not isinstance(output_data, str):
+        return EvaluatorResult(
+            value=False,
+            reasoning=f"output_data was {type(output_data).__name__}, expected str",
+            assessment="fail",
+        )
+    if len(output_data) > 500:
+        return EvaluatorResult(
+            value=False,
+            reasoning=f"output exceeded 500 chars (was {len(output_data)})",
+            assessment="fail",
+            metadata={"length": len(output_data)},
+        )
+    return EvaluatorResult(value=True, assessment="pass")
+```
+
+## When to extend
+
+- If the user passed `--dataset` with a structured `expected_output`, add a JSON-shape check (also returning `EvaluatorResult`).
+- For LLM-as-Judge surrogates, prefer `RemoteEvaluator` references (server-side, scalable) over inline `LLMJudge` calls.
+
+## When NOT to use this style
+
+If the evaluator needs persistent state (a model client, a cached lookup, an async I/O resource), use `class` style instead — `BaseEvaluator.__init__` is where you set up state safely. See `references/evaluator-styles/class.md`.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/remote.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/evaluator-styles/remote.md
@@ -1,0 +1,45 @@
+# `--evaluator-style remote` (LLM-as-Judge running server-side)
+
+`RemoteEvaluator` instances that point at a judge configured in the Datadog UI. The judge LLM call runs on Datadog's side, not in the user's experiment process — useful when the judge is shared across experiments or has its own quota / model selection.
+
+## Code to emit
+
+```python
+from ddtrace.llmobs import RemoteEvaluator
+
+# Create the judge in Datadog UI first: LLM Observability → Evaluations → New Evaluator
+quality_judge = RemoteEvaluator(eval_name="<name-from-datadog-ui>")
+
+# Optional: customize the payload the judge receives
+custom_judge = RemoteEvaluator(
+    eval_name="<name>",
+    transform_fn=lambda ctx: {
+        "question": ctx.input_data.get("question"),
+        "answer": ctx.output_data,
+        "reference": ctx.expected_output,
+    },
+)
+```
+
+## Setup the user has to do first
+
+The judge must exist in the Datadog UI before the experiment runs. Emit a comment in the generated file telling the user:
+
+```
+# Before running this experiment:
+#   1. Open Datadog → LLM Observability → Evaluations → Custom evaluators
+#   2. Create an LLM-as-a-Judge evaluator. Note the eval_name you give it.
+#   3. Paste that name into RemoteEvaluator(eval_name="...") below.
+```
+
+## When to prefer remote over inline LLMJudge
+
+- The same judge is reused across multiple experiments (single source of truth in the UI).
+- The judge needs its own model/provider config that the experiment process doesn't have access to.
+- The user wants to swap judges without changing experiment code.
+
+For one-off rubrics tied to a single experiment, inline `LLMJudge` (under the `function` style) is simpler. See `references/evaluator-styles/function.md`.
+
+## When NOT to use this style
+
+If the user doesn't have a judge configured in Datadog yet and won't set one up, fall back to `function` style with an `LLMJudge` placeholder — at least the experiment runs end-to-end.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/anthropic.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/anthropic.md
@@ -1,0 +1,29 @@
+# Provider: Anthropic
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `anthropic` and calls one of:
+
+- `anthropic.messages.create`
+- `client.messages.create` (where `client = anthropic.Anthropic(...)`)
+- `Anthropic(...).messages.create`
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+```python
+assert os.getenv("ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY is required for the wired task_fn."
+```
+
+## Optional env vars (do NOT assert; document in `# TODO` comments)
+
+- `ANTHROPIC_BASE_URL` — only needed when pointing at a proxy or self-hosted relay.
+
+## Adapter notes
+
+- `anthropic.Anthropic().messages.create(model=..., max_tokens=..., messages=[...])` returns a `Message` object. Extract text via `.content[0].text` (note: `content` is a list of blocks, not a single string).
+- If the user's function returns the raw `Message`, wrap with a `.content[0].text` extractor in `task_fn`.
+- `max_tokens` is **required** — unlike OpenAI, Anthropic raises if it's missing. If the user's function omits it, leave their signature alone; the call will fail at runtime and the user can fix.
+- Async (`AsyncAnthropic`): wrap with `asyncio.run(...)` inside a sync `task_fn`.
+
+## Common gotchas
+
+- Tool use response format differs from OpenAI — `tool_use` blocks are interleaved with `text` blocks in `.content`. Don't assume `.content[0]` is text; loop and concatenate `text` blocks if needed.
+- Anthropic models require `messages` to alternate user/assistant (no two consecutive same-role messages). If the user's function builds messages, trust it; don't second-guess.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/bedrock.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/bedrock.md
@@ -1,0 +1,38 @@
+# Provider: AWS Bedrock
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `boto3` and calls:
+
+- `boto3.client("bedrock-runtime").invoke_model(...)`
+- `boto3.client("bedrock-runtime").converse(...)` (newer API)
+- `boto3.Session(...).client("bedrock-runtime")...`
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+```python
+assert os.getenv("AWS_ACCESS_KEY_ID"), "AWS_ACCESS_KEY_ID is required for the wired task_fn (Bedrock)."
+assert os.getenv("AWS_SECRET_ACCESS_KEY"), "AWS_SECRET_ACCESS_KEY is required for the wired task_fn (Bedrock)."
+```
+
+## Optional env vars (do NOT assert; document in `# TODO` comments)
+
+- `AWS_SESSION_TOKEN` — required when using short-lived credentials (SSO, IAM Identity Center, etc.). If set, must be present at runtime.
+- `AWS_REGION` (or `AWS_DEFAULT_REGION`) — Bedrock is region-scoped. Defaults to `us-east-1` if unset; emit a comment:
+
+  ```python
+  # AWS Bedrock is region-scoped. Defaults to us-east-1; set AWS_REGION if your
+  # Bedrock-enabled region differs (us-west-2, eu-central-1, etc.).
+  ```
+
+- `AWS_PROFILE` — alternative to access-key/secret pair when using `~/.aws/credentials`. If the user's function uses `boto3.Session(profile_name=...)`, key-pair asserts may not apply — emit a comment instead.
+
+## Adapter notes
+
+- `client.invoke_model(modelId=..., body=...)` (older API) — body is a JSON string with provider-specific shape (Anthropic Claude, Amazon Titan, AI21, Cohere, Meta Llama — each has different body schema). Extract response via `json.loads(response["body"].read())`.
+- `client.converse(modelId=..., messages=[...])` (newer Converse API) — standardized request/response across providers. Extract via `response["output"]["message"]["content"][0]["text"]`.
+- If the user's function uses `invoke_model`, leave their body construction intact in `task_fn` — Anthropic-on-Bedrock vs Llama-on-Bedrock have different request shapes.
+
+## Common gotchas
+
+- Model IDs differ from upstream provider IDs (e.g., `anthropic.claude-3-5-sonnet-20240620-v1:0` rather than `claude-3-5-sonnet-20240620`). Don't rewrite the model ID.
+- Bedrock charges per call; rate limits apply. Consider `--jobs 1` for the first experiment run to gauge cost.
+- Cross-region inference profiles use a different model ID prefix (`us.anthropic...`, `eu.anthropic...`). Trust the user's setup.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/gemini.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/gemini.md
@@ -1,0 +1,41 @@
+# Provider: Google Gemini / Vertex AI
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `google.generativeai` and calls:
+
+- `google.generativeai.GenerativeModel(...).generate_content(...)`
+- `genai.GenerativeModel(...).generate_content(...)` (aliased import)
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+Either `GEMINI_API_KEY` or `GOOGLE_API_KEY` works — both are valid env names per `google-generativeai`'s SDK conventions. Emit a single combined assert:
+
+```python
+assert os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"), (
+    "GEMINI_API_KEY or GOOGLE_API_KEY is required for the wired task_fn."
+)
+```
+
+## Vertex AI variant (separate authentication path)
+
+If the call-site uses `vertexai.generative_models.GenerativeModel` (not `google.generativeai`), the auth path is Google Cloud Application Default Credentials, not an API key. Emit:
+
+```python
+# Vertex AI uses Google Cloud ADC, not an API key.
+# Run `gcloud auth application-default login` before running this file, or set
+# GOOGLE_APPLICATION_CREDENTIALS to point at a service account JSON.
+assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS"), (
+    "GOOGLE_APPLICATION_CREDENTIALS path is required for the wired task_fn (Vertex AI), "
+    "or run `gcloud auth application-default login` before invoking."
+)
+```
+
+## Adapter notes
+
+- `GenerativeModel("gemini-pro").generate_content("prompt")` returns a `GenerateContentResponse`. Extract via `.text` (single-candidate) or `.candidates[0].content.parts[0].text`.
+- For chat: `model.start_chat(history=[]).send_message("prompt")` returns the same response shape.
+- Async: `generate_content_async(...)` — wrap with `asyncio.run(...)`.
+
+## Common gotchas
+
+- Safety filters: Gemini may return an empty response if safety thresholds block it. `.text` raises `ValueError` in that case. If the user's function doesn't handle this, surface a `WARNING:`.
+- Quota lives at the project level for Vertex AI, per-key for `google.generativeai`. Be aware of which path the user's function uses.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/langchain.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/langchain.md
@@ -1,0 +1,38 @@
+# Provider: LangChain
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports from `langchain` / `langchain_openai` / `langchain_anthropic` / etc. and uses one of:
+
+- `langchain.*.invoke(...)`
+- `ChatOpenAI(...)`, `ChatAnthropic(...)`, `ChatVertexAI(...)`, `ChatBedrock(...)`, etc.
+- `LLMChain(...)`
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+LangChain is a meta-framework — it wraps a specific provider. **Walk one level deeper**: the chat-client class names the provider. Read the user's function (and immediate imports) to identify which `Chat*` class is instantiated, then emit the assert for THAT provider per the table below:
+
+| LangChain class | Underlying provider | Reference file |
+|---|---|---|
+| `ChatOpenAI`, `OpenAI`, `AzureChatOpenAI` (with `azure_endpoint=`) | OpenAI / Azure OpenAI | `providers/openai.md` or `providers/openai.md` (Azure: also `AZURE_OPENAI_ENDPOINT`) |
+| `ChatAnthropic`, `AnthropicLLM` | Anthropic | `providers/anthropic.md` |
+| `ChatVertexAI`, `ChatGoogleGenerativeAI` | Vertex / Gemini | `providers/gemini.md` |
+| `ChatBedrock`, `BedrockLLM` | AWS Bedrock | `providers/bedrock.md` |
+| `ChatLiteLLM` | LiteLLM (auto-routes) | `providers/litellm.md` |
+
+**Emit the assert for the underlying provider**, not LangChain itself. Example: if the user's function has `from langchain_anthropic import ChatAnthropic`, emit:
+
+```python
+assert os.getenv("ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY is required for the wired task_fn (LangChain ChatAnthropic)."
+```
+
+If the call-site uses multiple chat clients (rare), emit asserts for each.
+
+## Adapter notes
+
+- `chain.invoke({...})` returns either a string (for simple chains) or an `AIMessage` (for chat-based chains). Extract `.content` if it's the latter.
+- LangChain LCEL chains (`prompt | llm | parser`) return the parser's output type directly — usually a string. Trust the user's function signature.
+- Async: `chain.ainvoke(...)` — wrap with `asyncio.run(...)`.
+
+## Common gotchas
+
+- LangChain configures provider via env vars by default but ALSO supports per-instance kwargs (`ChatOpenAI(api_key="sk-...")`). If the user's function passes a key explicitly, the env var is irrelevant — emit a `# Note:` comment instead of an assert.
+- LangChain `prompts/` directory conventions vary widely; the wrapped function should encapsulate prompt loading, so `task_fn` just calls `function(input_data)` and trusts the chain.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/litellm.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/litellm.md
@@ -1,0 +1,33 @@
+# Provider: LiteLLM
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `litellm` and calls:
+
+- `litellm.completion(...)`
+- `litellm.acompletion(...)`
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+LiteLLM auto-routes to whatever provider the underlying model identifier resolves to (`gpt-5.4-mini` → OpenAI, `claude-sonnet-4-5` → Anthropic, `gemini-pro` → Vertex, etc.). The skill cannot statically determine which provider's key is needed — the routing decision happens at runtime based on the model arg.
+
+**Emit a comment instead of an assert:**
+
+```python
+# LiteLLM auto-routes to the underlying provider at runtime. Make sure the keys
+# for your chosen model's provider are set in .env or shell:
+#   - OpenAI models  → OPENAI_API_KEY
+#   - Anthropic models → ANTHROPIC_API_KEY
+#   - Gemini models → GEMINI_API_KEY or GOOGLE_API_KEY
+#   - Bedrock models → AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ AWS_REGION)
+#   - Azure OpenAI  → AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT
+```
+
+## Adapter notes
+
+- `litellm.completion(model=..., messages=[...])` returns a response with the same `.choices[0].message.content` shape as OpenAI, regardless of underlying provider. LiteLLM normalizes for you.
+- Async variant: `litellm.acompletion(...)` — wrap with `asyncio.run(...)` inside a sync `task_fn`.
+- LiteLLM has its own retry / fallback config (`litellm.set_verbose`, `litellm.api_base`, etc.). If the user's function configures these, leave their setup intact in `task_fn`.
+
+## Common gotchas
+
+- Detecting *which* underlying provider needs which key at runtime is on the user — they know which model they're calling. The TODO comment is the most we can do statically.
+- If the user is using LiteLLM's proxy mode (`litellm.api_base` pointing at their own proxy), they may not need any provider keys at all in this process — surface that possibility in the comment block.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/llamaindex.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/llamaindex.md
@@ -1,0 +1,40 @@
+# Provider: LlamaIndex
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `llama_index.*` and uses one of:
+
+- `index.as_query_engine(...).query(...)`
+- `index.as_chat_engine(...).chat(...)`
+- `VectorStoreIndex.from_documents(...)`
+- LlamaIndex agent classes (`AgentRunner`, `ReActAgent`, etc.)
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+Like LangChain, LlamaIndex is a meta-framework. **Walk one level deeper**: find the underlying `LLM` / `embedder` class the index / chat engine is configured with. The provider table:
+
+| LlamaIndex class | Underlying provider | Reference file |
+|---|---|---|
+| `OpenAI`, `OpenAILike` (from `llama_index.llms.openai`) | OpenAI | `providers/openai.md` |
+| `Anthropic` (from `llama_index.llms.anthropic`) | Anthropic | `providers/anthropic.md` |
+| `Gemini` (from `llama_index.llms.gemini`) | Gemini | `providers/gemini.md` |
+| `Bedrock` (from `llama_index.llms.bedrock`) | AWS Bedrock | `providers/bedrock.md` |
+| `LiteLLM` (from `llama_index.llms.litellm`) | LiteLLM | `providers/litellm.md` |
+
+**Emit the assert for the underlying provider**, not LlamaIndex itself. Embedders (`OpenAIEmbedding`, `HuggingFaceEmbedding`, etc.) may need separate keys if they're hosted; surface in a comment.
+
+Example: if the user's function uses `Settings.llm = OpenAI(model="gpt-5.4o-mini")`, emit:
+
+```python
+assert os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY is required for the wired task_fn (LlamaIndex OpenAI LLM)."
+```
+
+## Adapter notes
+
+- `query_engine.query("...")` returns a `Response` object — extract `.response` for the text.
+- `chat_engine.chat("...")` returns a string directly.
+- LlamaIndex `Settings` is global state — once configured, all index operations use the same LLM. Trust the user's function not to re-configure mid-call.
+- Async: `aquery(...)` / `achat(...)` — wrap with `asyncio.run(...)`.
+
+## Common gotchas
+
+- If the user's function constructs the index inside `task_fn` (rebuilding it per record), the experiment will be very slow. Surface as a `WARNING:` in the next-steps output: "task_fn appears to rebuild the LlamaIndex on every call — consider caching the index at module scope for faster experiment runs."
+- Embedding API calls also count against the LLM provider's quota — `OPENAI_API_KEY` may be used by both the embedder and the LLM. One assert covers both.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/openai.md
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/references/providers/openai.md
@@ -1,0 +1,31 @@
+# Provider: OpenAI
+
+Triggered by introspection (Workflow step 2.5) when the call-site function imports `openai` and calls one of:
+
+- `openai.ChatCompletion.create` / `openai.chat.completions.create`
+- `client.chat.completions.create` (where `client = openai.OpenAI(...)`)
+- `openai.completions.create` / `client.completions.create` (legacy text completions)
+
+Also the fallback when introspection finds nothing and `--placeholder-task` is in effect — the placeholder makes an OpenAI chat call.
+
+## `{{PROVIDER_ASSERTS}}` substitution
+
+```python
+assert os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY is required for the wired task_fn."
+```
+
+## Optional env vars (do NOT assert; document in `# TODO` comments)
+
+- `OPENAI_ORG_ID` — only needed for orgs that scope keys per org.
+- `OPENAI_BASE_URL` — only needed when pointing at a self-hosted / Azure-compatible endpoint. If the call-site uses `OpenAI(base_url=...)`, the wrapped function already handles this.
+
+## Adapter notes
+
+- Sync chat completion: `openai.OpenAI().chat.completions.create(model=..., messages=[...])` returns a `ChatCompletion` object. Extract the text via `.choices[0].message.content`.
+- If the user's function returns the raw `ChatCompletion`, wrap with a `.choices[0].message.content` extractor in `task_fn` (the evaluator expects a string output, not the full SDK object).
+- Async variants (`AsyncOpenAI`, `acreate`): wrap the async call with `asyncio.run(...)` inside a sync `task_fn`. See Workflow step 2.5d "Signature adaptation".
+
+## Common gotchas
+
+- Rate limits — pass `--jobs 1` or `--jobs 2` if the experiment hits 429s.
+- `gpt-5.4-turbo` deprecations: the user's function may reference a model that has been retired. Don't silently rewrite the model name — surface as a `WARNING:` if `gpt-3.5-turbo` or similar is detected.

--- a/dd-llmo/llm-obs-experiment-py-bootstrap/scripts/env_setup_template.py
+++ b/dd-llmo/llm-obs-experiment-py-bootstrap/scripts/env_setup_template.py
@@ -1,0 +1,91 @@
+# ─── 1. Env setup ─────────────────────────────────────────────────────────────
+#
+# Auto-discovers .env files at runtime. NO python-dotenv dependency — the
+# `_load_env_files` helper below is a tiny pure-Python walker.
+#
+# Discovery order (first non-empty value wins per key; shell env always
+# overrides files):
+#   1. ENV_FILE_OVERRIDE entries below (set at generation time from --env-file)
+#   2. This file's directory: ./.env and .env.local
+#   3. Current working directory: ./.env and .env.local
+#   4. Parent walk from cwd up to /
+#   5. ~/.datadog/credentials
+#
+# To override on a per-run basis, just `export DD_API_KEY=...` in your shell
+# before running this file — the loader never overwrites a value already in
+# os.environ.
+
+import os
+import pathlib
+
+
+def _load_env_files(extra: list[str] | None = None) -> list[str]:
+    here = pathlib.Path(__file__).resolve().parent
+    cwd = pathlib.Path.cwd().resolve()
+    candidates: list[pathlib.Path] = []
+    for p in extra or []:
+        candidates.append(pathlib.Path(p).expanduser())
+    candidates += [
+        here / ".env",
+        here / ".env.local",
+        cwd / ".env",
+        cwd / ".env.local",
+    ]
+    p = cwd
+    while p != p.parent and p != pathlib.Path.home().parent:
+        candidates.append(p / ".env")
+        p = p.parent
+    candidates.append(pathlib.Path.home() / ".datadog" / "credentials")
+
+    loaded: list[str] = []
+    seen: set[pathlib.Path] = set()
+    for path in candidates:
+        try:
+            path = path.resolve()
+        except Exception:
+            continue
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
+        try:
+            text = path.read_text()
+        except Exception:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            k, _, v = line.partition("=")
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k and k not in os.environ:
+                os.environ[k] = v
+        loaded.append(str(path))
+    return loaded
+
+
+# Baked in at generation time from --env-file (always tried first). Edit this
+# list to point at a different .env without regenerating the file.
+ENV_FILE_OVERRIDE: list[str] = {{ENV_FILE_OVERRIDE_LIST}}
+
+_loaded_env_paths = _load_env_files(ENV_FILE_OVERRIDE)
+if _loaded_env_paths:
+    print(f"Loaded credentials from: {', '.join(_loaded_env_paths)}")
+
+# ─── Required key assertions ─────────────────────────────────────────────────
+# Datadog keys are always required. Provider-key assertions are emitted
+# conditionally by the skill (see Workflow step 2.6 — only the keys the wired
+# task_fn actually calls).
+
+assert os.getenv("DD_API_KEY"), (
+    "DD_API_KEY is not set. Export it in your shell or add it to a discovered "
+    ".env file (this file checked: cwd, app dir, parent dirs, "
+    "~/.datadog/credentials)."
+)
+assert os.getenv("DD_APPLICATION_KEY") or os.getenv("DD_APP_KEY"), (
+    "DD_APPLICATION_KEY (or its alias DD_APP_KEY) is not set. Same fallback "
+    "paths as above."
+)
+{{PROVIDER_ASSERTS}}


### PR DESCRIPTION
## Summary

Three closely-related changes to `llm-obs-experiment-py-bootstrap`, bundled because they all touch Workflow step 2.x and would conflict if split. No behavior change for `--placeholder-task` users; major behavior change for the default path (introspection wires `task_fn` to the user's real entry point).

### 1. Application introspection — auto-wire `task_fn` to the user's real entry point

The generated file used to emit a `# TODO(user): replace with your actual LLM call` placeholder. Now the skill scans the user's project for LLM call sites and wires `task_fn` to the most likely entry point automatically.

- Detects: `openai.*`, `anthropic.*`, `litellm.*`, `langchain.*`, `llama_index.*`, `google.generativeai.*`, `boto3.client("bedrock-runtime")`, plus any function already decorated with `@LLMObs.*` / `@workflow` / `@agent`.
- Scores candidates by: function-name keywords, decorator presence, module path, class-name suffix, signature shape.
- Presents the top 3 in chat and waits for confirmation (defaults to #1 on `continue`).
- Emits a real wrapper that imports `<module>:<function>` and adapts the SDK's `(input_data, config)` signature to whatever args the user's function actually takes. Handles `async`, class methods, `**kwargs`, `config` passthrough.
- Side-effect scan flags non-LLM HTTP calls, DB drivers, env-var reads beyond LLM creds, and disk writes as `WARNING:` lines.
- New flags: `--task-source <module:function>` (override), `--placeholder-task` (opt-out), `--app-root <path>`.

### 2. Credential auto-discovery — no more `export DD_API_KEY=...` before every run

The generated file ships an inline `_load_env_files()` helper (no `python-dotenv` dependency) that walks:

1. `--env-file <path>` baked in as `ENV_FILE_OVERRIDE`
2. `<output-file-dir>/.env` and `.env.local`
3. `<cwd>/.env` and `.env.local`
4. Parent-walk from cwd up to `/`
5. `~/.datadog/credentials`

Shell env always wins. Provider-key asserts in the generated file are **conditional on what introspection picked**: `OPENAI_API_KEY` only if the task imports OpenAI, `ANTHROPIC_API_KEY` only for Anthropic, etc. No more spurious "missing key" errors.

New flag: `--env-file <path>`.

### 3. scripts/ and references/ split — context savings

The SKILL.md is now a router; details live in side-files that load on demand.

- `scripts/env_setup_template.py` — canonical text for section 1 of the generated experiment. Skill reads it, substitutes `{{ENV_FILE_OVERRIDE_LIST}}` and `{{PROVIDER_ASSERTS}}`, embeds verbatim. Replaces ~84 lines inline.
- `references/evaluator-styles/{function,class,remote}.md` — only the one matching `--evaluator-style` is read. Saves ~70 lines per invocation.
- `references/providers/{openai,anthropic,litellm,langchain,llamaindex,gemini,bedrock}.md` — only the one matching the introspected SDK is read. Saves ~80 lines per invocation.

Adding a new provider later = one new `references/providers/<name>.md` + one row in the router table. No SKILL.md body churn.

## Companion PRs (split from #47)

This PR is part of a three-PR split:

1. `llm-obs-eval-bootstrap` gets `--emit-dataset` mode — #55
2. (this PR) `llm-obs-experiment-py-bootstrap`
3. `llm-obs-eval-pipeline` extends to 8 phases — depends on PR 1

Mirrors DataDog/llm-obs: #388 (merged) + #391 (open, refactor portion).

## Test plan

- [ ] Run `/llm-obs-experiment-py-bootstrap` from inside a project that imports `openai`. Verify the skill scans the project, lists top 3 candidates, and (on `continue`) emits a `task_fn` that imports + calls the chosen function.
- [ ] Confirm `--placeholder-task` opts out and emits the legacy placeholder behavior.
- [ ] Confirm `--task-source mymod.handlers:respond` skips discovery and uses that function directly.
- [ ] Confirm the generated file's section 1 has `_load_env_files()` and `ENV_FILE_OVERRIDE`, no python-dotenv import.
- [ ] Confirm the assertions match the wired provider: for an Anthropic-imported task, the file asserts `ANTHROPIC_API_KEY` not `OPENAI_API_KEY`.
- [ ] Confirm shell `export DD_API_KEY=staging-...` overrides a value of the same key in a discovered `.env`.
- [ ] Confirm only the relevant `references/providers/<x>.md` and `references/evaluator-styles/<y>.md` are read (not all of them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)