### PR TITLE
feat(dd-llmo/eval-pipeline): extend to datasets, experiments, analysis (depends on #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,12 @@ npx skills add datadog-labs/agent-skills \
   --skill dd-audit-compliance-report \
   --skill dd-audit-ai-activity \
   --skill llm-obs-experiment-analyzer \
+  --skill llm-obs-experiment-py-bootstrap \
   --skill llm-obs-trace-rca \
   --skill llm-obs-eval-bootstrap \
   --skill llm-obs-eval-pipeline \
   --skill llm-obs-session-classify \
   --skill k9-ownership-byod-setup \
-  --skill unblock-pr \
-  --skill triage-flaky-test \
   --full-depth -y
 ```
 
@@ -92,8 +91,8 @@ The `dd-llmo` directory contains six skills for working with LLM Observability d
 | `llm-obs-experiment-analyzer` | Analyze and compare offline LLM experiments |
 | `llm-obs-experiment-py-bootstrap` | Generate self-contained Python experiment code using the `ddtrace.llmobs` SDK |
 | `llm-obs-trace-rca` | Root-cause production failures using eval judge signal or runtime errors |
-| `llm-obs-eval-bootstrap` | Generate evaluator code from traces, optionally seeded by RCA output |
-| `llm-obs-eval-pipeline` | End-to-end pipeline: classify sessions → RCA → bootstrap evaluators |
+| `llm-obs-eval-bootstrap` | Generate evaluator code from traces, optionally seeded by RCA output. Also emits a dataset from traces in `--emit-dataset` mode. |
+| `llm-obs-eval-pipeline` | Eight-phase pipeline: classify → RCA → bootstrap evaluators → create dataset → publish → generate experiment → run → analyze. Stop early with `--stop-after`. |
 | `llm-obs-session-classify` | Classify whether user intent was satisfied in a session (trace + RUM signals) |
 
 **Eval pipeline flow:**
@@ -171,6 +170,10 @@ Look at the errors on <ml_app> over the last 24h
 
 # Classify a session
 /eval-session-classify <session_id>
+
+# Guided onboarding through datasets + experiments (6 narrated states)
+/llm-obs-onboarding-datasets-experiments <ml_app>
+/llm-obs-onboarding-datasets-experiments <ml_app> --timeframe now-30d --trace-limit 25 --format ipynb
 ```
 
 ### Software Delivery (dd-software-delivery)
@@ -221,8 +224,8 @@ Or via `npx`:
 
 ```bash
 npx skills add datadog-labs/agent-skills \
-  --skill unblock-pr \
-  --skill triage-flaky-test \
+  --skill dd-software-delivery/unblock-pr \
+  --skill dd-software-delivery/triage-flaky-test \
   --full-depth -y
 ```
 
@@ -330,8 +333,8 @@ Or via `npx`:
 
 ```bash
 npx skills add datadog-labs/agent-skills \
-  --skill unblock-pr \
-  --skill triage-flaky-test \
+  --skill dd-software-delivery/unblock-pr \
+  --skill dd-software-delivery/triage-flaky-test \
   --full-depth -y
 ```
 

--- a/dd-llmo/llm-obs-eval-pipeline/SKILL.md
+++ b/dd-llmo/llm-obs-eval-pipeline/SKILL.md
@@ -60,7 +60,11 @@ This skill is **pure orchestration plus pedagogy** — no new analytical logic. 
 /llm-obs-eval-pipeline <ml_app> [--project-name <name>] [--timeframe <window>] [--trace-limit <N>]
                                 [--format py|ipynb] [--evaluator-style function|class|remote]
                                 [--data-only | --publish]
+                                [--start-at classify|rca|eval-bootstrap|dataset|publish|experiment|run|analyze]
                                 [--stop-after classify|rca|eval-bootstrap|dataset|publish|experiment|run|analyze]
+                                [--classification-summary <path>] [--rca-report <path>]
+                                [--dataset-file <path>] [--dataset-name <name>]
+                                [--experiment-file <path>] [--experiment-id <uuid> | --experiment-url <url>]
                                 [--app-root <path>] [--env-file <path>] [--output-dir <dir>]
                                 [--backend pup]
 ```
@@ -80,6 +84,14 @@ Arguments: $ARGUMENTS
 | `--data-only` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: emit JSON spec instead of Python SDK code. |
 | `--publish` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: publish online LLM-judge evaluators to Datadog. |
 | `--stop-after <phase>` | No | `analyze` (run everything) | Stop after the named phase completes. `classify` = Phase 1 only. `rca` = through Phase 2. `eval-bootstrap` = through Phase 3 (matches the classic eval-pipeline). `dataset` = through Phase 4. `publish` = through Phase 5. `experiment` = through Phase 6 (file generated, not run). `run` = through Phase 7 (skip analyzer). `analyze` = all eight phases (default). |
+| `--start-at <phase>` | No | `classify` (start at the top) | Skip earlier phases and start at the named phase. Same vocabulary as `--stop-after`. The skill auto-loads any required prior-phase artifacts from `<output-dir>/state/` (see "State persistence and entry/exit" section). For phases that need an artifact the auto-load can't find, supply it via one of the override flags below. Combinable with `--stop-after` to run a contiguous slice of the pipeline. |
+| `--classification-summary <path>` | No | auto-loaded from `<output-dir>/state/01-classification.md` if `--start-at rca` or later | Override the Phase 1 output that Phase 2 consumes. Useful when the prior state file is missing or you want to point at a hand-edited version. |
+| `--rca-report <path>` | No | auto-loaded from `<output-dir>/state/02-rca-report.md` if `--start-at eval-bootstrap` or later | Override the Phase 2 output that Phase 3 consumes. |
+| `--dataset-file <path>` | No | auto-loaded from `<output-dir>/state/04-dataset.json` (or the most recent `<output-dir>/dataset_<ml_app>_*.json`) if `--start-at publish` | The local `DatasetRecordRaw[]` JSON that Phase 5 publishes. |
+| `--dataset-name <name>` | No | auto-loaded from `<output-dir>/state/05-published-dataset.json` if `--start-at experiment` | The name of a published Datadog dataset that Phase 6 wires the experiment to. |
+| `--experiment-file <path>` | No | auto-loaded from `<output-dir>/state/06-experiment.json` (which points at the actual `.py` / `.ipynb`) if `--start-at run` | The generated experiment file Phase 7 executes. |
+| `--experiment-id <uuid>` | No | auto-loaded from `<output-dir>/state/07-experiment-run.json` if `--start-at analyze` | The Datadog experiment ID Phase 8 analyzes. Mutually exclusive with `--experiment-url`. |
+| `--experiment-url <url>` | No | auto-loaded as above | Alternative to `--experiment-id`. The skill parses the trailing UUID out of the URL. |
 | `--app-root` | No | resolved from cwd / `pyproject.toml` etc. | Restricts `llm-obs-experiment-py-bootstrap`'s task-function introspection to this directory tree. |
 | `--env-file` | No | none (auto-discovery walks standard locations) | Explicit `.env` path for credential loading. Surfaced in the Precheck and baked into the generated experiment as `ENV_FILE_OVERRIDE`. |
 | `--output-dir` | No | `./experiments` | Where the dataset JSON, publish script, and generated experiment file are written. |
@@ -101,7 +113,7 @@ Before Phase 1, run a single short verification pass — do **not** announce a "
 
    **Project creation semantics**: the project is created lazily by the Datadog SDK the first time `LLMObs.enable(project_name=...)` is called against the org (in Phase 5's publish script and Phase 6's generated experiment). The user does not need to pre-create anything in the UI. Surface the chosen project name in the Precheck output so the user can override before Phase 5 if it isn't what they wanted.
 
-4. **Ensure `--output-dir` exists** — `mkdir -p <output-dir>` via Bash. Cheap.
+4. **Ensure `--output-dir` and `<output-dir>/state/` exist** — `mkdir -p <output-dir>/state` via Bash. Cheap. The `state/` subdirectory is where phase outputs get persisted (see "State persistence and entry/exit" below).
 
 5. **Resolve credentials.** Walk the discovery order below to find Datadog credentials before Phase 5 needs them — failing late at the publish step is bad UX. Read-only at this stage: do NOT write any new files. Do NOT print secret values to the user; only report which file was loaded and which keys were resolved.
 
@@ -171,6 +183,11 @@ Every phase below uses this exact template. Do not deviate — the deterministic
 
 <full sub-skill output OR execution log reproduced here — do NOT summarize or truncate>
 
+<after the action completes successfully, Write the phase output to
+`<output-dir>/state/0N-<name>.{md,json}` per the State persistence contract — see
+"State persistence and entry/exit" section. This happens BEFORE the checkpoint
+so the file is on disk even if the user types `stop` next.>
+
 ---
 
 ### Checkpoint <N>
@@ -180,7 +197,7 @@ Every phase below uses this exact template. Do not deviate — the deterministic
 Before I continue to Phase N+1 (<next title>):
 - <2–3 phase-specific review prompts the user can answer>
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 **Never auto-advance.** Always pause at the checkpoint and wait for explicit user input. The whole point of this skill is determinism — that includes determinism over *when* the user moves on.
@@ -255,7 +272,7 @@ Before I continue:
 - Any traces you'd like to exclude from the dataset sample in Phase 4? (Paste trace IDs from the link above and I'll drop them.)
 - Any quality dimension you already know you want to measure later?
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for explicit user confirmation. If the user excludes specific traces, mark them as "excluded by user" — drop them from Phase 2's failure bucket and from Phase 4's sampling. Do NOT re-classify.
@@ -292,7 +309,7 @@ Before I continue:
 - Any failure modes to add, remove, or reframe?
 - Which root causes should the evaluators target? (Default: all of them.)
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for explicit user confirmation. If the user adjusts the taxonomy, incorporate the changes before continuing.
@@ -339,7 +356,7 @@ Before I continue:
 - Do the generated evaluators look right?
 - Any to drop or rename before they're referenced in the experiment?
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for explicit user confirmation. If `--stop-after eval-bootstrap` is set, this is where the pipeline ends — emit the Stop summary instead of the Checkpoint and exit.
@@ -388,7 +405,7 @@ Before I continue:
 - Happy with the proposed dataset name `<ml_app>_seed_<YYYYMMDD>`, or pick another?
 - Any records you want me to drop?
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for confirmation. The proposed `dataset_name` defaults to `<ml_app>_seed_<YYYYMMDD>` but the user can override — carry the final chosen name into Phase 5.
@@ -453,7 +470,7 @@ Before I continue:
 - Confirm you can see the dataset in the Datadog UI (LLM Observability → Datasets → search `<dataset_name>`)?
 - Any second thoughts on the dataset records (we can re-emit before generating the experiment)?
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for confirmation.
@@ -511,7 +528,7 @@ Then confirm:
 - Have you set `DD_API_KEY`, `DD_APPLICATION_KEY`, `DD_SITE` (if non-default), and the provider key your task needs (the generated file's section 1 asserts only the right one — check what it expects)?
 - Ready to run?
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for confirmation.
@@ -555,7 +572,7 @@ Before I continue:
 - Take a look at the experiment in the UI (link above). Do the per-record scores roughly match your expectations?
 - Any specific question you want Phase 8 to focus on? (Optional — leaving it open runs an exploratory analysis.)
 
-Type "continue" to proceed, or give me adjustments.
+Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
 Wait for confirmation. If the user provides a focus question, carry it to Phase 8 as the analyzer's `question` argument.
@@ -660,11 +677,96 @@ This makes `--stop-after eval-bootstrap` a drop-in replacement for the old `llm-
 
 ---
 
+## State persistence and entry/exit
+
+The pipeline persists every phase's primary output to `<output-dir>/state/` so that subsequent invocations can resume mid-flow with `--start-at <phase>` instead of starting from Phase 1 every time.
+
+### State file contract
+
+After every successful phase completion (i.e. after the user types `continue` past its checkpoint, OR before the Stop summary if `--stop-after` matches), **write the phase output to `<output-dir>/state/0N-<name>.{md,json}`**. Schema is fixed per phase:
+
+| Phase | State file | Schema |
+|---|---|---|
+| 1 classify | `state/01-classification.md` | The full `# Session Classification Summary` block plus all per-unit compact blocks, verbatim from `llm-obs-session-classify`. Markdown. |
+| 2 rca | `state/02-rca-report.md` | The full Phase 6 RCA report from `llm-obs-trace-rca`, verbatim. Markdown. |
+| 3 eval-bootstrap | `state/03-evaluators.json` | `{"mode": "sdk_code\|data_only\|publish", "output_path": "<path>", "evaluator_names": [...], "ml_app": "<ml_app>", "generated_at": "<ISO 8601>"}`. The actual evaluator code/JSON stays where the sub-skill wrote it. |
+| 4 dataset | `state/04-dataset.json` | The same `DatasetRecordRaw[]` content as `<output-dir>/dataset_<ml_app>_<YYYYMMDD>.json`. Treat this as a symlink-or-copy — both paths must point at the same content. |
+| 5 publish | `state/05-published-dataset.json` | `{"dataset_name": "<name>", "project_name": "<name>", "version": <int>, "url": "<datadog url>", "record_count": <int>, "published_at": "<ISO 8601>"}` |
+| 6 experiment | `state/06-experiment.json` | `{"experiment_file": "<path>", "format": "py\|ipynb", "dataset_name": "<name>", "task_source": "<module:function>\|placeholder", "purpose": "<text>", "generated_at": "<ISO 8601>"}` |
+| 7 run | `state/07-experiment-run.json` | `{"experiment_id": "<uuid>", "experiment_url": "<datadog url>", "records_processed": <int>, "duration_seconds": <float>, "ran_at": "<ISO 8601>"}` |
+| 8 analyze | `state/08-analysis.md` | The full analyzer report from `llm-obs-experiment-analyzer`. Markdown. |
+
+`<output-dir>/state/` should be created via `mkdir -p` at the top of the Precheck (alongside the existing `<output-dir>` creation). Never write state files outside this directory.
+
+### `--start-at` resolution
+
+At the top of the run, after the Precheck, branch on `--start-at`:
+
+1. If `--start-at` is not set or equals `classify`, proceed normally with Phase 1.
+2. Otherwise, for every phase strictly before the start phase, **load the state file** corresponding to that phase. If an override flag was passed (`--classification-summary`, `--rca-report`, `--dataset-file`, `--dataset-name`, `--experiment-file`, `--experiment-id`, `--experiment-url`), it takes precedence over the state file.
+3. If a required state file is missing AND no override flag was supplied, **fail fast** with a clear message:
+
+   > "Can't `--start-at <phase>` — Phase <N-1>'s state file at `<output-dir>/state/0(N-1)-<name>.{md,json}` is missing and no `--<prior-phase>-override <path>` flag was supplied. Either re-run from an earlier phase or pass the override flag explicitly."
+
+4. For each loaded state file or override, print a one-line "Loaded prior state: <phase> from <path>" in the Precheck output so the user can see what's being reused.
+5. Skip directly to the start phase. The first phase to actually run prints its full banner; the earlier phases get a one-line note in the Precheck.
+
+The Precheck output gets an extra line at the bottom when `--start-at` is in effect:
+
+```
+- Resumed from: --start-at <phase> (loaded state for phases 1..N-1)
+```
+
+### Mid-run exit at any checkpoint
+
+Every Checkpoint accepts these inputs (case-insensitive, leading/trailing whitespace OK):
+
+| User types | Behavior |
+|---|---|
+| `continue`, `c`, `go`, `yes`, `y`, `next`, or just `<Enter>` with no text | Advance to the next phase. |
+| `stop`, `exit`, `done`, `quit`, `q`, `cancel` | Emit the **Stop summary** here and end the run. Same shape as if `--stop-after <current-phase>` had been set from the top. State for completed phases is preserved on disk, so the user can `--start-at <next-phase>` later. |
+| `redo` (optionally followed by adjustment notes like `redo with --trace-limit 50`) | Re-run the current phase only. Do **not** re-run earlier phases — their state on disk is unchanged. Apply any adjustment notes the user appended. |
+| `back` (optionally followed by a phase name) | Move backward one phase (or to the named phase) and re-run from there. Discard state for the affected phases on disk so they're regenerated. |
+| anything else | Treat as adjustment / question. Reason about it in context; if the user is asking a clarifying question, answer and re-show the checkpoint prompt. If the user is requesting a phase modification, apply it and re-run the phase. |
+
+The Phase Template's "Type 'continue' to proceed" line should be updated to:
+
+> Type `continue` to proceed, `stop` to exit cleanly (state is saved — you can resume with `--start-at <next-phase>` later), `redo` to re-run this phase, or give me adjustments.
+
+### Practical re-entry examples
+
+```bash
+# First-time, full run end-to-end
+/llm-obs-eval-pipeline lux --project-name lux
+
+# (user typed 'stop' at Checkpoint 5)
+# Later, pick up where they left off:
+/llm-obs-eval-pipeline lux --project-name lux --start-at experiment
+
+# Already have a dataset published; want to scaffold + run an experiment around it
+/llm-obs-eval-pipeline lux --project-name lux --start-at experiment --dataset-name lux_seed_v3
+
+# Re-analyze a previous experiment without re-running it
+/llm-obs-eval-pipeline lux --start-at analyze --experiment-id 8a3f9c2b-...
+
+# Slice — just classify + RCA, leave the rest for later
+/llm-obs-eval-pipeline lux --stop-after rca
+
+# Continue from the slice above without redoing classify
+/llm-obs-eval-pipeline lux --start-at eval-bootstrap --stop-after eval-bootstrap
+```
+
+`--start-at` and `--stop-after` compose freely. Internally, `--start-at X --stop-after Y` runs exactly phases X through Y inclusive (and the run is invalid if Y < X — error out at argument parse time).
+
+---
+
 ## Orchestration Rules
 
 - **Always run the precheck, even on re-invocations.** It's cheap and it catches a stale `ml_app` argument, an expired auth token, or a typo in `--project-name` before you waste a sub-skill call.
 - **Always emit the precheck block.** Even though it isn't a "phase", users have learned to look for it as the first output.
-- **Never auto-advance between phases.** Every checkpoint waits for explicit user input. If the user says something other than "continue" (e.g. "skip ahead", "redo phase 2"), interpret and act — but never silently move on.
+- **Never auto-advance between phases.** Every checkpoint waits for explicit user input. The recognized checkpoint vocabulary is `continue` / `stop` / `redo` / `back` plus free-text adjustments — see "State persistence and entry/exit → Mid-run exit at any checkpoint" for the full table.
+- **Persist phase output before showing the checkpoint.** Every phase writes its primary output to `<output-dir>/state/0N-<name>.{md,json}` *before* the checkpoint prompt is rendered. This way `stop` at any point leaves a re-enterable artifact on disk — the user can resume later with `--start-at <next-phase>` and the skill will load the prior state without re-running anything.
+- **Honor `--start-at` precisely.** When `--start-at <phase>` is set, load every prior phase's state file (or its override flag if supplied), print a one-line confirmation per loaded phase in the Precheck, and begin from the named phase. If a required state file is missing and no override was passed, fail fast — do not silently re-run the missing phase.
 - **Never truncate sub-skill output.** The user is here to learn what the sub-skills do; if you summarize their output, you defeat the pedagogical purpose. Reproduce verbatim. Downstream phases also depend on the full text being in context (Phase 2 detects Phase 1's classification summary; Phase 3 detects Phase 2's failure taxonomy).
 - **The phase envelope is invariant.** The banner ("You are here. Phase N of 8…"), the entity block, the action label, and the checkpoint header must appear identically across every phase. The *content inside* may differ; the envelope must not. This is the determinism the skill promises.
 - **Execute only at Phases 5 and 7.** No other phase runs code on the user's machine. If a sub-skill output suggests the user should run something themselves, hand it off — don't quietly execute it.

--- a/dd-llmo/llm-obs-eval-pipeline/SKILL.md
+++ b/dd-llmo/llm-obs-eval-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-obs-eval-pipeline
-description: End-to-end LLM Observability pipeline for an instrumented ml_app — classify production traces, root-cause failures, bootstrap evaluators, then (optionally) sample a dataset, publish it, generate an experiment, run it, and analyze results. Eight narrated phases with a standardized banner and a "continue" checkpoint between each. Pure orchestration over the dd-llmo sub-skills (`llm-obs-session-classify`, `llm-obs-trace-rca`, `llm-obs-eval-bootstrap`, `llm-obs-experiment-py-bootstrap`, `llm-obs-experiment-analyzer`). Use when user says "run the eval pipeline", "go from traces to evals", "bootstrap evals end to end", "classify then RCA then bootstrap", "build an eval set from scratch", "onboard me to datasets and experiments", "walk me through experiments", "I have an ml_app, now what", "LLM Obs onboarding", "guided experiment setup", "from traces to experiments", or wants a deterministic, narrated tour from production data through evaluators, datasets, and experiments. Stop early with `--stop-after <phase>` to short-circuit at evaluators / dataset / experiment.
+description: End-to-end LLM Observability pipeline for an instrumented ml_app — classify production traces, root-cause failures, bootstrap evaluators, then (optionally) sample + publish a dataset, generate + run an experiment, and analyze results. Six narrated phases with a standardized banner and a "continue" checkpoint between each. Pure orchestration over the dd-llmo sub-skills (`llm-obs-session-classify`, `llm-obs-trace-rca`, `llm-obs-eval-bootstrap`, `llm-obs-experiment-py-bootstrap`, `llm-obs-experiment-analyzer`). Use when user says "run the eval pipeline", "go from traces to evals", "bootstrap evals end to end", "classify then RCA then bootstrap", "build an eval set from scratch", "onboard me to datasets and experiments", "walk me through experiments", "I have an ml_app, now what", "LLM Obs onboarding", "guided experiment setup", "from traces to experiments", or wants a deterministic, narrated tour from production data through evaluators, datasets, and experiments. Stop early with `--stop-after <phase>` to short-circuit at evaluators or dataset, or resume mid-flow with `--start-at <phase>`.
 ---
 
 ## Backend
@@ -17,7 +17,7 @@ description: End-to-end LLM Observability pipeline for an instrumented ml_app �
 
 `--backend pup` is accepted anywhere in the invocation arguments. Strip it from args before passing to sub-skills, but carry the pup-mode decision forward — every sub-skill must also operate in pup mode for the entire pipeline run.
 
-**Sub-skill backend propagation**: The backend detected at startup applies to all sub-skills invoked across the eight phases. Do not re-detect per phase. Announce once at startup:
+**Sub-skill backend propagation**: The backend detected at startup applies to all sub-skills invoked across the six phases. Do not re-detect per phase. Announce once at startup:
 - MCP mode: "(Running in MCP mode — all features available.)"
 - pup mode: "(Running in pup mode — pup commands used throughout. All features available.)"
 
@@ -29,27 +29,24 @@ description: End-to-end LLM Observability pipeline for an instrumented ml_app �
 
 # LLM Obs Eval Pipeline — Classify → RCA → Eval Bootstrap → Dataset → Experiment → Analyze
 
-A deterministic, eight-phase guided pipeline for an already-instrumented `ml_app` owner. Each phase has the same envelope — a banner that names the entity being produced, an explanation of its purpose, the action (a sub-skill call or a small executable step), and a checkpoint. **You always know where you are.**
+A deterministic, six-phase guided pipeline for an already-instrumented `ml_app` owner. Each phase has the same envelope — a banner that names the entity being produced, an explanation of its purpose, the action (a sub-skill call or a small executable step), and a checkpoint. **You always know where you are.**
 
 ```
 [Precheck] verify ml_app, project, backend, credentials, output dir
    ↓
-[Phase 1: Classify ml_app traces]      entity: ml_app, trace, span
+[Phase 1: Classify ml_app traces]        entity: ml_app, trace, span
    ↓
-[Phase 2: Root cause analysis]         entity: failure mode, root cause
+[Phase 2: Root cause analysis]           entity: failure mode, root cause
    ↓
-[Phase 3: Bootstrap evaluators]        entity: evaluator, LLM judge
-   ↓                                   (stop here with --stop-after eval-bootstrap
-   ↓                                    for the classic eval-pipeline behavior)
-[Phase 4: Create dataset from traces]  entity: dataset record
-   ↓
-[Phase 5: Publish dataset]             entity: published dataset, dataset_name
-   ↓
-[Phase 6: Generate experiment code]    entity: experiment, task, evaluator
-   ↓
-[Phase 7: Run experiment]              entity: experiment run, experiment.url
-   ↓
-[Phase 8: Analyze experiment]          entity: metric, comparison, recommendation
+[Phase 3: Bootstrap evaluators]          entity: evaluator, LLM judge
+   ↓                                     (stop here with --stop-after eval-bootstrap
+   ↓                                      for the classic eval-pipeline behavior)
+[Phase 4: Create + publish dataset]      entity: dataset record, published dataset
+   ↓                                     (executes: LLMObs.create_dataset)
+[Phase 5: Generate + run experiment]     entity: experiment, task, evaluator, run
+   ↓                                     (executes: python <generated_file>)
+   ↓                                     (in-phase review beat before run)
+[Phase 6: Analyze experiment]            entity: metric, comparison, recommendation
 ```
 
 This skill is **pure orchestration plus pedagogy** — no new analytical logic. The work happens inside the sub-skills (`llm-obs-session-classify`, `llm-obs-trace-rca`, `llm-obs-eval-bootstrap`, `llm-obs-experiment-py-bootstrap`, `llm-obs-experiment-analyzer`). What this skill adds is the deterministic envelope: every phase has the same shape, the same checkpoint contract, and the same entity-explanation banner — so the user gets a consistent, narrated experience regardless of how they phrased the original request.
@@ -60,8 +57,8 @@ This skill is **pure orchestration plus pedagogy** — no new analytical logic. 
 /llm-obs-eval-pipeline <ml_app> [--project-name <name>] [--timeframe <window>] [--trace-limit <N>]
                                 [--format py|ipynb] [--evaluator-style function|class|remote]
                                 [--data-only | --publish]
-                                [--start-at classify|rca|eval-bootstrap|dataset|publish|experiment|run|analyze]
-                                [--stop-after classify|rca|eval-bootstrap|dataset|publish|experiment|run|analyze]
+                                [--start-at classify|rca|eval-bootstrap|dataset|experiment|analyze]
+                                [--stop-after classify|rca|eval-bootstrap|dataset|experiment|analyze]
                                 [--classification-summary <path>] [--rca-report <path>]
                                 [--dataset-file <path>] [--dataset-name <name>]
                                 [--experiment-file <path>] [--experiment-id <uuid> | --experiment-url <url>]
@@ -79,18 +76,18 @@ Arguments: $ARGUMENTS
 | `--project-name` | No | derived from `pyproject.toml` / `setup.cfg` / `setup.py` / `package.json` / cwd (same order as `llm-obs-experiment-py-bootstrap`); falls back to `experiment-sdk-default` | The Datadog **project** the pipeline writes datasets and experiments into. The SDK lazily creates the project on first use via `LLMObs.enable(project_name=...)`. Surface this in the Precheck so the user can confirm before anything is created. |
 | `--timeframe` | No | `now-7d` | Lookback window for Phase 1 classification and Phase 4 dataset sampling. |
 | `--trace-limit` | No | `20` | Sampling cap for Phase 4. Phase 1 internally uses `min(20, --trace-limit)` for the classification sample. |
-| `--format` | No | `py` | Passed to `llm-obs-experiment-py-bootstrap` in Phase 6: `py` (script) or `ipynb` (Jupyter notebook). |
-| `--evaluator-style` | No | `function` | Passed to `llm-obs-eval-bootstrap` (Phase 3) and `llm-obs-experiment-py-bootstrap` (Phase 6): `function`, `class`, or `remote`. |
+| `--format` | No | `py` | Passed to `llm-obs-experiment-py-bootstrap` in Phase 5: `py` (script) or `ipynb` (Jupyter notebook). |
+| `--evaluator-style` | No | `function` | Passed to `llm-obs-eval-bootstrap` (Phase 3) and `llm-obs-experiment-py-bootstrap` (Phase 5): `function`, `class`, or `remote`. |
 | `--data-only` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: emit JSON spec instead of Python SDK code. |
 | `--publish` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: publish online LLM-judge evaluators to Datadog. |
-| `--stop-after <phase>` | No | `analyze` (run everything) | Stop after the named phase completes. `classify` = Phase 1 only. `rca` = through Phase 2. `eval-bootstrap` = through Phase 3 (matches the classic eval-pipeline). `dataset` = through Phase 4. `publish` = through Phase 5. `experiment` = through Phase 6 (file generated, not run). `run` = through Phase 7 (skip analyzer). `analyze` = all eight phases (default). |
+| `--stop-after <phase>` | No | `analyze` (run everything) | Stop after the named phase completes. `classify` = Phase 1 only. `rca` = through Phase 2. `eval-bootstrap` = through Phase 3 (matches the classic eval-pipeline). `dataset` = through Phase 4 (dataset created + published). `experiment` = through Phase 5 (experiment generated + run). `analyze` = all six phases (default). |
 | `--start-at <phase>` | No | `classify` (start at the top) | Skip earlier phases and start at the named phase. Same vocabulary as `--stop-after`. The skill auto-loads any required prior-phase artifacts from `<output-dir>/state/` (see "State persistence and entry/exit" section). For phases that need an artifact the auto-load can't find, supply it via one of the override flags below. Combinable with `--stop-after` to run a contiguous slice of the pipeline. |
 | `--classification-summary <path>` | No | auto-loaded from `<output-dir>/state/01-classification.md` if `--start-at rca` or later | Override the Phase 1 output that Phase 2 consumes. Useful when the prior state file is missing or you want to point at a hand-edited version. |
 | `--rca-report <path>` | No | auto-loaded from `<output-dir>/state/02-rca-report.md` if `--start-at eval-bootstrap` or later | Override the Phase 2 output that Phase 3 consumes. |
-| `--dataset-file <path>` | No | auto-loaded from `<output-dir>/state/04-dataset.json` (or the most recent `<output-dir>/dataset_<ml_app>_*.json`) if `--start-at publish` | The local `DatasetRecordRaw[]` JSON that Phase 5 publishes. |
-| `--dataset-name <name>` | No | auto-loaded from `<output-dir>/state/05-published-dataset.json` if `--start-at experiment` | The name of a published Datadog dataset that Phase 6 wires the experiment to. |
-| `--experiment-file <path>` | No | auto-loaded from `<output-dir>/state/06-experiment.json` (which points at the actual `.py` / `.ipynb`) if `--start-at run` | The generated experiment file Phase 7 executes. |
-| `--experiment-id <uuid>` | No | auto-loaded from `<output-dir>/state/07-experiment-run.json` if `--start-at analyze` | The Datadog experiment ID Phase 8 analyzes. Mutually exclusive with `--experiment-url`. |
+| `--dataset-file <path>` | No | auto-loaded from `<output-dir>/state/04-published-dataset.json`'s `dataset_file` field (or the most recent `<output-dir>/dataset_<ml_app>_*.json`) | The local `DatasetRecordRaw[]` JSON. Used by Phase 4's publish sub-step when re-publishing without re-sampling. |
+| `--dataset-name <name>` | No | auto-loaded from `<output-dir>/state/04-published-dataset.json` if `--start-at experiment` | The name of a published Datadog dataset that Phase 5 wires the experiment to. |
+| `--experiment-file <path>` | No | auto-loaded from `<output-dir>/state/05-experiment-run.json`'s `experiment_file` field if `--start-at experiment` and the file already exists | The generated experiment file. When present, Phase 5 skips the codegen sub-step (5a) and goes straight to the review beat (5b) → run (5c). |
+| `--experiment-id <uuid>` | No | auto-loaded from `<output-dir>/state/05-experiment-run.json` if `--start-at analyze` | The Datadog experiment ID Phase 6 analyzes. Mutually exclusive with `--experiment-url`. |
 | `--experiment-url <url>` | No | auto-loaded as above | Alternative to `--experiment-id`. The skill parses the trailing UUID out of the URL. |
 | `--app-root` | No | resolved from cwd / `pyproject.toml` etc. | Restricts `llm-obs-experiment-py-bootstrap`'s task-function introspection to this directory tree. |
 | `--env-file` | No | none (auto-discovery walks standard locations) | Explicit `.env` path for credential loading. Surfaced in the Precheck and baked into the generated experiment as `ENV_FILE_OVERRIDE`. |
@@ -111,11 +108,11 @@ Before Phase 1, run a single short verification pass — do **not** announce a "
 
 3. **Resolve `project_name`** — if `--project-name <name>` was supplied, use it verbatim. Otherwise derive using the same resolution order as `llm-obs-experiment-py-bootstrap` (Workflow step 1): `pyproject.toml` → `setup.cfg` → `setup.py` → `package.json` → cwd basename (slugified). Final value is `experiment-<service-name>`; fall back to `experiment-sdk-default` if nothing resolves and emit a warning telling the user to set `--project-name` explicitly.
 
-   **Project creation semantics**: the project is created lazily by the Datadog SDK the first time `LLMObs.enable(project_name=...)` is called against the org (in Phase 5's publish script and Phase 6's generated experiment). The user does not need to pre-create anything in the UI. Surface the chosen project name in the Precheck output so the user can override before Phase 5 if it isn't what they wanted.
+   **Project creation semantics**: the project is created lazily by the Datadog SDK the first time `LLMObs.enable(project_name=...)` is called against the org (in Phase 4's publish script, and again in Phase 5's generated experiment). The user does not need to pre-create anything in the UI. Surface the chosen project name in the Precheck output so the user can override before Phase 4 if it isn't what they wanted.
 
 4. **Ensure `--output-dir` and `<output-dir>/state/` exist** — `mkdir -p <output-dir>/state` via Bash. Cheap. The `state/` subdirectory is where phase outputs get persisted (see "State persistence and entry/exit" below).
 
-5. **Resolve credentials.** Walk the discovery order below to find Datadog credentials before Phase 5 needs them — failing late at the publish step is bad UX. Read-only at this stage: do NOT write any new files. Do NOT print secret values to the user; only report which file was loaded and which keys were resolved.
+5. **Resolve credentials.** Walk the discovery order below to find Datadog credentials before Phase 4 needs them — failing late at the publish step is bad UX. Read-only at this stage: do NOT write any new files. Do NOT print secret values to the user; only report which file was loaded and which keys were resolved.
 
    **Discovery order** (first hit per variable wins; shell env vars always override files):
    1. **`--env-file <path>`** override if supplied — always tried first.
@@ -150,7 +147,7 @@ Output the precheck summary, then start Phase 1:
 
 - Backend: <MCP | pup>
 - ml_app `<ml_app>` has traces in <timeframe>: yes (<sample_count> root spans found)
-- Project name: `<project_name>` (created lazily on first LLMObs.enable() call in Phase 5)
+- Project name: `<project_name>` (created lazily on first LLMObs.enable() call in Phase 4)
 - Output dir: `<output-dir>` (created)
 - Credentials: <one of:
     "loaded from shell env (DD_API_KEY, DD_APPLICATION_KEY, DD_SITE)"
@@ -159,7 +156,7 @@ Output the precheck summary, then start Phase 1:
   >
 - Stop-after: <phase from --stop-after, default `analyze`>
 
-Starting Phase 1 of 8.
+Starting Phase 1 of 6.
 ```
 
 The exact list of keys in the credentials parenthetical reflects what was actually discovered (so the user can verify nothing surprising was loaded). Never print the values.
@@ -171,9 +168,9 @@ The exact list of keys in the credentials parenthetical reflects what was actual
 Every phase below uses this exact template. Do not deviate — the deterministic envelope is what makes the pipeline experience consistent across invocations.
 
 ```
-## Phase N of 8: <Title>
+## Phase N of 6: <Title>
 
-**You are here.** Phase N of 8 — <one-line position summary>.
+**You are here.** Phase N of 6 — <one-line position summary>.
 
 **What this phase produces**: <Entity name>
 **What a <entity> is**: <2-3 sentence definition tailored to this phase>
@@ -363,112 +360,82 @@ Wait for explicit user confirmation. If `--stop-after eval-bootstrap` is set, th
 
 ---
 
-## Phase 4: Create dataset from prod traces
+## Phase 4: Create and publish dataset
 
-**Entity**: `dataset`, `dataset record`.
+**Entity**: `dataset`, `dataset record`, published dataset (Datadog-side), `dataset_name`, version.
 
 **Pedagogy banner**:
 
-> **What a dataset is**: a named collection of records that an experiment runs against. Each record has `input_data` (what the task receives) and optionally `expected_output` (what you expect back). Datasets live in Datadog under your project and have a version — every time you push changes, a new version is created.
+> **What a dataset is**: a named collection of records that an experiment runs against. Each record has `input_data` (what the task receives) and optionally `expected_output` (what you expect back). Datasets live in Datadog under your project and have a version — every push that changes records produces a new version.
 >
 > **What a record is**: a single `(input_data, expected_output)` pair, optionally with `metadata` and `tags`. One record = one experiment row.
 >
-> **Why this phase matters**: experiments need a stable input set. Sampling production traces gives you a realistic starting dataset — the inputs your app actually sees — without making you write fixtures by hand.
+> **What "publishing" means**: pushing the local records to Datadog so the dataset becomes addressable by name across all subsequent experiments. After publish, anyone in your org (with access) can pull it with `LLMObs.pull_dataset(dataset_name="…")` — including the experiment code we generate in Phase 5.
+>
+> **Why this phase matters**: experiments need a stable, addressable input set. Sampling production traces gives you a realistic starting dataset (the inputs your app actually sees), and publishing it under your project makes it the contract between dataset curation and the experiments that consume it.
 
-**Action**: Follow the **`llm-obs-eval-bootstrap`** skill in **`--emit-dataset` mode**:
+**This phase executes code on your machine** (the publish step writes to Datadog via `LLMObs.create_dataset(...)`). The dataset-create step is read-only; the publish step is the one that changes state.
+
+**Action — two sub-steps, no intermediate checkpoint:**
+
+**4a — Sample traces into a `DatasetRecordRaw[]` JSON.** Follow the **`llm-obs-eval-bootstrap`** skill in **`--emit-dataset` mode**:
 
 ```
 /eval-bootstrap <ml_app> --timeframe <timeframe> --trace-limit <trace-limit> --emit-dataset <output-dir>/dataset_<ml_app>_<YYYYMMDD>.json
 ```
 
-This mode samples root spans, extracts `(input_data, expected_output)` pairs from each, applies a PII scrub, and writes a `DatasetRecordRaw[]` JSON file. **It does not propose or generate evaluators in this mode** — the dataset is the sole artifact. See `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` → Phase 3D for the full spec.
+This mode samples root spans, extracts `(input_data, expected_output)` pairs, applies a PII scrub, and writes the JSON. **It does not propose or generate evaluators** — the dataset is the sole artifact. See `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` → Phase 3D for the full spec.
 
 If the user excluded specific traces in Checkpoint 1, pass that exclusion list along (sub-skill drops them during sampling — do NOT re-classify).
 
 Reproduce the sub-skill's `## Generated Dataset` summary verbatim.
 
-### Checkpoint 4
-
-```
-## Phase 4 complete — local dataset file ready
-
-- File: `<path>`
-- Records: <N> (skipped: <M> with no usable output)
-- PII redactions: <P>
-- Tag normalizations: <T>
-- Caveat: `expected_output` is the **current production behavior baseline**, not ground truth. Spot-check a few records before publishing.
-
-Next up — Phase 5 will publish this dataset to Datadog under project `<project_name>` so an experiment can pull it by name.
-
-Before I continue:
-- Want to open the file and edit any records first? (recommended — spot-check at least 3–5)
-- Happy with the proposed dataset name `<ml_app>_seed_<YYYYMMDD>`, or pick another?
-- Any records you want me to drop?
-
-Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
-```
-
-Wait for confirmation. The proposed `dataset_name` defaults to `<ml_app>_seed_<YYYYMMDD>` but the user can override — carry the final chosen name into Phase 5.
-
----
-
-## Phase 5: Publish dataset
-
-**Entity**: published dataset (Datadog-side), `dataset_name`, version.
-
-**Pedagogy banner**:
-
-> **What "publishing" means**: pushing the local records to Datadog so the dataset becomes addressable by name across all subsequent experiments. After publish, anyone in your org (with access) can pull it with `LLMObs.pull_dataset(dataset_name="…")` — including the experiment code we generate in Phase 6.
->
-> **What a dataset version is**: every push that changes records produces a new version. You can pin an experiment to a specific version (`pull_dataset(version=N)`) so a refactor of the dataset doesn't silently change which inputs your experiment runs on.
->
-> **Why this phase matters**: a published, named dataset is the contract between your dataset curation work (which lives in code/JSON) and the experiments that consume it. Without this phase, the experiment in Phase 6 has no input.
-
-**This is one of the two phases in this pipeline where executable code is run.** The user is in "publish" mode and that's the clear, expected signal.
-
-**Action**: Invoke the pre-shipped publish helper at `<this-skill-dir>/scripts/publish_dataset.py` via Bash. **Do not** inline the script content into this SKILL.md or re-write it from scratch — the helper is the source of truth for the publish flow (credential discovery, tag normalization, project creation, error handling). It accepts CLI args, so no placeholder substitution is needed.
-
-Invocation:
+**4b — Publish to Datadog.** Immediately invoke the pre-shipped publish helper at `<this-skill-dir>/scripts/publish_dataset.py` via Bash. **Do not** inline the script content into this SKILL.md or re-write it from scratch — the helper is the source of truth for the publish flow (credential discovery, tag normalization, project creation, error handling). It accepts CLI args, so no placeholder substitution is needed.
 
 ```bash
 python <skill-dir>/scripts/publish_dataset.py \
-  --records <absolute path to dataset JSON from Phase 4> \
-  --dataset-name <chosen dataset_name from Checkpoint 4> \
+  --records <absolute path to JSON from 4a> \
+  --dataset-name <chosen dataset_name, default <ml_app>_seed_<YYYYMMDD>> \
   --project-name <resolved project_name from Precheck> \
   [--env-file <path>]   # repeatable; takes precedence over auto-discovery
 ```
 
-`<skill-dir>` resolves to wherever the skill is installed (e.g., `~/.claude/skills/llm-obs-eval-pipeline/`). The script bundles two sibling modules — `scripts/load_env.py` (the env-file discovery walker, identical to the one the generated experiment file ships with) and inline tag normalization — and prints either:
+`<skill-dir>` resolves to wherever the skill is installed (e.g., `~/.claude/skills/llm-obs-eval-pipeline/`). The script prints either:
 
 - `Loaded credentials from: <file paths>` (if any `.env` files contributed values), then
 - `OK dataset_name=<name> record_count=<N> url=<url>` (on success), or
 - `ERROR: <message>` on stderr with a non-zero exit (auth, missing keys, ddtrace import failure, etc.).
 
 **Notes for the orchestrator:**
-- Before invoking, do an import-availability precheck: `python -c "import ddtrace.llmobs"` via Bash. If it fails, stop and tell the user:
-  > "`ddtrace` is not installed in the active Python environment. Run `pip install 'ddtrace>=4.7'` and re-invoke this skill (re-run from the top — Phases 1–4 outputs are idempotent)."
-- The script's discovery walk mirrors the Precheck. If the Precheck already loaded credentials, the script's `_load_env_files()` will just be a confirmation no-op (the keys are already in `os.environ`).
-- `LLMObs.enable(project_name=...)` inside the script is where the `--project-name` from the Precheck actually materializes — the Datadog project is created lazily on first call.
-- If the script prints a `WARNING:` line about tag normalization, surface it in Checkpoint 5 so the user knows their upstream dataset had malformed tags.
-- If the script prints `Loaded credentials from: ...`, include that file path in Checkpoint 5.
-- If the script exits non-zero with an auth error (401/403), surface the stderr and stop — do not retry. Tell the user the most likely cause is a stale `.env` value, and that `export DD_API_KEY=... DD_APPLICATION_KEY=...` in their shell takes precedence and can be used to override.
-- On success, capture the printed `dataset_name` and `url` and carry them into Phase 6.
 
-### Checkpoint 5
+- Before invoking the publish helper, do an import-availability precheck: `python -c "import ddtrace.llmobs"` via Bash. If it fails, stop and tell the user:
+  > "`ddtrace` is not installed in the active Python environment. Run `pip install 'ddtrace>=4.7'` and re-invoke this skill (re-run from the top — Phases 1–3 outputs are idempotent)."
+- `LLMObs.enable(project_name=...)` inside the script is where the `--project-name` from the Precheck actually materializes — the Datadog project is created lazily on first call.
+- If the script prints a `WARNING:` line about tag normalization, surface it in Checkpoint 4 so the user knows their upstream dataset had malformed tags.
+- If the script prints `Loaded credentials from: ...`, include that file path in Checkpoint 4.
+- If the script exits non-zero with an auth error (401/403), surface the stderr and stop — do not retry. Tell the user the most likely cause is a stale `.env` value, and that `export DD_API_KEY=... DD_APPLICATION_KEY=...` in their shell takes precedence and can be used to override.
+- On success, capture the printed `dataset_name` and `url` and carry them into Phase 5. Write both to the Phase 4 state file (see State persistence section).
+
+**Why no intermediate checkpoint between 4a and 4b?** The local JSON is auto-extracted from traces and goes straight into `LLMObs.create_dataset(records=...)` — there is essentially no editable surface between the two steps in the common case. Users who want to inspect or edit the JSON before publish should run `eval-bootstrap --emit-dataset` standalone, edit the JSON, then re-enter this pipeline with `--start-at experiment --dataset-name <name>` once they've published manually.
+
+### Checkpoint 4
 
 ```
-## Phase 5 complete — dataset published
+## Phase 4 complete — dataset created and published
 
-- Dataset name: `<dataset_name>`
-- Project: `<project_name>` <(created if it did not exist)>
-- Records published: <N>
+- Local file: `<path>` (kept for inspection / re-publish)
+- Records emitted: <N> (skipped: <M> with no usable output)
+- PII redactions: <P>
+- Tag normalizations: <T>
+- Published as: `<dataset_name>` in project `<project_name>` <(created if it did not exist)>
 - Datadog UI: <url or "open LLM Observability → Datasets to confirm">
+- Caveat: `expected_output` is the **current production behavior baseline**, not ground truth. Treat the dataset as a regression-style baseline before promoting it to a labelled gold set.
 
-Next up — Phase 6 will generate a Python experiment script that pulls this dataset and runs your task code (auto-discovered) against it.
+Next up — Phase 5 will generate a Python experiment script that pulls `<dataset_name>` and runs your task code (auto-discovered) against it.
 
 Before I continue:
 - Confirm you can see the dataset in the Datadog UI (LLM Observability → Datasets → search `<dataset_name>`)?
-- Any second thoughts on the dataset records (we can re-emit before generating the experiment)?
+- Any second thoughts on the records (we can re-emit and re-publish before generating the experiment)?
 
 Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
@@ -477,9 +444,9 @@ Wait for confirmation.
 
 ---
 
-## Phase 6: Generate experiment code
+## Phase 5: Generate and run experiment
 
-**Entity**: `experiment`, `task` function, `evaluator`.
+**Entity**: `experiment`, `task` function, `evaluator`, experiment run, `experiment.url`, metric stream.
 
 **Pedagogy banner**:
 
@@ -489,9 +456,15 @@ Wait for confirmation.
 >
 > **What an evaluator is**: covered in Phase 3 above. The generated experiment ships placeholder evaluators by default; if you ran Phase 3 with `--evaluator-style remote`, you can wire those names in here.
 >
-> **Why this phase matters**: this is the artifact you'll actually run. Everything before this phase was prep work.
+> **What `experiment.url` is**: the deep link to the run in the Datadog Experiments UI. Phase 6 uses this to analyze results.
+>
+> **Why this phase matters**: this is where your code actually executes against the dataset and produces measurements. Generation is the cheap part; running is what costs provider tokens and produces signal.
 
-**Action**: Follow the **`llm-obs-experiment-py-bootstrap`** skill:
+**This phase executes code on your machine** (Python file is run end-to-end after an in-phase review beat).
+
+**Action — three sub-steps with an in-phase review beat between codegen and run:**
+
+**5a — Generate the experiment file.** Follow the **`llm-obs-experiment-py-bootstrap`** skill:
 
 ```
 /llm-obs-experiment-py-bootstrap \
@@ -504,82 +477,66 @@ Wait for confirmation.
   --output <output-dir>/experiment_<ml_app>_<YYYYMMDD>.<py|ipynb>
 ```
 
-Reproduce the sub-skill's full output (including the generated SDK calls summary, the "Task function source" block, the credential discovery section, and the Next steps block) verbatim. Do not summarize. The "Task function source" block tells the user which `module:function` was auto-wired — that's load-bearing for Checkpoint 6.
+Reproduce the sub-skill's full output (including the generated SDK calls summary, the "Task function source" block, the credential discovery section, and the Next steps block) verbatim. Do not summarize. The "Task function source" block tells the user which `module:function` was auto-wired — that's load-bearing for the next sub-step.
 
-### Checkpoint 6
+**5b — In-phase review beat (MANDATORY).** After the sub-skill output, **pause** with a brief inline prompt (this is NOT a full checkpoint with a new banner — it's a single-line review beat *inside* Phase 5):
 
 ```
-## Phase 6 complete — experiment file ready to run
+## Phase 5 — review the generated experiment before running
 
 - File: `<path>`
-- Format: <py | ipynb>
 - Wired to dataset: `<dataset_name>` (pulled at runtime via LLMObs.pull_dataset)
-- Task function source: <line lifted from the sub-skill — names the discovered module:function, or notes the placeholder fallback>
-- Evaluators: <list the 2–3 evaluator names from the sub-skill output>
+- Task function source: <line lifted from the sub-skill output — module:function, or "placeholder fallback">
+- Evaluators: <2–3 evaluator names>
 
-Next up — Phase 7 will run this file end-to-end against the published dataset.
+**Open the file and check three things before I run it:**
+1. The wired `task_fn` (section 4) — confirm the sub-skill picked the right entry point. If it picked a helper or deprecated path, edit the import to point at the right function. If it fell back to a placeholder, replace it with a real call.
+2. The placeholder evaluators (section 5) — these are starting points. If Phase 3 produced online evaluators via `--publish`, swap one of the placeholders for a `RemoteEvaluator(eval_name="...")`.
+3. The `experiment.run(jobs=<N>)` parallelism (section 7) — defaults to 10; lower it if you're worried about rate limits.
 
-**Before continuing — open the file and look at three things**:
-1. The wired `task_fn` (section 4 of the generated file). The sub-skill introspected your app and imported the most likely entry point — **confirm it picked the right function**. If it picked a sibling helper or a deprecated path, edit the import in section 4 to point at the function you actually want to evaluate. If the sub-skill fell back to a placeholder (no LLM call site found in `<app-root>`), this is the phase where you replace it with a real call.
-2. The placeholder evaluators — these are starting points. You can leave them for the first run, or refine. If Phase 3 produced online evaluators via `--publish`, swap one of the placeholders for a `RemoteEvaluator(eval_name="...")` referencing your judge.
-3. The `experiment.run(jobs=<N>)` parallelism — defaults to 10; lower it if you're worried about rate limits.
-
-Then confirm:
-- Have you set `DD_API_KEY`, `DD_APPLICATION_KEY`, `DD_SITE` (if non-default), and the provider key your task needs (the generated file's section 1 asserts only the right one — check what it expects)?
-- Ready to run?
-
-Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
+Type **`run`** to execute the file as-is, **`edit`** to pause here so you can edit and re-run this skill, or **`stop`** to exit cleanly. State for Phase 4 and earlier is preserved.
 ```
 
-Wait for confirmation.
+Wait for the user's reply.
 
----
+- If `run`: proceed to 5c.
+- If `edit`: tell the user the file is at `<path>` and they can re-invoke this skill with `--start-at experiment` once they're satisfied. End the run cleanly. The generated file path is written to the state file so `--start-at experiment` can resume codegen-free (just re-run sub-step 5c).
+- If `stop`: emit the Stop summary and end. State for completed phases (including the generated experiment file) is preserved on disk.
+- Anything else: treat as adjustment / question. Reason about it, answer, then re-show the review prompt.
 
-## Phase 7: Run experiment
-
-**Entity**: experiment run, `experiment.url`, metric stream.
-
-**Pedagogy banner**:
-
-> **What "running the experiment" means**: iterating over every record in the dataset, calling your `task` function, then calling each evaluator on the result, and streaming the scores to Datadog. The SDK creates the experiment in Datadog the first time it runs and updates the same experiment record on re-runs (if you keep the same `name=`).
->
-> **What `experiment.url` is**: the deep link to the run in the Datadog Experiments UI. Phase 8 uses this to analyze results.
->
-> **Why this phase matters**: until you actually run the experiment, the dataset and the code are just plumbing. The run is what produces the first measurements.
-
-**This is the second of the two phases in this pipeline where executable code is run.** Clearly signal it.
-
-**Action**: Execute the generated experiment file.
+**5c — Execute the file.**
 
 - For `--format py`: `python <generated_path>` via Bash. Stream output to the user.
 - For `--format ipynb`: tell the user the generated file is a notebook and ask whether to (a) execute it via `jupyter nbconvert --to notebook --execute --inplace <path>` (requires `jupyter` installed), or (b) hand off — the user opens it in JupyterLab and runs cells manually. Default to (a) if `jupyter` is on PATH; otherwise (b).
 - Capture the printed `experiment.url` from the run's stdout — the generated file always ends with `print(experiment.url)`. If you can't find it, parse stdout for the substring `https://app.datadoghq.com/llm/experiments/` (account for non-default `DD_SITE` hosts).
 - If the run fails: do NOT retry automatically. Surface the full traceback, identify the failure category (auth, missing dep, dataset not found, task function raised, evaluator raised) in a one-line diagnosis, and ask the user whether to fix and re-run.
 
-### Checkpoint 7
+### Checkpoint 5
 
 ```
-## Phase 7 complete — experiment run published
+## Phase 5 complete — experiment generated and run
 
+- File: `<path>`
 - Experiment URL: <experiment.url>
 - Records processed: <N>
 - Duration: <wall-clock seconds>
+- Task function: <module:function>
 - Evaluator score summary (from stdout, if printed): <table or "open the UI">
 
-Next up — Phase 8 will pull the experiment results back from Datadog and produce an analysis report (struggling metrics, qualitative examples, root-cause hypotheses).
+Next up — Phase 6 will pull the experiment results back from Datadog and produce an analysis report (struggling metrics, qualitative examples, root-cause hypotheses).
 
 Before I continue:
 - Take a look at the experiment in the UI (link above). Do the per-record scores roughly match your expectations?
-- Any specific question you want Phase 8 to focus on? (Optional — leaving it open runs an exploratory analysis.)
+- Any specific question you want Phase 6 to focus on? (Optional — leaving it open runs an exploratory analysis.)
 
 Type `continue` to proceed, `stop` to exit cleanly (state is saved), `redo` to re-run this phase, or give me adjustments.
 ```
 
-Wait for confirmation. If the user provides a focus question, carry it to Phase 8 as the analyzer's `question` argument.
+Wait for confirmation. If the user provides a focus question, carry it to Phase 6 as the analyzer's `question` argument.
 
 ---
 
-## Phase 8: Analyze experiment
+## Phase 6: Analyze experiment
 
 **Entity**: experiment `metric`, segment comparison, recommendation.
 
@@ -597,7 +554,7 @@ Wait for confirmation. If the user provides a focus question, carry it to Phase 
 /llm-obs-experiment-analyzer <experiment_id_from_url> [<focus question if any>] --output agent
 ```
 
-Extract the `<experiment_id>` from the URL captured in Phase 7 (the trailing UUID after `/llm/experiments/`).
+Extract the `<experiment_id>` from the URL captured in Phase 5 (the trailing UUID after `/llm/experiments/`).
 
 Reproduce the analyzer's full report verbatim.
 
@@ -615,17 +572,15 @@ After the analyzer report, emit the closing summary — this replaces the per-ph
 | 1. Classify ml_app | <N> traces classified (<F> failures) |
 | 2. Root cause analysis | <K> failure modes, <M> root causes |
 | 3. Bootstrap evaluators | <J> evaluators → `<path>` (or "<N> drafts published to Datadog") |
-| 4. Create dataset | <K> records → `<dataset_path>` |
-| 5. Publish dataset | `<dataset_name>` (v1) in project `<project_name>` |
-| 6. Generate experiment code | `<experiment_file_path>` |
-| 7. Run experiment | <experiment.url> |
-| 8. Analyze experiment | <2–3 bullet headline findings from the analyzer> |
+| 4. Create + publish dataset | <K> records → `<dataset_path>`, published as `<dataset_name>` (v1) in project `<project_name>` |
+| 5. Generate + run experiment | `<experiment_file_path>` → <experiment.url> (<N> records, <duration>s) |
+| 6. Analyze experiment | <2–3 bullet headline findings from the analyzer> |
 
 ## What you learned
 
 - The five core entities you touched: **ml_app**, **failure mode**, **evaluator**, **dataset**, **experiment**. Each has a dedicated docs page — see Datadog Documentation below.
 - The loop you can now repeat: **edit dataset → re-run experiment → compare in the UI**. Pull-by-name + auto-versioning makes the loop cheap.
-- The reusable artifacts you produced: an evaluator suite (Phase 3), a published dataset (Phase 5), and an experiment script (Phase 6). All three survive beyond this pipeline run.
+- The reusable artifacts you produced: an evaluator suite (Phase 3), a published dataset (Phase 4), and an experiment script (Phase 5). All three survive beyond this pipeline run.
 
 ## Recommended next steps
 
@@ -647,18 +602,16 @@ After the analyzer report, emit the closing summary — this replaces the per-ph
 
 ## Stop-after handling
 
-`--stop-after <phase>` lets the user exit cleanly before the full eight-phase pipeline completes. Valid values map to the phase numbers:
+`--stop-after <phase>` lets the user exit cleanly before the full six-phase pipeline completes. Valid values map to the phase numbers:
 
 | Value | Stop after | Use case |
 |---|---|---|
 | `classify` | Phase 1 | "I just want to see what's going on in my ml_app." |
 | `rca` | Phase 2 | "I want to understand failure modes — I'll write evaluators myself." |
 | `eval-bootstrap` | Phase 3 | **Matches the classic `llm-obs-eval-pipeline` behavior.** Use for "I want evaluators, not experiments." |
-| `dataset` | Phase 4 | "I want a dataset JSON to inspect / edit before publishing." |
-| `publish` | Phase 5 | "I want the dataset live in Datadog but I'll wire up the experiment myself." |
-| `experiment` | Phase 6 | "Generate the experiment file but don't run it yet." |
-| `run` | Phase 7 | "Run the experiment; I'll do the analysis manually." |
-| `analyze` | Phase 8 (default) | Full pipeline. |
+| `dataset` | Phase 4 | "I want the dataset created and published, but I'll generate / run / analyze the experiment myself." |
+| `experiment` | Phase 5 | "Generate and run the experiment; I'll analyze the results myself." |
+| `analyze` | Phase 6 (default) | Full pipeline. |
 
 When the current phase matches the stop value, **replace the Checkpoint at the bottom of that phase with a Stop summary**:
 
@@ -666,7 +619,7 @@ When the current phase matches the stop value, **replace the Checkpoint at the b
 ## Pipeline stopped — `--stop-after <phase>`
 
 Completed phases: <list 1..stop>
-Skipped: <list stop+1..8 with one-line descriptions>
+Skipped: <list stop+1..6 with one-line descriptions>
 
 Artifacts produced: <list with paths / URLs>
 
@@ -690,11 +643,9 @@ After every successful phase completion (i.e. after the user types `continue` pa
 | 1 classify | `state/01-classification.md` | The full `# Session Classification Summary` block plus all per-unit compact blocks, verbatim from `llm-obs-session-classify`. Markdown. |
 | 2 rca | `state/02-rca-report.md` | The full Phase 6 RCA report from `llm-obs-trace-rca`, verbatim. Markdown. |
 | 3 eval-bootstrap | `state/03-evaluators.json` | `{"mode": "sdk_code\|data_only\|publish", "output_path": "<path>", "evaluator_names": [...], "ml_app": "<ml_app>", "generated_at": "<ISO 8601>"}`. The actual evaluator code/JSON stays where the sub-skill wrote it. |
-| 4 dataset | `state/04-dataset.json` | The same `DatasetRecordRaw[]` content as `<output-dir>/dataset_<ml_app>_<YYYYMMDD>.json`. Treat this as a symlink-or-copy — both paths must point at the same content. |
-| 5 publish | `state/05-published-dataset.json` | `{"dataset_name": "<name>", "project_name": "<name>", "version": <int>, "url": "<datadog url>", "record_count": <int>, "published_at": "<ISO 8601>"}` |
-| 6 experiment | `state/06-experiment.json` | `{"experiment_file": "<path>", "format": "py\|ipynb", "dataset_name": "<name>", "task_source": "<module:function>\|placeholder", "purpose": "<text>", "generated_at": "<ISO 8601>"}` |
-| 7 run | `state/07-experiment-run.json` | `{"experiment_id": "<uuid>", "experiment_url": "<datadog url>", "records_processed": <int>, "duration_seconds": <float>, "ran_at": "<ISO 8601>"}` |
-| 8 analyze | `state/08-analysis.md` | The full analyzer report from `llm-obs-experiment-analyzer`. Markdown. |
+| 4 dataset | `state/04-published-dataset.json` | `{"dataset_file": "<path to local DatasetRecordRaw[] JSON>", "dataset_name": "<published name>", "project_name": "<name>", "version": <int>, "url": "<datadog url>", "record_count": <int>, "skipped_count": <int>, "pii_redactions": <int>, "tag_normalizations": <int>, "published_at": "<ISO 8601>"}` — combines what was previously two state files (`04-dataset.json` and `05-published-dataset.json`) because Phase 4 now creates and publishes in one step. |
+| 5 experiment | `state/05-experiment-run.json` | `{"experiment_file": "<path>", "format": "py\|ipynb", "dataset_name": "<name>", "task_source": "<module:function>\|placeholder", "purpose": "<text>", "experiment_id": "<uuid>", "experiment_url": "<datadog url>", "records_processed": <int>, "duration_seconds": <float>, "generated_at": "<ISO 8601>", "ran_at": "<ISO 8601>"}` — combines what was previously two state files (`06-experiment.json` and `07-experiment-run.json`) because Phase 5 now generates and runs in one step. If the user halts at the in-phase review beat (5b) with `edit`, only the codegen fields are populated; re-entering with `--start-at experiment` reads the file path from here and resumes at 5c. |
+| 6 analyze | `state/06-analysis.md` | The full analyzer report from `llm-obs-experiment-analyzer`. Markdown. |
 
 `<output-dir>/state/` should be created via `mkdir -p` at the top of the Precheck (alongside the existing `<output-dir>` creation). Never write state files outside this directory.
 
@@ -739,7 +690,7 @@ The Phase Template's "Type 'continue' to proceed" line should be updated to:
 # First-time, full run end-to-end
 /llm-obs-eval-pipeline lux --project-name lux
 
-# (user typed 'stop' at Checkpoint 5)
+# (user typed 'stop' at Checkpoint 4)
 # Later, pick up where they left off:
 /llm-obs-eval-pipeline lux --project-name lux --start-at experiment
 
@@ -768,10 +719,11 @@ The Phase Template's "Type 'continue' to proceed" line should be updated to:
 - **Persist phase output before showing the checkpoint.** Every phase writes its primary output to `<output-dir>/state/0N-<name>.{md,json}` *before* the checkpoint prompt is rendered. This way `stop` at any point leaves a re-enterable artifact on disk — the user can resume later with `--start-at <next-phase>` and the skill will load the prior state without re-running anything.
 - **Honor `--start-at` precisely.** When `--start-at <phase>` is set, load every prior phase's state file (or its override flag if supplied), print a one-line confirmation per loaded phase in the Precheck, and begin from the named phase. If a required state file is missing and no override was passed, fail fast — do not silently re-run the missing phase.
 - **Never truncate sub-skill output.** The user is here to learn what the sub-skills do; if you summarize their output, you defeat the pedagogical purpose. Reproduce verbatim. Downstream phases also depend on the full text being in context (Phase 2 detects Phase 1's classification summary; Phase 3 detects Phase 2's failure taxonomy).
-- **The phase envelope is invariant.** The banner ("You are here. Phase N of 8…"), the entity block, the action label, and the checkpoint header must appear identically across every phase. The *content inside* may differ; the envelope must not. This is the determinism the skill promises.
-- **Execute only at Phases 5 and 7.** No other phase runs code on the user's machine. If a sub-skill output suggests the user should run something themselves, hand it off — don't quietly execute it.
+- **The phase envelope is invariant.** The banner ("You are here. Phase N of 6…"), the entity block, the action label, and the checkpoint header must appear identically across every phase. The *content inside* may differ; the envelope must not. This is the determinism the skill promises.
+- **Execute only at Phases 4 and 5.** No other phase runs code on the user's machine. Phase 4 runs the publish script (writes the dataset to Datadog); Phase 5 runs the generated experiment file (calls provider APIs against the dataset). All other phases are read-only or write generated files to `--output-dir`. If a sub-skill output suggests the user should run something themselves, hand it off — don't quietly execute it.
+- **Phase 5 has a mandatory in-phase review beat.** Between sub-step 5a (codegen) and 5c (execute), pause with the in-phase review prompt. Wait for the user to type `run`, `edit`, or `stop`. Never auto-run after codegen.
 - **One backend for the whole run.** Detected at startup, propagated to all sub-skill calls. Do not re-detect mid-run.
-- **`--project-name` is sticky.** Whatever the user picked at Precheck flows unchanged into Phases 5 and 6 and into the final summary. If the user changes their mind at Checkpoint 5, re-run Phase 5 (and only Phase 5) with the new name — do NOT silently rewrite earlier outputs.
+- **`--project-name` is sticky.** Whatever the user picked at Precheck flows unchanged into Phases 4 and 5 and into the final summary. If the user changes their mind at Checkpoint 4, re-run Phase 4 (and only Phase 4) with the new name — do NOT silently rewrite earlier outputs.
 - **Phase re-entry**: if the user types something like "redo phase 4 with --trace-limit 30", re-run that phase only (and clearly say so — "Re-running Phase 4 with the new trace limit. Phases 1–3 outputs are unchanged."). After it completes, fall through to Phase 5 just like a fresh run would.
 
 ---
@@ -782,8 +734,8 @@ This list exists so reviewers can spot scope creep:
 
 - **Does not instrument your app.** Audience assumption: the user already has `ml_app` traces flowing into Datadog. If the precheck finds zero traces, the skill stops and points the user at the instrumentation docs — it does not attempt to bootstrap instrumentation.
 - **Does not push code or commit anything.** All generated files land in `<output-dir>`; the user owns version control.
-- **Does not run any phase's code without an explicit checkpoint confirmation.** Phases 5 and 7 ask before executing.
-- **Does not deeply modify your app.** Phase 6's experiment file *imports* your task function; it does not refactor it. If you want prompt / model variants without editing your app, inline the call inside `task_fn` in the generated file.
+- **Does not run any phase's code without an explicit checkpoint or review confirmation.** Phase 4 advances from the dataset-create sub-step to the publish sub-step automatically (no user-editable surface between them), but Phase 5 pauses at the in-phase review beat between codegen and run — the user types `run` to proceed.
+- **Does not deeply modify your app.** Phase 5's experiment file *imports* your task function; it does not refactor it. If you want prompt / model variants without editing your app, inline the call inside `task_fn` in the generated file.
 - **Does not auto-create `.env` files.** Credential files are discovered, not generated — secrets-on-disk decisions belong to the user.
 
 ---
@@ -793,8 +745,8 @@ This list exists so reviewers can spot scope creep:
 This skill itself does almost no direct tool calls — the only direct calls are:
 
 1. The **precheck** `search_llmobs_spans` (to confirm the ml_app has traces).
-2. `Bash` for **Phase 5** (running the publish script) and **Phase 7** (running the generated experiment).
-3. **No** Write for Phase 5 — the publish helper ships at `scripts/publish_dataset.py` alongside this SKILL.md; the orchestrator invokes it by path with CLI args. The skill does not generate the script on the fly.
+2. `Bash` for **Phase 4** (running the publish script) and **Phase 5** (running the generated experiment).
+3. **No** Write for Phase 4's publish — the publish helper ships at `scripts/publish_dataset.py` alongside this SKILL.md; the orchestrator invokes it by path with CLI args. The skill does not generate the script on the fly.
 
 Everything else routes through sub-skills, which carry their own MCP-to-pup mappings:
 
@@ -803,9 +755,9 @@ Everything else routes through sub-skills, which carry their own MCP-to-pup mapp
 | `llm-obs-session-classify` | Phase 1 | `dd-llmo/llm-obs-session-classify/SKILL.md` (Tool Reference appendix) |
 | `llm-obs-trace-rca` | Phase 2 | `dd-llmo/llm-obs-trace-rca/SKILL.md` (Tool Reference appendix) |
 | `llm-obs-eval-bootstrap` (sdk_code / data_only / publish) | Phase 3 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Tool Reference appendix) |
-| `llm-obs-eval-bootstrap` (`--emit-dataset` mode) | Phase 4 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Phase 3D + Tool Reference appendix) |
-| `llm-obs-experiment-py-bootstrap` | Phase 6 | `dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md` |
-| `llm-obs-experiment-analyzer` | Phase 8 | `dd-llmo/llm-obs-experiment-analyzer/SKILL.md` (Tool Reference appendix) |
+| `llm-obs-eval-bootstrap` (`--emit-dataset` mode) | Phase 4 (sub-step 4a) | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Phase 3D + Tool Reference appendix) |
+| `llm-obs-experiment-py-bootstrap` | Phase 5 (sub-step 5a) | `dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md` |
+| `llm-obs-experiment-analyzer` | Phase 6 | `dd-llmo/llm-obs-experiment-analyzer/SKILL.md` (Tool Reference appendix) |
 
 ### Precheck `search_llmobs_spans` ↔ pup
 

--- a/dd-llmo/llm-obs-eval-pipeline/SKILL.md
+++ b/dd-llmo/llm-obs-eval-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-obs-eval-pipeline
-description: End-to-end pipeline from unlabeled ml_app traces to a bootstrapped evaluator suite. Runs trace classification → root cause analysis → eval bootstrap in sequence with user checkpoints. Use when user says "run the eval pipeline", "go from traces to evals", "bootstrap evals end to end", "classify then RCA then bootstrap", "build an eval set from scratch", or wants a guided walkthrough from production data to evaluator code.
+description: End-to-end LLM Observability pipeline for an instrumented ml_app — classify production traces, root-cause failures, bootstrap evaluators, then (optionally) sample a dataset, publish it, generate an experiment, run it, and analyze results. Eight narrated phases with a standardized banner and a "continue" checkpoint between each. Pure orchestration over the dd-llmo sub-skills (`llm-obs-session-classify`, `llm-obs-trace-rca`, `llm-obs-eval-bootstrap`, `llm-obs-experiment-py-bootstrap`, `llm-obs-experiment-analyzer`). Use when user says "run the eval pipeline", "go from traces to evals", "bootstrap evals end to end", "classify then RCA then bootstrap", "build an eval set from scratch", "onboard me to datasets and experiments", "walk me through experiments", "I have an ml_app, now what", "LLM Obs onboarding", "guided experiment setup", "from traces to experiments", or wants a deterministic, narrated tour from production data through evaluators, datasets, and experiments. Stop early with `--stop-after <phase>` to short-circuit at evaluators / dataset / experiment.
 ---
 
 ## Backend
@@ -15,39 +15,54 @@ description: End-to-end pipeline from unlabeled ml_app traces to a bootstrapped 
 6. If neither is available → stop and tell the user:
    > "Neither the Datadog MCP server nor the pup CLI is available. Connect the MCP server (`claude mcp add --scope user --transport http datadog-llmo-mcp 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'`) or install pup."
 
-`--backend pup` is accepted anywhere in the invocation arguments. Strip it from args before passing to sub-skills, but carry the pup-mode decision forward — sub-skills must also operate in pup mode for the entire pipeline run.
+`--backend pup` is accepted anywhere in the invocation arguments. Strip it from args before passing to sub-skills, but carry the pup-mode decision forward — every sub-skill must also operate in pup mode for the entire pipeline run.
 
-**Sub-skill backend propagation**: The backend detected at pipeline startup applies to all three sub-skills (session-classify → trace-rca → eval-bootstrap). Do not re-detect per phase. Announce once at startup:
+**Sub-skill backend propagation**: The backend detected at startup applies to all sub-skills invoked across the eight phases. Do not re-detect per phase. Announce once at startup:
 - MCP mode: "(Running in MCP mode — all features available.)"
-- pup mode: "(Running in pup mode — pup commands used throughout. RUM signals use `pup rum aggregate`. Notebooks use `pup notebooks create/edit`. All features available.)"
-
-**pup invocation rules:**
-- Invoke via Bash: `pup llm-obs <subcommand> [flags]`
-- pup always outputs JSON. Parse directly — no content-block unwrapping (unlike MCP results).
-- If pup returns an auth error, tell the user to run `pup auth login` and stop.
-- Parallelization: issue multiple Bash tool calls in a single message (one pup command per call).
-- Time flags: pup accepts bare duration strings (`1h`, `7d`, `30m`) and RFC3339 timestamps. Do **not** use `now-`-prefixed strings — strip the prefix when converting from a skill `--timeframe` argument: `now-7d` → `7d`, `now-24h` → `24h`, `now-30d` → `30d`.
+- pup mode: "(Running in pup mode — pup commands used throughout. All features available.)"
 
 **Invocation ID:** At the very start of each invocation, before any MCP tool call, generate an 8-character hex invocation ID (e.g., `3a9f1c2b`). Keep it constant for the entire invocation.
 
-**Intent tagging:** On every MCP tool call, prefix `telemetry.intent` with `skill:llm-obs-eval-pipeline[<inv_id>] — ` followed by a description of why the tool is being called. On the **first MCP tool call only**, use `skill:llm-obs-eval-pipeline:start[<inv_id>] — ` instead (note the `:start` suffix). Example first call: `skill:llm-obs-eval-pipeline:start[3a9f1c2b] — Phase 1: sample root spans for ml_app to begin classification`
+**Intent tagging:** On every MCP tool call, prefix `telemetry.intent` with `skill:llm-obs-eval-pipeline[<inv_id>] — ` followed by a description of why the tool is being called. On the **first MCP tool call only**, use `skill:llm-obs-eval-pipeline:start[<inv_id>] — ` instead (note the `:start` suffix). Example first call: `skill:llm-obs-eval-pipeline:start[3a9f1c2b] — Precheck: verify ml_app has traces in the last 7 days`
 
-# LLM Obs Eval Pipeline — Classify → RCA → Bootstrap
+---
 
-Walks from unlabeled production LLM trace data to a ready-to-use evaluator suite in three phases, with user checkpoints between each. No pre-existing evals or labeled data required.
+# LLM Obs Eval Pipeline — Classify → RCA → Eval Bootstrap → Dataset → Experiment → Analyze
+
+A deterministic, eight-phase guided pipeline for an already-instrumented `ml_app` owner. Each phase has the same envelope — a banner that names the entity being produced, an explanation of its purpose, the action (a sub-skill call or a small executable step), and a checkpoint. **You always know where you are.**
 
 ```
-llm-obs-session-classify  (ml_app mode)
-           ↓
-  llm-obs-trace-rca  (from classifications)
-           ↓
-  llm-obs-eval-bootstrap  (from RCA output)
+[Precheck] verify ml_app, project, backend, credentials, output dir
+   ↓
+[Phase 1: Classify ml_app traces]      entity: ml_app, trace, span
+   ↓
+[Phase 2: Root cause analysis]         entity: failure mode, root cause
+   ↓
+[Phase 3: Bootstrap evaluators]        entity: evaluator, LLM judge
+   ↓                                   (stop here with --stop-after eval-bootstrap
+   ↓                                    for the classic eval-pipeline behavior)
+[Phase 4: Create dataset from traces]  entity: dataset record
+   ↓
+[Phase 5: Publish dataset]             entity: published dataset, dataset_name
+   ↓
+[Phase 6: Generate experiment code]    entity: experiment, task, evaluator
+   ↓
+[Phase 7: Run experiment]              entity: experiment run, experiment.url
+   ↓
+[Phase 8: Analyze experiment]          entity: metric, comparison, recommendation
 ```
+
+This skill is **pure orchestration plus pedagogy** — no new analytical logic. The work happens inside the sub-skills (`llm-obs-session-classify`, `llm-obs-trace-rca`, `llm-obs-eval-bootstrap`, `llm-obs-experiment-py-bootstrap`, `llm-obs-experiment-analyzer`). What this skill adds is the deterministic envelope: every phase has the same shape, the same checkpoint contract, and the same entity-explanation banner — so the user gets a consistent, narrated experience regardless of how they phrased the original request.
 
 ## Usage
 
 ```
-/llm-obs-eval-pipeline <ml_app> [--timeframe <window>] [--trace-limit <N>] [--data-only] [--publish]
+/llm-obs-eval-pipeline <ml_app> [--project-name <name>] [--timeframe <window>] [--trace-limit <N>]
+                                [--format py|ipynb] [--evaluator-style function|class|remote]
+                                [--data-only | --publish]
+                                [--stop-after classify|rca|eval-bootstrap|dataset|publish|experiment|run|analyze]
+                                [--app-root <path>] [--env-file <path>] [--output-dir <dir>]
+                                [--backend pup]
 ```
 
 Arguments: $ARGUMENTS
@@ -56,178 +71,644 @@ Arguments: $ARGUMENTS
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `ml_app` | Yes | — | LLM app to analyze end to end |
-| `--timeframe` | No | `now-7d` | Lookback window for trace sampling and RCA |
-| `--trace-limit` | No | `20` | Max traces to classify in Phase 1 |
-| `--data-only` | No | off | Pass through to llm-obs-eval-bootstrap: emit JSON spec instead of Python SDK code |
-| `--publish` | No | off | Pass through to llm-obs-eval-bootstrap: publish online LLM-judge evaluators to Datadog |
+| `ml_app` | Yes | — | The instrumented LLM app to onboard / evaluate against. The precheck verifies it has recent traces. |
+| `--project-name` | No | derived from `pyproject.toml` / `setup.cfg` / `setup.py` / `package.json` / cwd (same order as `llm-obs-experiment-py-bootstrap`); falls back to `experiment-sdk-default` | The Datadog **project** the pipeline writes datasets and experiments into. The SDK lazily creates the project on first use via `LLMObs.enable(project_name=...)`. Surface this in the Precheck so the user can confirm before anything is created. |
+| `--timeframe` | No | `now-7d` | Lookback window for Phase 1 classification and Phase 4 dataset sampling. |
+| `--trace-limit` | No | `20` | Sampling cap for Phase 4. Phase 1 internally uses `min(20, --trace-limit)` for the classification sample. |
+| `--format` | No | `py` | Passed to `llm-obs-experiment-py-bootstrap` in Phase 6: `py` (script) or `ipynb` (Jupyter notebook). |
+| `--evaluator-style` | No | `function` | Passed to `llm-obs-eval-bootstrap` (Phase 3) and `llm-obs-experiment-py-bootstrap` (Phase 6): `function`, `class`, or `remote`. |
+| `--data-only` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: emit JSON spec instead of Python SDK code. |
+| `--publish` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: publish online LLM-judge evaluators to Datadog. |
+| `--stop-after <phase>` | No | `analyze` (run everything) | Stop after the named phase completes. `classify` = Phase 1 only. `rca` = through Phase 2. `eval-bootstrap` = through Phase 3 (matches the classic eval-pipeline). `dataset` = through Phase 4. `publish` = through Phase 5. `experiment` = through Phase 6 (file generated, not run). `run` = through Phase 7 (skip analyzer). `analyze` = all eight phases (default). |
+| `--app-root` | No | resolved from cwd / `pyproject.toml` etc. | Restricts `llm-obs-experiment-py-bootstrap`'s task-function introspection to this directory tree. |
+| `--env-file` | No | none (auto-discovery walks standard locations) | Explicit `.env` path for credential loading. Surfaced in the Precheck and baked into the generated experiment as `ENV_FILE_OVERRIDE`. |
+| `--output-dir` | No | `./experiments` | Where the dataset JSON, publish script, and generated experiment file are written. |
+| `--backend` | No | auto-detect | `pup` forces pup mode regardless of MCP availability. |
 
-If `ml_app` is not provided, ask the user before proceeding.
-
----
-
-## Phase 1: Trace Classification
-
-Follow the **llm-obs-session-classify** skill in **ml_app mode**, using:
-- `ml_app` = the provided ml_app
-- `timeframe` = the provided timeframe
-- `sample_limit` = the provided trace-limit
-
-Run the complete ml_app mode workflow as defined in that skill (Steps M1 through M3):
-sample spans → classify each → emit per-unit compact blocks → emit summary.
-
-**Output the full classification output**, including all compact per-unit blocks and the final
-`# Session Classification Summary` section. Do not summarize or truncate this output —
-downstream phase detection depends on the full text being present in context.
+If `ml_app` is not provided, ask the user before proceeding. If `--data-only` and `--publish` are both set, error out — they're mutually exclusive (per `llm-obs-eval-bootstrap`'s rules).
 
 ---
 
-### CHECKPOINT 1
+## Precheck
 
-After the `# Session Classification Summary` is output, pause and present:
+Before Phase 1, run a single short verification pass — do **not** announce a "Phase" banner for this; it's plumbing. Output a one-block precheck summary, then move directly to Phase 1.
+
+1. **Backend** — already detected at the top of this skill. Note the chosen backend in the precheck output so the user can confirm.
+
+2. **ml_app has recent traces** — call `search_llmobs_spans(query="@ml_app:\"<ml_app>\"", root_spans_only=true, limit=1, from="<timeframe>")` (MCP) or the pup equivalent. If the result is empty, stop and tell the user the precheck failed — there is nothing to evaluate against — and suggest widening `--timeframe` or confirming the ml_app name.
+
+3. **Resolve `project_name`** — if `--project-name <name>` was supplied, use it verbatim. Otherwise derive using the same resolution order as `llm-obs-experiment-py-bootstrap` (Workflow step 1): `pyproject.toml` → `setup.cfg` → `setup.py` → `package.json` → cwd basename (slugified). Final value is `experiment-<service-name>`; fall back to `experiment-sdk-default` if nothing resolves and emit a warning telling the user to set `--project-name` explicitly.
+
+   **Project creation semantics**: the project is created lazily by the Datadog SDK the first time `LLMObs.enable(project_name=...)` is called against the org (in Phase 5's publish script and Phase 6's generated experiment). The user does not need to pre-create anything in the UI. Surface the chosen project name in the Precheck output so the user can override before Phase 5 if it isn't what they wanted.
+
+4. **Ensure `--output-dir` exists** — `mkdir -p <output-dir>` via Bash. Cheap.
+
+5. **Resolve credentials.** Walk the discovery order below to find Datadog credentials before Phase 5 needs them — failing late at the publish step is bad UX. Read-only at this stage: do NOT write any new files. Do NOT print secret values to the user; only report which file was loaded and which keys were resolved.
+
+   **Discovery order** (first hit per variable wins; shell env vars always override files):
+   1. **`--env-file <path>`** override if supplied — always tried first.
+   2. **Current shell environment** (`os.environ`) — already-exported `DD_API_KEY` / `DD_APPLICATION_KEY` / `DD_APP_KEY` / `DD_SITE` take precedence over file values. If all required keys are already present, skip file loading entirely.
+   3. **`<output-dir>/.env`** — if the user previously ran the skill and dropped a `.env` next to past artifacts, prefer that.
+   4. **`<app-root>/.env`** — the resolved `pyproject.toml` / `setup.cfg` / `setup.py` / `package.json` directory (or cwd if none).
+   5. **`<app-root>/.env.local`** — git-ignored local override convention.
+   6. **`<cwd>/.env`** — fallback if cwd differs from app-root.
+   7. **Parent walk**: from cwd, walk up directory by directory looking for `.env` until reaching `/` or the user's home directory. Stop at the first hit.
+   8. **`~/.datadog/credentials`** — Datadog's well-known per-user credentials file, if present.
+
+   For each file checked, parse line-by-line: skip blanks / comment lines (`#`) / malformed lines (no `=`). Strip a leading `export ` if present (so `.envrc`-style files work). Split on the first `=`. Strip surrounding quotes on the value. Only set a variable that is not already in `os.environ` — never overwrite the shell.
+
+   **Required keys**: `DD_API_KEY` AND (`DD_APPLICATION_KEY` OR `DD_APP_KEY`). `DD_SITE` is optional (defaults to `datadoghq.com`). Provider keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) are validated later in Phases 6/7 against the introspected task — not here.
+
+   **If all required keys resolved** — record which file(s) were loaded and emit a single-line summary in the Precheck block. Continue.
+
+   **If required keys NOT found after walking every location** — stop and prompt the user with a clear, actionable message:
+
+   > "Datadog credentials were not found in your shell env or any discovered `.env` file. Two options before continuing:
+   > - **Export in your shell**: `export DD_API_KEY=…` and `export DD_APPLICATION_KEY=…` (also `DD_SITE=…` if non-default), then re-invoke this skill.
+   > - **Drop a `.env`** at `<app-root>/.env` with `DD_API_KEY=…` and `DD_APPLICATION_KEY=…` on separate lines, then re-invoke.
+   >
+   > Make sure `.env` is in your `.gitignore` before committing."
+
+   Do **not** offer to create the `.env` file for the user — secrets-on-disk decisions belong to the user, not the skill.
+
+Output the precheck summary, then start Phase 1:
 
 ```
-## Phase 1 Complete
+## Precheck
 
-[verdict distribution table]
-[failure mode frequency table]
+- Backend: <MCP | pup>
+- ml_app `<ml_app>` has traces in <timeframe>: yes (<sample_count> root spans found)
+- Project name: `<project_name>` (created lazily on first LLMObs.enable() call in Phase 5)
+- Output dir: `<output-dir>` (created)
+- Credentials: <one of:
+    "loaded from shell env (DD_API_KEY, DD_APPLICATION_KEY, DD_SITE)"
+  | "loaded from <relative path to .env file> (DD_API_KEY, DD_APPLICATION_KEY[, DD_SITE])"
+  | "shell env + <relative path>: keys resolved from both (shell overrode file for <list>)"
+  >
+- Stop-after: <phase from --stop-after, default `analyze`>
 
-Before I continue to root cause analysis:
-- Do these failure patterns look right?
-- Any traces you'd like to exclude from the RCA?
-- Any failure modes to focus on or ignore?
+Starting Phase 1 of 8.
+```
+
+The exact list of keys in the credentials parenthetical reflects what was actually discovered (so the user can verify nothing surprising was loaded). Never print the values.
+
+---
+
+## Phase Template
+
+Every phase below uses this exact template. Do not deviate — the deterministic envelope is what makes the pipeline experience consistent across invocations.
+
+```
+## Phase N of 8: <Title>
+
+**You are here.** Phase N of 8 — <one-line position summary>.
+
+**What this phase produces**: <Entity name>
+**What a <entity> is**: <2-3 sentence definition tailored to this phase>
+**Why it matters**: <1 sentence on why the user needs this>
+
+→ Action: <invoke <sub-skill> | execute <script>>
+
+<full sub-skill output OR execution log reproduced here — do NOT summarize or truncate>
+
+---
+
+### Checkpoint <N>
+
+<concise summary of what was produced, where it lives (path / Datadog URL), and any caveats>
+
+Before I continue to Phase N+1 (<next title>):
+- <2–3 phase-specific review prompts the user can answer>
 
 Type "continue" to proceed, or give me adjustments.
 ```
 
-**Wait for explicit user confirmation before proceeding.**
+**Never auto-advance.** Always pause at the checkpoint and wait for explicit user input. The whole point of this skill is determinism — that includes determinism over *when* the user moves on.
 
-- If the user excludes specific traces: mark them as "excluded by user" and drop them from the failure bucket. Do NOT re-classify.
-- If the user asks to re-run with different parameters: re-run Phase 1 with the new parameters.
-- If Phase 1 yielded zero failures: surface this explicitly and offer to retry with a wider timeframe or stop.
+If the current phase matches the value of `--stop-after`, replace the checkpoint prompt with a **Stop summary** (see "Stop-after handling" at the bottom of this file).
 
 ---
 
-## Phase 2: Root Cause Analysis
+## Phase 1: Classify ml_app traces
 
-Follow the **llm-obs-trace-rca** skill.
+**Entity**: `ml_app`, `trace`, `span`.
+
+**Pedagogy banner** (use verbatim, adapted only to the actual ml_app name):
+
+> **What an ml_app is**: a logical LLM application — a name you tag spans with when instrumenting (`ml_app=<name>`). It groups all production traces and evaluator runs that belong to the same product surface. Every dataset, experiment, and evaluator you create later targets this scope.
+>
+> **What a trace is**: one end-to-end execution of your ml_app — typically the agent loop for a single user request, made up of one or more spans (LLM calls, tool calls, retrievals).
+>
+> **Why this phase matters**: before you root-cause failures (Phase 2), bootstrap evaluators (Phase 3), or curate a dataset (Phase 4), you want a quick read on what your app actually does in production and where its current failure modes are. Classification gives you that signal in one pass.
+
+**Trace pool preview (MANDATORY).** Before invoking the sub-skill, build and surface a Datadog Traces UI link that opens the **exact set of root spans Phase 4 will sample from**. This lets the user eyeball the pool, spot outliers, or adjust `--timeframe` before any classification work runs. The link must match the filter that `llm-obs-eval-bootstrap --emit-dataset` uses in Phase 4 (see `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` → Phase 3D → Sampling): `@ml_app:"<ml_app>" @status:ok`, root spans only.
+
+URL construction rules:
+
+1. **Host**: prepend `app.` to `DD_SITE`. If `DD_SITE` is unset, default to `app.datadoghq.com`.
+   - `datadoghq.com` → `app.datadoghq.com`
+   - `datadoghq.eu` → `app.datadoghq.eu`
+   - `us3.datadoghq.com` → `app.us3.datadoghq.com`
+   - `us5.datadoghq.com` → `app.us5.datadoghq.com`
+   - `ap1.datadoghq.com` → `app.ap1.datadoghq.com`
+   - `ap2.datadoghq.com` → `app.ap2.datadoghq.com`
+   - `datad0g.com` → `app.datad0g.com` (staging)
+2. **Path**: `/llm/traces` (the LLM Observability Traces explorer).
+3. **Query string**: URL-encode `@ml_app:"<ml_app>" @status:ok @parent_id:undefined` and bind to `query=`.
+4. **Time window**: convert `--timeframe` to absolute epoch milliseconds (`now - <duration in ms>` for the start, `now` for the end) and bind to `start=` / `end=`.
+5. **Optional**: append `&paused=true` so the UI does not live-stream the result on open.
+
+Surface the link immediately before the Action block:
+
+```
+**Trace pool being analyzed** ({timeframe}, filter `@ml_app:"<ml_app>" @status:ok`, root spans only):
+
+  <full URL>
+
+Phase 1 will classify the first {min(20, trace-limit)} of these for orientation. Phase 4 will sample up to {trace-limit} from the same pool for the dataset. Click through if you want to see the pool before either runs, or adjust `--timeframe` and re-invoke if the window looks off.
+```
+
+**Action**: Follow the **`llm-obs-session-classify`** skill in **ml_app mode**, using:
+- `ml_app` = the provided ml_app
+- `timeframe` = the provided timeframe
+- `sample_limit` = `min(20, trace-limit)` — keep this fast; Phase 4 will do the bigger sample
+
+Run the complete ml_app mode workflow as defined in that skill (Steps M1 through M3). **Output the full classification output** (all compact per-unit blocks plus the final `# Session Classification Summary`) — do not summarize or truncate. Downstream Phase 2's RCA depends on the full text being in context.
+
+### Checkpoint 1
+
+After the `# Session Classification Summary` is output, present:
+
+```
+## Phase 1 complete — you've seen what `<ml_app>` does in production
+
+[verdict distribution table from session-classify]
+[failure mode frequency table from session-classify]
+
+**Trace pool for Phase 4's dataset sample**: <full URL from the Trace pool preview above>
+(same filter / same timeframe — open it now if you want to scan for traces you'd rather exclude)
+
+Next up — Phase 2 will diagnose *why* the failing traces are failing.
+
+Before I continue:
+- Do these failure patterns look right?
+- Any traces you'd like to exclude from the dataset sample in Phase 4? (Paste trace IDs from the link above and I'll drop them.)
+- Any quality dimension you already know you want to measure later?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for explicit user confirmation. If the user excludes specific traces, mark them as "excluded by user" — drop them from Phase 2's failure bucket and from Phase 4's sampling. Do NOT re-classify.
+
+---
+
+## Phase 2: Root cause analysis
+
+**Entity**: `failure mode`, `root cause`.
+
+**Pedagogy banner**:
+
+> **What a failure mode is**: a recurring pattern in *how* your app fails — e.g. "the model hallucinates citation URLs", "the agent forgets state across tool calls", "the retrieval returns irrelevant chunks". Each failure mode has one or more *root causes* (system prompt deficiency, tool gap, retrieval miss, etc.).
+>
+> **Why this phase matters**: an evaluator that scores generic "is this response good?" misses the specific things going wrong in your app. RCA lets Phase 3 propose evaluators that target your *actual* failure modes — sharper signal, fewer false alarms.
+
+**Action**: Follow the **`llm-obs-trace-rca`** skill.
 
 The `# Session Classification Summary` from Phase 1 is in context. The skill detects it automatically via its Phase 0 Step 0S check and enters the "from classifications" path — it extracts the failure bucket, presents the Classification Overview, and proceeds directly to Phase 2 (open coding) without running its own Phase 1 span search.
 
 Run the full workflow through Phase 6 (the compiled RCA report). **Output the full RCA report** — do not summarize. The full report must be in context for Phase 3's detection to work.
 
----
-
-### CHECKPOINT 2
-
-After the RCA report is output, pause and present:
+### Checkpoint 2
 
 ```
-## Phase 2 Complete
+## Phase 2 complete — root causes identified
 
 [the Phase 6 RCA report is above]
 
-Before I generate evaluators:
+Next up — Phase 3 will bootstrap evaluators that target these failure modes.
+
+Before I continue:
 - Do these root causes look accurate?
 - Any failure modes to add, remove, or reframe?
-- Which root causes should the evaluators target?
+- Which root causes should the evaluators target? (Default: all of them.)
 
 Type "continue" to proceed, or give me adjustments.
 ```
 
-**Wait for explicit user confirmation before proceeding.**
-
-If the user adjusts the taxonomy: incorporate the changes before continuing to Phase 3.
+Wait for explicit user confirmation. If the user adjusts the taxonomy, incorporate the changes before continuing.
 
 ---
 
-## Phase 3: Eval Bootstrap
+## Phase 3: Bootstrap evaluators
 
-Follow the **llm-obs-eval-bootstrap** skill.
+**Entity**: `evaluator`, `LLM judge`.
+
+**Pedagogy banner**:
+
+> **What an evaluator is**: a function that grades one record's output. Returns `bool` / `float` / a structured `EvaluatorResult`. Two flavors: **code evaluators** (deterministic checks — JSON validity, regex match, length, custom Python) and **LLM-as-judge evaluators** (a model graded against a rubric — e.g. "is this response grounded in the retrieved documents?").
+>
+> **What "online" vs "offline" means**: an offline evaluator runs inside an experiment against a dataset. An online evaluator runs on production spans as they're emitted. Pass `--publish` to bootstrap online LLM-judge evaluators; default is offline `.py` code suitable for experiments.
+>
+> **Why this phase matters**: evaluators are the contract between "this output looks fine" and "this output meets our quality bar." The bootstrapped suite is grounded in the failure taxonomy from Phase 2 — sharper than generic evaluators you'd otherwise hand-write.
+
+**Action**: Follow the **`llm-obs-eval-bootstrap`** skill.
 
 The RCA report from Phase 2 is in context. The skill detects the `## Failure Taxonomy` heading automatically and enters its "from RCA" path in Phase 0.
 
 Pass through any flags:
 - `--data-only` → emit a JSON spec instead of Python SDK code
 - `--publish` → publish online LLM-judge evaluators directly to Datadog
+- `--evaluator-style` → pass through unchanged
 
 **The llm-obs-eval-bootstrap skill has its own mandatory proposal checkpoint** (the evaluator suite proposal before code generation). Honor it — do not skip or auto-confirm it.
 
+### Checkpoint 3
+
+```
+## Phase 3 complete — evaluator suite ready
+
+- Output: `<path to .py / .json / "published as drafts to Datadog">`
+- Evaluators emitted: <list of names>
+- Coverage: <one-liner: which failure-mode categories are now covered>
+
+Next up — Phase 4 will sample production traces into a dataset you can run experiments against (using these evaluators or the placeholders the experiment template ships with).
+
+If you only wanted evaluators (the classic eval-pipeline flow), this is the natural stopping point: re-invoke with `--stop-after eval-bootstrap` to formalize that as the exit.
+
+Before I continue:
+- Do the generated evaluators look right?
+- Any to drop or rename before they're referenced in the experiment?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for explicit user confirmation. If `--stop-after eval-bootstrap` is set, this is where the pipeline ends — emit the Stop summary instead of the Checkpoint and exit.
+
 ---
 
-## Final Summary
+## Phase 4: Create dataset from prod traces
 
-After Phase 3 completes, present:
+**Entity**: `dataset`, `dataset record`.
+
+**Pedagogy banner**:
+
+> **What a dataset is**: a named collection of records that an experiment runs against. Each record has `input_data` (what the task receives) and optionally `expected_output` (what you expect back). Datasets live in Datadog under your project and have a version — every time you push changes, a new version is created.
+>
+> **What a record is**: a single `(input_data, expected_output)` pair, optionally with `metadata` and `tags`. One record = one experiment row.
+>
+> **Why this phase matters**: experiments need a stable input set. Sampling production traces gives you a realistic starting dataset — the inputs your app actually sees — without making you write fixtures by hand.
+
+**Action**: Follow the **`llm-obs-eval-bootstrap`** skill in **`--emit-dataset` mode**:
+
+```
+/eval-bootstrap <ml_app> --timeframe <timeframe> --trace-limit <trace-limit> --emit-dataset <output-dir>/dataset_<ml_app>_<YYYYMMDD>.json
+```
+
+This mode samples root spans, extracts `(input_data, expected_output)` pairs from each, applies a PII scrub, and writes a `DatasetRecordRaw[]` JSON file. **It does not propose or generate evaluators in this mode** — the dataset is the sole artifact. See `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` → Phase 3D for the full spec.
+
+If the user excluded specific traces in Checkpoint 1, pass that exclusion list along (sub-skill drops them during sampling — do NOT re-classify).
+
+Reproduce the sub-skill's `## Generated Dataset` summary verbatim.
+
+### Checkpoint 4
+
+```
+## Phase 4 complete — local dataset file ready
+
+- File: `<path>`
+- Records: <N> (skipped: <M> with no usable output)
+- PII redactions: <P>
+- Tag normalizations: <T>
+- Caveat: `expected_output` is the **current production behavior baseline**, not ground truth. Spot-check a few records before publishing.
+
+Next up — Phase 5 will publish this dataset to Datadog under project `<project_name>` so an experiment can pull it by name.
+
+Before I continue:
+- Want to open the file and edit any records first? (recommended — spot-check at least 3–5)
+- Happy with the proposed dataset name `<ml_app>_seed_<YYYYMMDD>`, or pick another?
+- Any records you want me to drop?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for confirmation. The proposed `dataset_name` defaults to `<ml_app>_seed_<YYYYMMDD>` but the user can override — carry the final chosen name into Phase 5.
+
+---
+
+## Phase 5: Publish dataset
+
+**Entity**: published dataset (Datadog-side), `dataset_name`, version.
+
+**Pedagogy banner**:
+
+> **What "publishing" means**: pushing the local records to Datadog so the dataset becomes addressable by name across all subsequent experiments. After publish, anyone in your org (with access) can pull it with `LLMObs.pull_dataset(dataset_name="…")` — including the experiment code we generate in Phase 6.
+>
+> **What a dataset version is**: every push that changes records produces a new version. You can pin an experiment to a specific version (`pull_dataset(version=N)`) so a refactor of the dataset doesn't silently change which inputs your experiment runs on.
+>
+> **Why this phase matters**: a published, named dataset is the contract between your dataset curation work (which lives in code/JSON) and the experiments that consume it. Without this phase, the experiment in Phase 6 has no input.
+
+**This is one of the two phases in this pipeline where executable code is run.** The user is in "publish" mode and that's the clear, expected signal.
+
+**Action**: Invoke the pre-shipped publish helper at `<this-skill-dir>/scripts/publish_dataset.py` via Bash. **Do not** inline the script content into this SKILL.md or re-write it from scratch — the helper is the source of truth for the publish flow (credential discovery, tag normalization, project creation, error handling). It accepts CLI args, so no placeholder substitution is needed.
+
+Invocation:
+
+```bash
+python <skill-dir>/scripts/publish_dataset.py \
+  --records <absolute path to dataset JSON from Phase 4> \
+  --dataset-name <chosen dataset_name from Checkpoint 4> \
+  --project-name <resolved project_name from Precheck> \
+  [--env-file <path>]   # repeatable; takes precedence over auto-discovery
+```
+
+`<skill-dir>` resolves to wherever the skill is installed (e.g., `~/.claude/skills/llm-obs-eval-pipeline/`). The script bundles two sibling modules — `scripts/load_env.py` (the env-file discovery walker, identical to the one the generated experiment file ships with) and inline tag normalization — and prints either:
+
+- `Loaded credentials from: <file paths>` (if any `.env` files contributed values), then
+- `OK dataset_name=<name> record_count=<N> url=<url>` (on success), or
+- `ERROR: <message>` on stderr with a non-zero exit (auth, missing keys, ddtrace import failure, etc.).
+
+**Notes for the orchestrator:**
+- Before invoking, do an import-availability precheck: `python -c "import ddtrace.llmobs"` via Bash. If it fails, stop and tell the user:
+  > "`ddtrace` is not installed in the active Python environment. Run `pip install 'ddtrace>=4.7'` and re-invoke this skill (re-run from the top — Phases 1–4 outputs are idempotent)."
+- The script's discovery walk mirrors the Precheck. If the Precheck already loaded credentials, the script's `_load_env_files()` will just be a confirmation no-op (the keys are already in `os.environ`).
+- `LLMObs.enable(project_name=...)` inside the script is where the `--project-name` from the Precheck actually materializes — the Datadog project is created lazily on first call.
+- If the script prints a `WARNING:` line about tag normalization, surface it in Checkpoint 5 so the user knows their upstream dataset had malformed tags.
+- If the script prints `Loaded credentials from: ...`, include that file path in Checkpoint 5.
+- If the script exits non-zero with an auth error (401/403), surface the stderr and stop — do not retry. Tell the user the most likely cause is a stale `.env` value, and that `export DD_API_KEY=... DD_APPLICATION_KEY=...` in their shell takes precedence and can be used to override.
+- On success, capture the printed `dataset_name` and `url` and carry them into Phase 6.
+
+### Checkpoint 5
+
+```
+## Phase 5 complete — dataset published
+
+- Dataset name: `<dataset_name>`
+- Project: `<project_name>` <(created if it did not exist)>
+- Records published: <N>
+- Datadog UI: <url or "open LLM Observability → Datasets to confirm">
+
+Next up — Phase 6 will generate a Python experiment script that pulls this dataset and runs your task code (auto-discovered) against it.
+
+Before I continue:
+- Confirm you can see the dataset in the Datadog UI (LLM Observability → Datasets → search `<dataset_name>`)?
+- Any second thoughts on the dataset records (we can re-emit before generating the experiment)?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for confirmation.
+
+---
+
+## Phase 6: Generate experiment code
+
+**Entity**: `experiment`, `task` function, `evaluator`.
+
+**Pedagogy banner**:
+
+> **What an experiment is**: a programmatic harness that, for each record in a dataset, calls a `task` function (your code under test — typically an LLM call), then runs one or more `evaluators` against the task's output. Datadog collects all those results into a single experiment view you can compare across runs.
+>
+> **What a task function is**: a Python callable that receives one record's `input_data` and a `config` dict, and returns whatever your app would have returned for that input. **The sub-skill introspects your project to find this function automatically** — no `# TODO(user)` placeholder unless nothing was found.
+>
+> **What an evaluator is**: covered in Phase 3 above. The generated experiment ships placeholder evaluators by default; if you ran Phase 3 with `--evaluator-style remote`, you can wire those names in here.
+>
+> **Why this phase matters**: this is the artifact you'll actually run. Everything before this phase was prep work.
+
+**Action**: Follow the **`llm-obs-experiment-py-bootstrap`** skill:
+
+```
+/llm-obs-experiment-py-bootstrap \
+  --dataset-name <dataset_name> \
+  --project-name <project_name> \
+  --format <format> \
+  --evaluator-style <evaluator-style> \
+  --app-root <app-root> \
+  --env-file <env-file if set> \
+  --output <output-dir>/experiment_<ml_app>_<YYYYMMDD>.<py|ipynb>
+```
+
+Reproduce the sub-skill's full output (including the generated SDK calls summary, the "Task function source" block, the credential discovery section, and the Next steps block) verbatim. Do not summarize. The "Task function source" block tells the user which `module:function` was auto-wired — that's load-bearing for Checkpoint 6.
+
+### Checkpoint 6
+
+```
+## Phase 6 complete — experiment file ready to run
+
+- File: `<path>`
+- Format: <py | ipynb>
+- Wired to dataset: `<dataset_name>` (pulled at runtime via LLMObs.pull_dataset)
+- Task function source: <line lifted from the sub-skill — names the discovered module:function, or notes the placeholder fallback>
+- Evaluators: <list the 2–3 evaluator names from the sub-skill output>
+
+Next up — Phase 7 will run this file end-to-end against the published dataset.
+
+**Before continuing — open the file and look at three things**:
+1. The wired `task_fn` (section 4 of the generated file). The sub-skill introspected your app and imported the most likely entry point — **confirm it picked the right function**. If it picked a sibling helper or a deprecated path, edit the import in section 4 to point at the function you actually want to evaluate. If the sub-skill fell back to a placeholder (no LLM call site found in `<app-root>`), this is the phase where you replace it with a real call.
+2. The placeholder evaluators — these are starting points. You can leave them for the first run, or refine. If Phase 3 produced online evaluators via `--publish`, swap one of the placeholders for a `RemoteEvaluator(eval_name="...")` referencing your judge.
+3. The `experiment.run(jobs=<N>)` parallelism — defaults to 10; lower it if you're worried about rate limits.
+
+Then confirm:
+- Have you set `DD_API_KEY`, `DD_APPLICATION_KEY`, `DD_SITE` (if non-default), and the provider key your task needs (the generated file's section 1 asserts only the right one — check what it expects)?
+- Ready to run?
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for confirmation.
+
+---
+
+## Phase 7: Run experiment
+
+**Entity**: experiment run, `experiment.url`, metric stream.
+
+**Pedagogy banner**:
+
+> **What "running the experiment" means**: iterating over every record in the dataset, calling your `task` function, then calling each evaluator on the result, and streaming the scores to Datadog. The SDK creates the experiment in Datadog the first time it runs and updates the same experiment record on re-runs (if you keep the same `name=`).
+>
+> **What `experiment.url` is**: the deep link to the run in the Datadog Experiments UI. Phase 8 uses this to analyze results.
+>
+> **Why this phase matters**: until you actually run the experiment, the dataset and the code are just plumbing. The run is what produces the first measurements.
+
+**This is the second of the two phases in this pipeline where executable code is run.** Clearly signal it.
+
+**Action**: Execute the generated experiment file.
+
+- For `--format py`: `python <generated_path>` via Bash. Stream output to the user.
+- For `--format ipynb`: tell the user the generated file is a notebook and ask whether to (a) execute it via `jupyter nbconvert --to notebook --execute --inplace <path>` (requires `jupyter` installed), or (b) hand off — the user opens it in JupyterLab and runs cells manually. Default to (a) if `jupyter` is on PATH; otherwise (b).
+- Capture the printed `experiment.url` from the run's stdout — the generated file always ends with `print(experiment.url)`. If you can't find it, parse stdout for the substring `https://app.datadoghq.com/llm/experiments/` (account for non-default `DD_SITE` hosts).
+- If the run fails: do NOT retry automatically. Surface the full traceback, identify the failure category (auth, missing dep, dataset not found, task function raised, evaluator raised) in a one-line diagnosis, and ask the user whether to fix and re-run.
+
+### Checkpoint 7
+
+```
+## Phase 7 complete — experiment run published
+
+- Experiment URL: <experiment.url>
+- Records processed: <N>
+- Duration: <wall-clock seconds>
+- Evaluator score summary (from stdout, if printed): <table or "open the UI">
+
+Next up — Phase 8 will pull the experiment results back from Datadog and produce an analysis report (struggling metrics, qualitative examples, root-cause hypotheses).
+
+Before I continue:
+- Take a look at the experiment in the UI (link above). Do the per-record scores roughly match your expectations?
+- Any specific question you want Phase 8 to focus on? (Optional — leaving it open runs an exploratory analysis.)
+
+Type "continue" to proceed, or give me adjustments.
+```
+
+Wait for confirmation. If the user provides a focus question, carry it to Phase 8 as the analyzer's `question` argument.
+
+---
+
+## Phase 8: Analyze experiment
+
+**Entity**: experiment `metric`, segment comparison, recommendation.
+
+**Pedagogy banner**:
+
+> **What an experiment metric is**: a per-record score produced by one of your evaluators, aggregated into a pass-rate / score-distribution across the dataset. The Datadog Experiments UI shows these as columns and lets you slice by `metadata` fields you attached to each record.
+>
+> **What a recommendation looks like**: based on which metrics underperformed and on patterns in the failing records, the analyzer surfaces hypotheses for what to change next (system prompt, retrieval, task code, the dataset itself, or the evaluator).
+>
+> **Why this phase matters**: this closes the loop. You started by looking at production behavior; you now have an evidence-backed read on where the experiment exposes gaps and what to try next.
+
+**Action**: Follow the **`llm-obs-experiment-analyzer`** skill in **single-exploratory** (or **single-Q&A** if the user supplied a focus question in Checkpoint 7):
+
+```
+/llm-obs-experiment-analyzer <experiment_id_from_url> [<focus question if any>] --output agent
+```
+
+Extract the `<experiment_id>` from the URL captured in Phase 7 (the trailing UUID after `/llm/experiments/`).
+
+Reproduce the analyzer's full report verbatim.
+
+### Final Summary
+
+After the analyzer report, emit the closing summary — this replaces the per-phase checkpoint:
 
 ```markdown
-# LLM Obs Eval Pipeline Complete
+# LLM Obs Eval Pipeline complete
 
-**App**: `<ml_app>`  |  **Timeframe**: <timeframe>
+**ml_app**: `<ml_app>` | **Project**: `<project_name>` | **Timeframe**: <timeframe>
 
 | Phase | Output |
-|-------|--------|
-| 1. Classification | <N> traces sampled, <F> failures identified |
-| 2. Root Cause Analysis | <K> failure modes, <M> root causes diagnosed |
-| 3. Eval Bootstrap | <J> evaluators → `<output_path>` |
+|---|---|
+| 1. Classify ml_app | <N> traces classified (<F> failures) |
+| 2. Root cause analysis | <K> failure modes, <M> root causes |
+| 3. Bootstrap evaluators | <J> evaluators → `<path>` (or "<N> drafts published to Datadog") |
+| 4. Create dataset | <K> records → `<dataset_path>` |
+| 5. Publish dataset | `<dataset_name>` (v1) in project `<project_name>` |
+| 6. Generate experiment code | `<experiment_file_path>` |
+| 7. Run experiment | <experiment.url> |
+| 8. Analyze experiment | <2–3 bullet headline findings from the analyzer> |
 
-## Key findings
+## What you learned
 
-[3–5 bullets: most important failure patterns and what the evaluators capture]
+- The five core entities you touched: **ml_app**, **failure mode**, **evaluator**, **dataset**, **experiment**. Each has a dedicated docs page — see Datadog Documentation below.
+- The loop you can now repeat: **edit dataset → re-run experiment → compare in the UI**. Pull-by-name + auto-versioning makes the loop cheap.
+- The reusable artifacts you produced: an evaluator suite (Phase 3), a published dataset (Phase 5), and an experiment script (Phase 6). All three survive beyond this pipeline run.
 
-## Next steps
+## Recommended next steps
 
-1. Review the generated evaluators at `<output_path>`
-2. Run an offline experiment to validate eval quality
-3. Once validated, configure as production evals in Datadog
+1. Open the experiment in the Datadog UI: <experiment.url>
+2. Replace the placeholder evaluators in `<experiment_file_path>` with the ones bootstrapped in Phase 3 (swap the function refs / `RemoteEvaluator` names).
+3. Re-run the experiment after every meaningful change to your task code. Datadog will keep the run history under the same project.
+4. If you published draft evaluators via `--publish`, review and enable them in the UI (LLM Observability → Evaluations).
+
+## Datadog Documentation
+
+- LLM Observability overview: <https://docs.datadoghq.com/llm_observability/>
+- Datasets: <https://docs.datadoghq.com/llm_observability/experiments/datasets_and_experiments/>
+- Experiments: <https://docs.datadoghq.com/llm_observability/experiments/>
+- Evaluations: <https://docs.datadoghq.com/llm_observability/evaluations/>
+- Python SDK reference: <https://docs.datadoghq.com/llm_observability/instrumentation/sdk/>
 ```
+
+---
+
+## Stop-after handling
+
+`--stop-after <phase>` lets the user exit cleanly before the full eight-phase pipeline completes. Valid values map to the phase numbers:
+
+| Value | Stop after | Use case |
+|---|---|---|
+| `classify` | Phase 1 | "I just want to see what's going on in my ml_app." |
+| `rca` | Phase 2 | "I want to understand failure modes — I'll write evaluators myself." |
+| `eval-bootstrap` | Phase 3 | **Matches the classic `llm-obs-eval-pipeline` behavior.** Use for "I want evaluators, not experiments." |
+| `dataset` | Phase 4 | "I want a dataset JSON to inspect / edit before publishing." |
+| `publish` | Phase 5 | "I want the dataset live in Datadog but I'll wire up the experiment myself." |
+| `experiment` | Phase 6 | "Generate the experiment file but don't run it yet." |
+| `run` | Phase 7 | "Run the experiment; I'll do the analysis manually." |
+| `analyze` | Phase 8 (default) | Full pipeline. |
+
+When the current phase matches the stop value, **replace the Checkpoint at the bottom of that phase with a Stop summary**:
+
+```
+## Pipeline stopped — `--stop-after <phase>`
+
+Completed phases: <list 1..stop>
+Skipped: <list stop+1..8 with one-line descriptions>
+
+Artifacts produced: <list with paths / URLs>
+
+Re-invoke with a later `--stop-after` (or no flag for the full run) when you're ready to continue. State from completed phases is idempotent — re-running them will just re-derive the same outputs.
+```
+
+This makes `--stop-after eval-bootstrap` a drop-in replacement for the old `llm-obs-eval-pipeline` behavior without losing the orchestrator's pedagogy banners.
 
 ---
 
 ## Orchestration Rules
 
-- **Always checkpoint before advancing.** Never auto-proceed between phases.
-- **Never truncate sub-skill outputs.** Downstream phase detection depends on the full text being in context.
-- **Phase isolation**: if the user wants to re-run a single phase, re-run only that phase and its downstream phases.
-- **Carry context forward**: the output of each phase is the input for the next. Present the full output of each sub-skill before showing the checkpoint prompt.
+- **Always run the precheck, even on re-invocations.** It's cheap and it catches a stale `ml_app` argument, an expired auth token, or a typo in `--project-name` before you waste a sub-skill call.
+- **Always emit the precheck block.** Even though it isn't a "phase", users have learned to look for it as the first output.
+- **Never auto-advance between phases.** Every checkpoint waits for explicit user input. If the user says something other than "continue" (e.g. "skip ahead", "redo phase 2"), interpret and act — but never silently move on.
+- **Never truncate sub-skill output.** The user is here to learn what the sub-skills do; if you summarize their output, you defeat the pedagogical purpose. Reproduce verbatim. Downstream phases also depend on the full text being in context (Phase 2 detects Phase 1's classification summary; Phase 3 detects Phase 2's failure taxonomy).
+- **The phase envelope is invariant.** The banner ("You are here. Phase N of 8…"), the entity block, the action label, and the checkpoint header must appear identically across every phase. The *content inside* may differ; the envelope must not. This is the determinism the skill promises.
+- **Execute only at Phases 5 and 7.** No other phase runs code on the user's machine. If a sub-skill output suggests the user should run something themselves, hand it off — don't quietly execute it.
+- **One backend for the whole run.** Detected at startup, propagated to all sub-skill calls. Do not re-detect mid-run.
+- **`--project-name` is sticky.** Whatever the user picked at Precheck flows unchanged into Phases 5 and 6 and into the final summary. If the user changes their mind at Checkpoint 5, re-run Phase 5 (and only Phase 5) with the new name — do NOT silently rewrite earlier outputs.
+- **Phase re-entry**: if the user types something like "redo phase 4 with --trace-limit 30", re-run that phase only (and clearly say so — "Re-running Phase 4 with the new trace limit. Phases 1–3 outputs are unchanged."). After it completes, fall through to Phase 5 just like a fresh run would.
+
+---
+
+## What this skill does NOT do
+
+This list exists so reviewers can spot scope creep:
+
+- **Does not instrument your app.** Audience assumption: the user already has `ml_app` traces flowing into Datadog. If the precheck finds zero traces, the skill stops and points the user at the instrumentation docs — it does not attempt to bootstrap instrumentation.
+- **Does not push code or commit anything.** All generated files land in `<output-dir>`; the user owns version control.
+- **Does not run any phase's code without an explicit checkpoint confirmation.** Phases 5 and 7 ask before executing.
+- **Does not deeply modify your app.** Phase 6's experiment file *imports* your task function; it does not refactor it. If you want prompt / model variants without editing your app, inline the call inside `task_fn` in the generated file.
+- **Does not auto-create `.env` files.** Credential files are discovered, not generated — secrets-on-disk decisions belong to the user.
 
 ---
 
 ## Tool Reference
 
-This appendix applies only in **pup mode**. Each sub-skill also carries its own Tool Reference with the same mappings — consult them for full parameter details. The tables below are a quick reference for pipeline-level orientation.
+This skill itself does almost no direct tool calls — the only direct calls are:
 
-### Spans and traces
+1. The **precheck** `search_llmobs_spans` (to confirm the ml_app has traces).
+2. `Bash` for **Phase 5** (running the publish script) and **Phase 7** (running the generated experiment).
+3. **No** Write for Phase 5 — the publish helper ships at `scripts/publish_dataset.py` alongside this SKILL.md; the orchestrator invokes it by path with CLI args. The skill does not generate the script on the fly.
 
-| MCP Tool | pup Command |
-|---|---|
-| `search_llmobs_spans(...)` | `pup llm-obs spans search --query "@ml_app:A [other_filters]" [--from F] [--to T] [--limit N] [--summary]` — **always use `--query "@ml_app:A"`**; `--ml-app A` is unreliable. |
-| `get_llmobs_span_details(...)` | `pup llm-obs spans get-details --trace-id T --span-ids S1,S2,...` |
-| `get_llmobs_span_content(...)` | `pup llm-obs spans get-content --trace-id T --span-id S --field F [--path P]` |
-| `get_llmobs_trace(...)` | `pup llm-obs spans get-trace --trace-id T [--include-tree]` |
-| `get_llmobs_agent_loop(...)` | `pup llm-obs spans get-agent-loop --trace-id T [--span-id S]` |
-| `find_llmobs_error_spans(...)` | `pup llm-obs spans find-errors --trace-id T` |
-| `expand_llmobs_spans(...)` | `pup llm-obs spans expand --trace-id T --span-ids S1,S2,...` |
+Everything else routes through sub-skills, which carry their own MCP-to-pup mappings:
 
-### Evaluators
+| Sub-skill | When invoked | Where its tool reference lives |
+|---|---|---|
+| `llm-obs-session-classify` | Phase 1 | `dd-llmo/llm-obs-session-classify/SKILL.md` (Tool Reference appendix) |
+| `llm-obs-trace-rca` | Phase 2 | `dd-llmo/llm-obs-trace-rca/SKILL.md` (Tool Reference appendix) |
+| `llm-obs-eval-bootstrap` (sdk_code / data_only / publish) | Phase 3 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Tool Reference appendix) |
+| `llm-obs-eval-bootstrap` (`--emit-dataset` mode) | Phase 4 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Phase 3D + Tool Reference appendix) |
+| `llm-obs-experiment-py-bootstrap` | Phase 6 | `dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md` |
+| `llm-obs-experiment-analyzer` | Phase 8 | `dd-llmo/llm-obs-experiment-analyzer/SKILL.md` (Tool Reference appendix) |
 
-| MCP Tool | pup Command |
-|---|---|
-| `list_llmobs_evals()` | `pup llm-obs evals list` |
-| `get_llmobs_evaluator(eval_name)` | `pup llm-obs evals get-evaluator EVAL_NAME` |
-| `get_llmobs_eval_aggregate_stats(...)` | `pup llm-obs evals get-aggregate-stats EVAL_NAME [--ml-app A] [--from F] [--to T]` |
-| `create_or_update_llmobs_evaluator(...)` | `pup llm-obs evals create-or-update EVAL_NAME --file /tmp/eval_EVAL_NAME.json` (see eval-bootstrap Tool Reference for flat schema details) |
-
-### RUM
+### Precheck `search_llmobs_spans` ↔ pup
 
 | MCP Tool | pup Command |
 |---|---|
-| `analyze_rum_events(event_type="view", filter="@usr.email:EMAIL", ...)` | `pup rum aggregate --user-email EMAIL --from F --to T --compute count --group-by @session.id` |
-| `analyze_rum_events(event_type="action", filter="@action.type:custom ...", ...)` | `pup rum aggregate --user-email EMAIL --query "@action.type:custom" --from F --to T --compute count --group-by @evt.name` |
+| `search_llmobs_spans(query="@ml_app:\"<ml_app>\"", root_spans_only=true, limit=1, from="<timeframe>")` | `pup llm-obs spans search --query "@ml_app:\"<ml_app>\"" --root-spans-only --limit 1 --from <stripped-timeframe> --summary` (strip the `now-` prefix from timeframe per the pup invocation rules above). |
 
-### Notebooks
-
-| MCP Tool | pup Command |
-|---|---|
-| `create_datadog_notebook(name, cells, ...)` | `pup notebooks create --title "TITLE" --file /tmp/nb_cells.json` |
-| `edit_datadog_notebook(id, cells, append_only=true)` | `pup notebooks edit NOTEBOOK_ID --file /tmp/nb_cells.json` |
 - **MCP result parsing safety**: Before writing any script (Python, jq, etc.) that iterates over or accesses fields in an MCP tool result, inspect the raw structure first — check `type(result)`, top-level keys, and whether the payload is nested inside a content block (e.g. `[{'type': 'text', 'text': '<json>'}]`). Extract and `json.loads()` the inner payload if needed. Never assume MCP results are bare dicts or lists.

--- a/dd-llmo/llm-obs-eval-pipeline/SKILL.md
+++ b/dd-llmo/llm-obs-eval-pipeline/SKILL.md
@@ -56,7 +56,7 @@ This skill is **pure orchestration plus pedagogy** — no new analytical logic. 
 ```
 /llm-obs-eval-pipeline <ml_app> [--project-name <name>] [--timeframe <window>] [--trace-limit <N>]
                                 [--format py|ipynb] [--evaluator-style function|class|remote]
-                                [--data-only | --publish]
+                                [--offline-evaluators | --online-evaluators | --data-only]
                                 [--start-at classify|rca|eval-bootstrap|dataset|experiment|analyze]
                                 [--stop-after classify|rca|eval-bootstrap|dataset|experiment|analyze]
                                 [--classification-summary <path>] [--rca-report <path>]
@@ -78,8 +78,9 @@ Arguments: $ARGUMENTS
 | `--trace-limit` | No | `20` | Sampling cap for Phase 4. Phase 1 internally uses `min(20, --trace-limit)` for the classification sample. |
 | `--format` | No | `py` | Passed to `llm-obs-experiment-py-bootstrap` in Phase 5: `py` (script) or `ipynb` (Jupyter notebook). |
 | `--evaluator-style` | No | `function` | Passed to `llm-obs-eval-bootstrap` (Phase 3) and `llm-obs-experiment-py-bootstrap` (Phase 5): `function`, `class`, or `remote`. |
-| `--data-only` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: emit JSON spec instead of Python SDK code. |
-| `--publish` | No | off | Phase 3 pass-through to `llm-obs-eval-bootstrap`: publish online LLM-judge evaluators to Datadog. |
+| `--offline-evaluators` | No | on (default) | Phase 3: emit a Python SDK evaluator suite (BaseEvaluator / LLMJudge classes) that runs inside an experiment against a dataset. Maps internally to `llm-obs-eval-bootstrap` `sdk_code` mode. |
+| `--online-evaluators` | No | off | Phase 3: publish online LLM-judge evaluators directly to Datadog (created as disabled drafts; enable in the UI). Online evaluators run on production spans as they're emitted. Maps internally to `llm-obs-eval-bootstrap` `publish` mode (was `--publish`). |
+| `--data-only` | No | off | Phase 3: emit a local data blob only — no executable evaluator code or online publish. At Phase 3 entry the skill **prompts** the user to pick one of: (a) a `DatasetRecordRaw[]` JSON suitable for experiment use (maps internally to `llm-obs-eval-bootstrap --emit-dataset`), or (b) a framework-agnostic JSON evaluator spec for local analysis (maps internally to `llm-obs-eval-bootstrap` `data_only` mode). |
 | `--stop-after <phase>` | No | `analyze` (run everything) | Stop after the named phase completes. `classify` = Phase 1 only. `rca` = through Phase 2. `eval-bootstrap` = through Phase 3 (matches the classic eval-pipeline). `dataset` = through Phase 4 (dataset created + published). `experiment` = through Phase 5 (experiment generated + run). `analyze` = all six phases (default). |
 | `--start-at <phase>` | No | `classify` (start at the top) | Skip earlier phases and start at the named phase. Same vocabulary as `--stop-after`. The skill auto-loads any required prior-phase artifacts from `<output-dir>/state/` (see "State persistence and entry/exit" section). For phases that need an artifact the auto-load can't find, supply it via one of the override flags below. Combinable with `--stop-after` to run a contiguous slice of the pipeline. |
 | `--classification-summary <path>` | No | auto-loaded from `<output-dir>/state/01-classification.md` if `--start-at rca` or later | Override the Phase 1 output that Phase 2 consumes. Useful when the prior state file is missing or you want to point at a hand-edited version. |
@@ -94,7 +95,7 @@ Arguments: $ARGUMENTS
 | `--output-dir` | No | `./experiments` | Where the dataset JSON, publish script, and generated experiment file are written. |
 | `--backend` | No | auto-detect | `pup` forces pup mode regardless of MCP availability. |
 
-If `ml_app` is not provided, ask the user before proceeding. If `--data-only` and `--publish` are both set, error out — they're mutually exclusive (per `llm-obs-eval-bootstrap`'s rules).
+If `ml_app` is not provided, ask the user before proceeding. The three evaluator-output flags (`--offline-evaluators`, `--online-evaluators`, `--data-only`) are mutually exclusive — error out if more than one is set. If none are set, `--offline-evaluators` is the default. The legacy flag names `--publish` and `--sdk-code` are still accepted as aliases for backward compatibility but map to the new names in all output.
 
 ---
 
@@ -321,7 +322,11 @@ Wait for explicit user confirmation. If the user adjusts the taxonomy, incorpora
 
 > **What an evaluator is**: a function that grades one record's output. Returns `bool` / `float` / a structured `EvaluatorResult`. Two flavors: **code evaluators** (deterministic checks — JSON validity, regex match, length, custom Python) and **LLM-as-judge evaluators** (a model graded against a rubric — e.g. "is this response grounded in the retrieved documents?").
 >
-> **What "online" vs "offline" means**: an offline evaluator runs inside an experiment against a dataset. An online evaluator runs on production spans as they're emitted. Pass `--publish` to bootstrap online LLM-judge evaluators; default is offline `.py` code suitable for experiments.
+> **Operating modes** (mutually exclusive; default is `--offline-evaluators`):
+>
+> - **`--offline-evaluators`** *(default)*: emit a Python SDK evaluator suite (BaseEvaluator / LLMJudge classes) that runs **inside an experiment against a dataset**. Use this when you'll run experiments locally.
+> - **`--online-evaluators`**: publish LLM-judge evaluators to Datadog as disabled drafts. They run **on production spans as they're emitted** once enabled. Use this when you want continuous evaluation in prod.
+> - **`--data-only`**: emit a local data blob only — no executable evaluator code or online publish. Prompts you to pick between a dataset for experiment use or a local analysis blob (see "Operating mode resolution" below).
 >
 > **Why this phase matters**: evaluators are the contract between "this output looks fine" and "this output meets our quality bar." The bootstrapped suite is grounded in the failure taxonomy from Phase 2 — sharper than generic evaluators you'd otherwise hand-write.
 
@@ -329,10 +334,22 @@ Wait for explicit user confirmation. If the user adjusts the taxonomy, incorpora
 
 The RCA report from Phase 2 is in context. The skill detects the `## Failure Taxonomy` heading automatically and enters its "from RCA" path in Phase 0.
 
-Pass through any flags:
-- `--data-only` → emit a JSON spec instead of Python SDK code
-- `--publish` → publish online LLM-judge evaluators directly to Datadog
-- `--evaluator-style` → pass through unchanged
+### Operating mode resolution
+
+Before invoking the sub-skill, resolve the operating mode:
+
+1. **`--offline-evaluators`** (default) → call `llm-obs-eval-bootstrap` with no mode flag (its `sdk_code` default).
+2. **`--online-evaluators`** → call `llm-obs-eval-bootstrap --publish`.
+3. **`--data-only`** → prompt the user via `AskUserQuestion`:
+
+   > "You picked `--data-only` for Phase 3. What kind of local data blob do you want?
+   >
+   > - **Dataset for experiment use** — a `DatasetRecordRaw[]` JSON suitable for `LLMObs.create_dataset(records=...)`. Useful when you want to seed an experiment with the records this skill samples. (Internally calls `llm-obs-eval-bootstrap --emit-dataset <path>`.)
+   > - **Local blob for analysis** — a framework-agnostic JSON evaluator spec describing what evaluators *would* be generated, without emitting Python code. Useful for inspecting evaluator coverage without running anything. (Internally calls `llm-obs-eval-bootstrap --data-only`.)"
+
+   If the user picks "Dataset for experiment use" and the pipeline is running through Phase 4 (i.e. `--stop-after` is not `eval-bootstrap` or earlier), tell the user that Phase 4's sample step will be **skipped** in favor of this Phase 3 output — the dataset they produce here will be the one Phase 4 publishes.
+
+Pass `--evaluator-style` through unchanged.
 
 **The llm-obs-eval-bootstrap skill has its own mandatory proposal checkpoint** (the evaluator suite proposal before code generation). Honor it — do not skip or auto-confirm it.
 
@@ -341,7 +358,8 @@ Pass through any flags:
 ```
 ## Phase 3 complete — evaluator suite ready
 
-- Output: `<path to .py / .json / "published as drafts to Datadog">`
+- Mode: `<offline-evaluators | online-evaluators | data-only (dataset-for-experiment) | data-only (analysis-blob)>`
+- Output: `<path to .py / .json / dataset-record JSON / "published as drafts to Datadog">`
 - Evaluators emitted: <list of names>
 - Coverage: <one-liner: which failure-mode categories are now covered>
 
@@ -389,6 +407,8 @@ This mode samples root spans, extracts `(input_data, expected_output)` pairs, ap
 If the user excluded specific traces in Checkpoint 1, pass that exclusion list along (sub-skill drops them during sampling — do NOT re-classify).
 
 Reproduce the sub-skill's `## Generated Dataset` summary verbatim.
+
+**Skip 4a if Phase 3 already produced a dataset.** When the user picked `--data-only` with the "Dataset for experiment use" sub-mode in Phase 3, the Phase 3 state file (`state/03-evaluators.json`) has `mode: data_only_dataset` and an `output_path` pointing at the dataset JSON. In that case, **skip sub-step 4a entirely** and feed the Phase 3 output to 4b's publish helper directly. Surface a one-line note: "Reusing dataset from Phase 3 (`<path>`); skipping fresh sampling."
 
 **4b — Publish to Datadog.** Immediately invoke the pre-shipped publish helper at `<this-skill-dir>/scripts/publish_dataset.py` via Bash. **Do not** inline the script content into this SKILL.md or re-write it from scratch — the helper is the source of truth for the publish flow (credential discovery, tag normalization, project creation, error handling). It accepts CLI args, so no placeholder substitution is needed.
 
@@ -571,7 +591,7 @@ After the analyzer report, emit the closing summary — this replaces the per-ph
 |---|---|
 | 1. Classify ml_app | <N> traces classified (<F> failures) |
 | 2. Root cause analysis | <K> failure modes, <M> root causes |
-| 3. Bootstrap evaluators | <J> evaluators → `<path>` (or "<N> drafts published to Datadog") |
+| 3. Bootstrap evaluators | <J> evaluators (`<offline-evaluators | online-evaluators | data-only>`) → `<path>` (or "<N> drafts published to Datadog") |
 | 4. Create + publish dataset | <K> records → `<dataset_path>`, published as `<dataset_name>` (v1) in project `<project_name>` |
 | 5. Generate + run experiment | `<experiment_file_path>` → <experiment.url> (<N> records, <duration>s) |
 | 6. Analyze experiment | <2–3 bullet headline findings from the analyzer> |
@@ -587,7 +607,7 @@ After the analyzer report, emit the closing summary — this replaces the per-ph
 1. Open the experiment in the Datadog UI: <experiment.url>
 2. Replace the placeholder evaluators in `<experiment_file_path>` with the ones bootstrapped in Phase 3 (swap the function refs / `RemoteEvaluator` names).
 3. Re-run the experiment after every meaningful change to your task code. Datadog will keep the run history under the same project.
-4. If you published draft evaluators via `--publish`, review and enable them in the UI (LLM Observability → Evaluations).
+4. If you published draft evaluators via `--online-evaluators`, review and enable them in the UI (LLM Observability → Evaluations).
 
 ## Datadog Documentation
 
@@ -642,7 +662,7 @@ After every successful phase completion (i.e. after the user types `continue` pa
 |---|---|---|
 | 1 classify | `state/01-classification.md` | The full `# Session Classification Summary` block plus all per-unit compact blocks, verbatim from `llm-obs-session-classify`. Markdown. |
 | 2 rca | `state/02-rca-report.md` | The full Phase 6 RCA report from `llm-obs-trace-rca`, verbatim. Markdown. |
-| 3 eval-bootstrap | `state/03-evaluators.json` | `{"mode": "sdk_code\|data_only\|publish", "output_path": "<path>", "evaluator_names": [...], "ml_app": "<ml_app>", "generated_at": "<ISO 8601>"}`. The actual evaluator code/JSON stays where the sub-skill wrote it. |
+| 3 eval-bootstrap | `state/03-evaluators.json` | `{"mode": "offline_evaluators\|online_evaluators\|data_only_dataset\|data_only_analysis", "output_path": "<path>", "evaluator_names": [...], "ml_app": "<ml_app>", "generated_at": "<ISO 8601>"}`. The actual evaluator code/JSON/dataset stays where the sub-skill wrote it. The `data_only_dataset` mode produces a `DatasetRecordRaw[]` JSON that Phase 4 then consumes directly. |
 | 4 dataset | `state/04-published-dataset.json` | `{"dataset_file": "<path to local DatasetRecordRaw[] JSON>", "dataset_name": "<published name>", "project_name": "<name>", "version": <int>, "url": "<datadog url>", "record_count": <int>, "skipped_count": <int>, "pii_redactions": <int>, "tag_normalizations": <int>, "published_at": "<ISO 8601>"}` — combines what was previously two state files (`04-dataset.json` and `05-published-dataset.json`) because Phase 4 now creates and publishes in one step. |
 | 5 experiment | `state/05-experiment-run.json` | `{"experiment_file": "<path>", "format": "py\|ipynb", "dataset_name": "<name>", "task_source": "<module:function>\|placeholder", "purpose": "<text>", "experiment_id": "<uuid>", "experiment_url": "<datadog url>", "records_processed": <int>, "duration_seconds": <float>, "generated_at": "<ISO 8601>", "ran_at": "<ISO 8601>"}` — combines what was previously two state files (`06-experiment.json` and `07-experiment-run.json`) because Phase 5 now generates and runs in one step. If the user halts at the in-phase review beat (5b) with `edit`, only the codegen fields are populated; re-entering with `--start-at experiment` reads the file path from here and resumes at 5c. |
 | 6 analyze | `state/06-analysis.md` | The full analyzer report from `llm-obs-experiment-analyzer`. Markdown. |
@@ -754,7 +774,7 @@ Everything else routes through sub-skills, which carry their own MCP-to-pup mapp
 |---|---|---|
 | `llm-obs-session-classify` | Phase 1 | `dd-llmo/llm-obs-session-classify/SKILL.md` (Tool Reference appendix) |
 | `llm-obs-trace-rca` | Phase 2 | `dd-llmo/llm-obs-trace-rca/SKILL.md` (Tool Reference appendix) |
-| `llm-obs-eval-bootstrap` (sdk_code / data_only / publish) | Phase 3 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Tool Reference appendix) |
+| `llm-obs-eval-bootstrap` (offline-evaluators / online-evaluators / data-only) | Phase 3 | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Tool Reference appendix) |
 | `llm-obs-eval-bootstrap` (`--emit-dataset` mode) | Phase 4 (sub-step 4a) | `dd-llmo/llm-obs-eval-bootstrap/SKILL.md` (Phase 3D + Tool Reference appendix) |
 | `llm-obs-experiment-py-bootstrap` | Phase 5 (sub-step 5a) | `dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md` |
 | `llm-obs-experiment-analyzer` | Phase 6 | `dd-llmo/llm-obs-experiment-analyzer/SKILL.md` (Tool Reference appendix) |

--- a/dd-llmo/llm-obs-eval-pipeline/scripts/.gitignore
+++ b/dd-llmo/llm-obs-eval-pipeline/scripts/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/dd-llmo/llm-obs-eval-pipeline/scripts/load_env.py
+++ b/dd-llmo/llm-obs-eval-pipeline/scripts/load_env.py
@@ -1,0 +1,74 @@
+"""Discover .env-style files and import their keys into os.environ.
+
+Used by both:
+- scripts/publish_dataset.py (imported at runtime)
+- dd-llmo/llm-obs-experiment-py-bootstrap/scripts/env_setup_template.py
+  (kept in sync as a verbatim copy — that copy is embedded into the
+  user's generated experiment file so the file runs standalone without
+  depending on this skill being installed)
+
+Discovery order (first hit per variable wins; shell env vars always
+override file-loaded values):
+
+  1. Any path in `extra` (typically the resolved --env-file argument)
+  2. <this-script-dir>/.env  and  .env.local
+  3. <cwd>/.env  and  .env.local
+  4. Parent-walk from cwd up to /  (stops at $HOME's parent)
+  5. ~/.datadog/credentials  (well-known Datadog convention)
+
+Never overwrites a value that is already in os.environ — that is the
+contract that lets users override anything by `export KEY=...` in
+their shell before running.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def load_env_files(extra: list[str] | None = None) -> list[str]:
+    """Walk discovery locations and return the absolute paths of files loaded."""
+    here = pathlib.Path(__file__).resolve().parent
+    cwd = pathlib.Path.cwd().resolve()
+    candidates: list[pathlib.Path] = []
+    for p in extra or []:
+        candidates.append(pathlib.Path(p).expanduser())
+    candidates += [
+        here / ".env",
+        here / ".env.local",
+        cwd / ".env",
+        cwd / ".env.local",
+    ]
+    p = cwd
+    while p != p.parent and p != pathlib.Path.home().parent:
+        candidates.append(p / ".env")
+        p = p.parent
+    candidates.append(pathlib.Path.home() / ".datadog" / "credentials")
+
+    loaded: list[str] = []
+    seen: set[pathlib.Path] = set()
+    for path in candidates:
+        try:
+            path = path.resolve()
+        except Exception:
+            continue
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
+        try:
+            text = path.read_text()
+        except Exception:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            k, _, v = line.partition("=")
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k and k not in os.environ:  # shell wins over file
+                os.environ[k] = v
+        loaded.append(str(path))
+    return loaded

--- a/dd-llmo/llm-obs-eval-pipeline/scripts/publish_dataset.py
+++ b/dd-llmo/llm-obs-eval-pipeline/scripts/publish_dataset.py
@@ -1,0 +1,122 @@
+"""Phase 5 dataset publisher for llm-obs-eval-pipeline.
+
+CLI wrapper around `LLMObs.create_dataset(records=...)` that:
+  - Auto-loads credentials via the shared load_env helper (script dir,
+    cwd, parent dirs, ~/.datadog/credentials). Shell env wins over
+    file values, so users can override by `export DD_API_KEY=...`.
+  - Defensively normalizes per-record `tags` (wraps bare strings as
+    `tag:<value>`, drops empties) so a malformed upstream dataset
+    cannot trip the SDK's `validate_tags_list` ValueError.
+  - Creates the Datadog project lazily on first `LLMObs.enable()` call.
+
+Usage:
+  python publish_dataset.py \\
+    --records /abs/path/to/dataset.json \\
+    --dataset-name my_seed_20260529 \\
+    --project-name my-llm-app \\
+    [--env-file /abs/path/to/extra.env]
+
+Prints `OK dataset_name=... record_count=... url=...` on success.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+# Make sibling load_env.py importable regardless of how the script is invoked.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from load_env import load_env_files  # noqa: E402
+
+
+def normalize_tags(raw):
+    """Return (normalized_tags, fix_count).
+
+    Wraps bare strings as `tag:<value>`, drops empty/None, preserves
+    malformed leading/trailing colons by wrapping the original as
+    `tag:<original>` so the SDK's `validate_tags_list` cannot reject
+    the record. See dd-llmo/llm-obs-eval-bootstrap/SKILL.md Phase 3D
+    "Tag normalization" for the rationale.
+    """
+    fixed = []
+    fix_count = 0
+    for t in raw or []:
+        if not isinstance(t, str):
+            fix_count += 1
+            continue
+        t = t.strip()
+        if not t:
+            fix_count += 1
+            continue
+        if ":" in t:
+            k, _, v = t.partition(":")
+            if k and v:
+                fixed.append(t)
+                continue
+            fixed.append(f"tag:{t}")
+            fix_count += 1
+            continue
+        fixed.append(f"tag:{t}")
+        fix_count += 1
+    return fixed, fix_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--records", required=True, help="Absolute path to the DatasetRecordRaw[] JSON file.")
+    parser.add_argument("--dataset-name", required=True, help="Name to publish the dataset under in Datadog.")
+    parser.add_argument("--project-name", required=True, help="Datadog project to publish the dataset under. Created lazily.")
+    parser.add_argument("--env-file", action="append", default=[], help="Extra .env path(s) to load FIRST (repeatable).")
+    args = parser.parse_args()
+
+    loaded = load_env_files(args.env_file)
+    if loaded:
+        print(f"Loaded credentials from: {', '.join(loaded)}")
+
+    api_key = os.getenv("DD_API_KEY")
+    app_key = os.getenv("DD_APPLICATION_KEY") or os.getenv("DD_APP_KEY")
+    if not api_key:
+        print("ERROR: DD_API_KEY is not set. Export it in your shell or add it to a discovered .env file.", file=sys.stderr)
+        return 2
+    if not app_key:
+        print("ERROR: DD_APPLICATION_KEY (or DD_APP_KEY) is not set. Same fallback paths as above.", file=sys.stderr)
+        return 2
+
+    from ddtrace.llmobs import LLMObs  # imported AFTER env load so credentials are picked up
+
+    LLMObs.enable(
+        api_key=api_key,
+        app_key=app_key,
+        site=os.getenv("DD_SITE", "datadoghq.com"),
+        project_name=args.project_name,  # project is created lazily here if it does not exist
+        agentless_enabled=True,
+    )
+
+    with open(args.records) as f:
+        records = json.load(f)
+
+    total_fixes = 0
+    for r in records:
+        if "tags" in r:
+            r["tags"], n = normalize_tags(r.get("tags"))
+            total_fixes += n
+    if total_fixes:
+        print(
+            f"WARNING: normalized {total_fixes} malformed tag(s) before publish "
+            "(bare strings wrapped as 'tag:<value>'; empties dropped)."
+        )
+
+    dataset = LLMObs.create_dataset(
+        dataset_name=args.dataset_name,
+        description=f"Seed dataset for {args.dataset_name} (eval-pipeline flow, sampled from production traces).",
+        records=records,
+    )
+    url = dataset.url if hasattr(dataset, "url") else "<inspect in UI>"
+    print(f"OK dataset_name={args.dataset_name} record_count={len(records)} url={url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## ⚠️ Depends on #55

Phase 4 invokes `eval-bootstrap --emit-dataset`, which is added by **#55**. This PR should merge **after** #55. Reviewers can read both in parallel.

## Summary

Extends `llm-obs-eval-pipeline` from a 3-phase eval-only flow (classify → RCA → eval-bootstrap) into an 8-phase guided pipeline that covers the full onboarding journey through evaluators, datasets, experiments, and analysis. The classic 3-phase behavior is preserved exactly: pass `--stop-after eval-bootstrap` to keep it.

## Phases

| # | Phase | Sub-skill | Executes? |
|---|---|---|---|
| 1 | Classify ml_app traces | `llm-obs-session-classify` (ml_app mode) | no |
| 2 | Root cause analysis | `llm-obs-trace-rca` | no |
| 3 | Bootstrap evaluators | `llm-obs-eval-bootstrap` (pass-through `--data-only` / `--publish`) | no |
| 4 | Create dataset from prod traces | `llm-obs-eval-bootstrap --emit-dataset` *(needs #55)* | no |
| 5 | Publish dataset | `scripts/publish_dataset.py` via Bash | **yes** |
| 6 | Generate experiment code | `llm-obs-experiment-py-bootstrap` | no |
| 7 | Run experiment | `python <generated_file>` | **yes** |
| 8 | Analyze experiment | `llm-obs-experiment-analyzer` | no |

Standardized banner + `continue` checkpoint between every phase. `--stop-after <phase>` lets users exit cleanly at any point. Execution gated to Phases 5 and 7 only.

## New top-level inputs

- `--project-name <name>` — the Datadog project the dataset + experiment land in. SDK creates it lazily on first `LLMObs.enable()` call in Phase 5. Auto-derived from `pyproject.toml` / `setup.cfg` / etc. when not supplied; surfaced in the Precheck so the user can override before anything is created.
- `--stop-after <phase>` — exit cleanly after phase N. Eight valid values; `--stop-after eval-bootstrap` is the drop-in replacement for the classic 3-phase eval-pipeline.
- `--evaluator-style`, `--app-root`, `--env-file`, `--output-dir` — pass-throughs / orchestrator knobs.

## Highlights

- **Standardized phase envelope**: every phase has a "You are here. Phase N of 8" banner, an entity-definition pedagogy block, an action, and a checkpoint. Determinism across invocations is the explicit goal.
- **Precheck credential discovery**: walks shell env → `<output-dir>/.env` → `<app-root>/.env` → `.env.local` → `<cwd>/.env` → parent dirs → `~/.datadog/credentials` and reports which file was loaded (never values).
- **Phase 1 trace-pool link**: builds a Datadog Traces UI URL that opens the exact set of root spans Phase 4 will sample for the dataset. Site-derived host, URL-encoded query, absolute epoch ms time window, `&paused=true`.
- **scripts/ extraction**: Phase 5's ~130-line inline publish script is replaced by `scripts/publish_dataset.py` (CLI tool with `--records` / `--dataset-name` / `--project-name` / `--env-file`) + `scripts/load_env.py` (env-file discovery walker, shell-overrides-file). Skill body is now a router; details live next to it.

## Companion PRs (split from #47)

1. `llm-obs-eval-bootstrap` gets `--emit-dataset` mode — #55
2. `llm-obs-experiment-py-bootstrap` gets introspection + .env + scripts/references split — #56
3. (this PR) `llm-obs-eval-pipeline` extends to 8 phases

Mirrors DataDog/llm-obs#390.

## Test plan

- [ ] Invoke `/llm-obs-eval-pipeline <ml_app>` against a real instrumented app; walk all 8 phases. Confirm each phase prints the standardized banner + entity definition before its action.
- [ ] Confirm Precheck step 5 reports which `.env` file loaded which keys (never the values).
- [ ] Confirm Precheck fails early with an actionable message if no DD credentials resolve.
- [ ] Confirm `--project-name my-new-project` flows into Phase 5's `LLMObs.enable(project_name="my-new-project", ...)` and creates the project in Datadog.
- [ ] Confirm Phase 1 outputs a clickable Datadog Traces UI URL pointing at the right pool, paused on open. Test against staging `datad0g.com` to confirm host derivation.
- [ ] Confirm `--stop-after eval-bootstrap` exits cleanly after Phase 3 with the Stop summary, skipping Phases 4–8.
- [ ] Confirm Phase 4 invokes `eval-bootstrap --emit-dataset` correctly (needs #55 merged).
- [ ] Confirm Phase 5's publish script auto-loads credentials and prints `Loaded credentials from: <path>`.
- [ ] Confirm Phase 7 runs the generated file end-to-end and captures `experiment.url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)