### PR TITLE
Fix duplicate entry for dd-software-delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-browser-sdk** | Browser SDK: RUM, Logs, Session Replay, profiling, product analytics, error tracking, version migration |
 | **dd-audit** | Audit Trail investigations: who changed what, key compromise, cost spike root cause, compliance evidence (SOC 2/PCI), AI activity auditing |
 | **dd-software-delivery** | CI/CD workflow skills — unblock PR pipelines, triage flaky tests (MCP + pup) |
-| **dd-software-delivery** | CI/CD workflow skills — unblock failing PR pipelines, triage flaky tests |
 
 ## Install
 


### PR DESCRIPTION
Removed duplicate entry for 'dd-software-delivery' in the README.