### PR TITLE
feat(lib): expose include_str! constants for all skill files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,57 @@
+pub const DD_APM_SKILL: &str = include_str!("../dd-apm/SKILL.md");
+
+pub static DD_APM_SUB_SKILLS: &[(&str, &str)] = &[
+    ("service-remapping/SKILL.md",            include_str!("../dd-apm/service-remapping/SKILL.md")),
+    ("k8s-ssi/agent-install/SKILL.md",        include_str!("../dd-apm/k8s-ssi/agent-install/SKILL.md")),
+    ("k8s-ssi/enable-ssi/SKILL.md",           include_str!("../dd-apm/k8s-ssi/enable-ssi/SKILL.md")),
+    ("k8s-ssi/verify-ssi/SKILL.md",           include_str!("../dd-apm/k8s-ssi/verify-ssi/SKILL.md")),
+    ("k8s-ssi/troubleshoot-ssi/SKILL.md",     include_str!("../dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md")),
+    ("k8s-ssi/onboarding-summary/SKILL.md",   include_str!("../dd-apm/k8s-ssi/onboarding-summary/SKILL.md")),
+    ("linux-ssi/agent-install/SKILL.md",      include_str!("../dd-apm/linux-ssi/agent-install/SKILL.md")),
+    ("linux-ssi/enable-ssi/SKILL.md",         include_str!("../dd-apm/linux-ssi/enable-ssi/SKILL.md")),
+    ("linux-ssi/verify-ssi/SKILL.md",         include_str!("../dd-apm/linux-ssi/verify-ssi/SKILL.md")),
+    ("linux-ssi/troubleshoot-ssi/SKILL.md",   include_str!("../dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md")),
+    ("linux-ssi/onboarding-summary/SKILL.md", include_str!("../dd-apm/linux-ssi/onboarding-summary/SKILL.md")),
+];
+
+pub const DD_AUDIT_SKILL: &str = include_str!("../dd-audit/SKILL.md");
+
+pub static DD_AUDIT_SUB_SKILLS: &[(&str, &str)] = &[
+    ("ai-activity-audit/SKILL.md",       include_str!("../dd-audit/ai-activity-audit/SKILL.md")),
+    ("compliance-report/SKILL.md",       include_str!("../dd-audit/compliance-report/SKILL.md")),
+    ("cost-spike-investigation/SKILL.md", include_str!("../dd-audit/cost-spike-investigation/SKILL.md")),
+    ("key-compromise/SKILL.md",          include_str!("../dd-audit/key-compromise/SKILL.md")),
+    ("security-investigation/SKILL.md",  include_str!("../dd-audit/security-investigation/SKILL.md")),
+];
+
+pub const DD_BROWSER_SDK_SKILL: &str = include_str!("../dd-browser-sdk/SKILL.md");
+
+pub static DD_BROWSER_SDK_SUB_SKILLS: &[(&str, &str)] = &[
+    ("upgrade-v7/SKILL.md", include_str!("../dd-browser-sdk/upgrade-v7/SKILL.md")),
+];
+
+pub const DD_DOCS_SKILL: &str = include_str!("../dd-docs/SKILL.md");
+
+pub static DD_LLMO_SUB_SKILLS: &[(&str, &str)] = &[
+    ("llm-obs-eval-bootstrap/SKILL.md",        include_str!("../dd-llmo/llm-obs-eval-bootstrap/SKILL.md")),
+    ("llm-obs-eval-pipeline/SKILL.md",         include_str!("../dd-llmo/llm-obs-eval-pipeline/SKILL.md")),
+    ("llm-obs-experiment-analyzer/SKILL.md",   include_str!("../dd-llmo/llm-obs-experiment-analyzer/SKILL.md")),
+    ("llm-obs-experiment-py-bootstrap/SKILL.md", include_str!("../dd-llmo/llm-obs-experiment-py-bootstrap/SKILL.md")),
+    ("llm-obs-session-classify/SKILL.md",      include_str!("../dd-llmo/llm-obs-session-classify/SKILL.md")),
+    ("llm-obs-trace-rca/SKILL.md",             include_str!("../dd-llmo/llm-obs-trace-rca/SKILL.md")),
+];
+
+pub const DD_LOGS_SKILL: &str = include_str!("../dd-logs/SKILL.md");
+
+pub const DD_MONITORS_SKILL: &str = include_str!("../dd-monitors/SKILL.md");
+
+pub const DD_PUP_SKILL: &str = include_str!("../dd-pup/SKILL.md");
+
+pub static DD_SECURITY_SUB_SKILLS: &[(&str, &str)] = &[
+    ("csm/ownership-agent/SKILL.md", include_str!("../dd-security/csm/ownership-agent/SKILL.md")),
+];
+
+pub static DD_SOFTWARE_DELIVERY_SUB_SKILLS: &[(&str, &str)] = &[
+    ("triage-flaky-test/SKILL.md", include_str!("../dd-software-delivery/triage-flaky-test/SKILL.md")),
+    ("unblock-pr/SKILL.md",        include_str!("../dd-software-delivery/unblock-pr/SKILL.md")),
+];


### PR DESCRIPTION
## Summary

- Implements the `src/lib.rs` interface required by [DataDog/pup#536](https://github.com/DataDog/pup/pull/536) so pup can consume this repo as a Cargo git dependency
- Exposes `DD_<PRODUCT>_SKILL: &str` for each product with a root `SKILL.md` (apm, audit, browser-sdk, docs, logs, monitors, pup)
- Exposes `DD_<PRODUCT>_SUB_SKILLS: &[(&str, &str)]` for products with sub-skills — each tuple is `(relative_path, content)` — covering apm (11), audit (5), browser-sdk (1), llmo (6), security (1), software-delivery (2)
- Products without a root `SKILL.md` (llmo, security, software-delivery) expose only a sub-skills array

## Usage (pup side)

```toml
# Cargo.toml
agent-skills = { git = "https://github.com/datadog-labs/agent-skills", rev = "<this-commit>" }
```

```rust
// src/skills.rs
agent_skills::DD_APM_SKILL          // root SKILL.md content
agent_skills::DD_APM_SUB_SKILLS     // &[("service-remapping/SKILL.md", "..."), ...]
```

## Test plan

- [x] Verify `cargo build` passes (all `include_str!` paths resolve)
- [ ] After merging, bump the `rev` in DataDog/pup#536 to this commit and confirm pup builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)