### PR TITLE
fix(dd-apm/troubleshoot-ssi): require surfacing every diagnostic in the final response (k8s + linux)

### DIFF
--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -142,6 +142,16 @@ The last command confirms the Admission Controller webhook is registered cluster
 
 ---
 
+## Presenting your findings (required)
+
+Your final response is the deliverable — not your investigation transcript. It must include **every diagnostic from this skill that you ran or that applies**, each with its purpose and what you found. Three failure modes to avoid:
+
+- **Running a check but not reporting it.** If you ran `kubectl get mutatingwebhookconfigurations`, the namespace `admission.datadoghq.com/mutate-pods` label check, or any other command during investigation, state the command and its result in your response. A check you ran but didn't surface gives the reader nothing — and the namespace-label and webhook checks in particular must appear explicitly.
+- **Dropping a tool because it isn't installed.** If `pup` is unavailable in your environment and can't be installed, do **not** abandon the pup-based diagnostics. Still recommend the exact commands — `pup apm troubleshooting list --hostname <NODE_HOSTNAME>` (injection errors) and `pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>` (runtime SDK config) — for the user to run. They are part of the runbook regardless of whether you can execute them here.
+- **Stopping at the first root cause.** When multiple services are affected, investigate and report each one independently — they may have different causes — and give per-service remediation.
+
+---
+
 ## Step 2: State Your Hypotheses
 
 Before investigating, explicitly state your ranked hypotheses based on triage output. Do not skip this step.

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -147,7 +147,11 @@ The last command confirms the Admission Controller webhook is registered cluster
 Your final response is the deliverable — not your investigation transcript. It must include **every diagnostic from this skill that you ran or that applies**, each with its purpose and what you found. Three failure modes to avoid:
 
 - **Running a check but not reporting it.** If you ran `kubectl get mutatingwebhookconfigurations`, the namespace `admission.datadoghq.com/mutate-pods` label check, or any other command during investigation, state the command and its result in your response. A check you ran but didn't surface gives the reader nothing — and the namespace-label and webhook checks in particular must appear explicitly.
-- **Dropping a tool because it isn't installed.** If `pup` is unavailable in your environment and can't be installed, do **not** abandon the pup-based diagnostics. Still recommend the exact commands — `pup apm troubleshooting list --hostname <NODE_HOSTNAME>` (injection errors) and `pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>` (runtime SDK config) — for the user to run. They are part of the runbook regardless of whether you can execute them here.
+- **Omitting the two required pup diagnostics.** Every diagnosis must explicitly include these two commands, by name, for each affected service — they are mandatory triage output, not optional:
+  - `pup apm troubleshooting list --hostname <NODE_HOSTNAME>` — surfaces injection errors Datadog received from the node
+  - `pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>` — shows the tracer's runtime SDK config
+
+  Run them if `pup` is available; recommend them for the user to run if it isn't. Do **not** substitute `pup fleet instrumented-pods list` or `pup traces search` for these — those are different checks and do not satisfy the runbook. If you don't know `<ENV>`, state your assumed value and run the command anyway.
 - **Stopping at the first root cause.** When multiple services are affected, investigate and report each one independently — they may have different causes — and give per-service remediation.
 
 ---

--- a/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md
@@ -158,12 +158,28 @@ pup traces search --query "service:<SERVICE_NAME>" --from 15m --limit 5
 pup metrics query --query "sum:trace.*.request.hits{host:<DD_HOSTNAME>,service:<SERVICE_NAME>}.as_count()" --from 15m
 ```
 
-`ENV` is required for `service-library-config get`. If the user didn't provide it, ask for it before running that command.
+`ENV` is required for `service-library-config get`. If the user didn't provide it, state your assumed value (e.g. `prod`) and run it anyway — don't stop to ask.
 
 Key values to check in `service-library-config get` output:
 - `apm_enabled` — must be `true`. If `false`, the tracer won't send traces regardless of injection.
 - `trace_agent_url` — must point to `http://localhost:8126` or the correct agent socket. Wrong value = tracer can't reach the Agent.
 - `site` — must match your Datadog org's site.
+
+---
+
+## Presenting your findings (required)
+
+Your final response is the deliverable — not your investigation transcript. It must include **every diagnostic from this skill that you ran or that applies**, each with its purpose and what you found. Avoid these failure modes:
+
+- **Omitting a required diagnostic.** Your response must explicitly include, by name:
+  - `pup apm troubleshooting list --hostname <DD_HOSTNAME>` — injection errors
+  - `pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>` — runtime SDK config
+  - verification that **`apm_enabled` is `true`** and that **`trace_agent_url` points to the correct agent endpoint** (e.g. `http://localhost:8126`)
+  - `datadog-agent status` for the APM receiver, and a `/proc/<pid>/maps` (or equivalent) check that the tracer `.so` is loaded into the process
+
+  Run them if you have access; recommend them for the user to run if you don't.
+- **Substituting a proxy check.** Confirming port 8126 is listening shows the Agent's receiver is up — it is **not** a substitute for verifying the tracer-side `apm_enabled` and `trace_agent_url` config keys. They answer different questions; report both.
+- **Concluding before the checks.** Outline and run the diagnostics before settling on a root cause, then give specific per-finding remediation and note that the service must be restarted after any config or package fix.
 
 ---
 


### PR DESCRIPTION
## Summary

Behavioral fix to both `troubleshoot-ssi` skills (k8s + linux). **Not new content** — both already document the checks; the agent just wasn't surfacing them in its final response, which is what the eval grades.

Validated via apm-evals (skill mode): **troubleshoot_k8s 56 → 100**, **troubleshoot_linux 78 → 100**.

## Problem

With tools available the agent investigates hands-on, finds the root cause, then under-reports — running checks silently or substituting a proxy for the specific check the runbook needs (k8s: `pup fleet instrumented-pods` instead of `pup apm troubleshooting list`; linux: "port 8126 listening" instead of the `apm_enabled` / `trace_agent_url` config keys).

## Change

Both skills get a **"Presenting your findings (required)"** section: report every check with its result, make the named diagnostics (pup commands, `apm_enabled`/`trace_agent_url`) mandatory output, and forbid the proxy substitutions. +31 lines across the two SKILL.md files.

## Validation (apm-evals, skill mode)

| Skill | Before | After |
|---|---|---|
| troubleshoot_k8s | 56 (5/9) | 100 (9/9) |
| troubleshoot_linux | 78 (7/9) | 100 (9/9) |

Each commit recovered exactly the criteria its wording targeted.