### PR TITLE
[APPS] Update Datadog Apps skill OAuth guidance

### DIFF
--- a/dd-apps/datadog-app/SKILL.md
+++ b/dd-apps/datadog-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datadog-app
-description: Guides developers building Datadog Apps with TypeScript, React, the @datadog/apps scaffolder, and @datadog/vite-plugin. Use when a user wants to scaffold, run, debug, upgrade, build, upload, publish, upload without publishing (draft upload), add an upload-no-publish script, set up CI/CD, trigger/poll Workflow Automation, choose DDSQL or Action Catalog for backend data access, or query app datastores with DDSQL, including backend function troubleshooting.
+description: Guides developers building Datadog Apps with TypeScript, React, the @datadog/apps scaffolder, and @datadog/vite-plugin. Use when a user wants to scaffold, run, debug, upgrade, build, upload, publish, upload without publishing (draft upload), add an upload-no-publish script, set up CI/CD, use OAuth or API/application key auth, trigger/poll Workflow Automation, choose DDSQL or Action Catalog for backend data access, or query app datastores with DDSQL, including backend function troubleshooting.
 ---
 
 # Datadog Apps
@@ -25,12 +25,12 @@ Read only the reference needed for the user's task:
 | Understand or configure Action Catalog connections | `references/querying-data/connections.md` |
 | Query Datadog App datastores with DDSQL | `references/querying-data/ddsql/datastores.md` |
 | Upgrade Datadog Apps dependencies or compare with a freshly scaffolded app | `references/upgrading.md` |
-| Diagnose auth, upload, Node, site, backend function failures, or `.env.local` credentials not being picked up | `references/troubleshooting.md` |
+| Diagnose OAuth, API/application key auth, upload, Node, site, or backend function failures | `references/troubleshooting.md` |
 
 ## Boundaries
 
 - After scaffolding or when working inside an existing app, read the app project's `AGENTS.md` before making changes.
-- For backend function implementation details, rely on the generated app project's `AGENTS.md`; this skill only covers local development credentials and troubleshooting.
+- For backend function implementation details, rely on the generated app project's `AGENTS.md`; this skill only covers local development auth choices and troubleshooting.
 - Preserve the app project's existing package manager, scripts, Datadog site, and repository conventions.
 - Do not cover Datadog package/platform development in this skill.
 - Low-code App Builder to Datadog Apps migration guidance is future work. Do not invent a migration process yet.

--- a/dd-apps/datadog-app/references/build-upload-publish.md
+++ b/dd-apps/datadog-app/references/build-upload-publish.md
@@ -10,15 +10,15 @@ Inspect the generated `package.json` scripts before choosing a command; scaffold
 npm run typecheck
 ```
 
-Export credentials and run build or upload commands:
+Run the generated upload script directly:
 
 ```bash
-export DD_API_KEY="<YOUR_API_KEY>"
-export DD_APP_KEY="<YOUR_APPLICATION_KEY>"
 npm run upload
 ```
 
-`npm run upload` builds with asset upload enabled and publishes the new version live. A successful upload prints a Datadog URL for the uploaded app. In some scaffold versions, `npm run build` may also exercise Datadog upload behavior; if it fails with missing API or app keys, ensure credentials are exported or use `typecheck` for local compile validation.
+`npm run upload` builds with asset upload enabled and publishes the new version live. A successful upload prints a Datadog URL for the uploaded app. Upload uses OAuth by default. If both `DD_API_KEY` and `DD_APP_KEY` are set, the generated app uses those keys instead of OAuth.
+
+In some scaffold versions, `npm run build` may also exercise Datadog upload behavior. If it needs auth, complete the OAuth browser flow or set both key environment variables. Use `typecheck` for local compile validation that does not touch Datadog.
 
 ## Upload Without Publishing
 
@@ -53,8 +53,8 @@ After an upload-no-publish, the new version appears in the App Builder version h
 
 Relevant environment variables:
 
-- `DD_API_KEY`: Datadog API key.
-- `DD_APP_KEY`: Datadog application key.
+- `DD_API_KEY`: optional Datadog API key for key-based local dev or upload.
+- `DD_APP_KEY`: optional Datadog application key for key-based local dev or upload.
 - `DD_APPS_PUBLISH`: set to `false` to upload without publishing. Defaults to `true`.
 - `DD_APPS_VERSION_NAME`: optional unique uploaded app version name.
 - `DD_APPS_UPLOAD_ASSETS`: enables asset upload; upload scripts normally set this.

--- a/dd-apps/datadog-app/references/getting-started.md
+++ b/dd-apps/datadog-app/references/getting-started.md
@@ -6,7 +6,7 @@ Use this when the user wants to create, scaffold, configure prerequisites, or ru
 
 - Use Node.js 20.19+ on the Node 20 release line, or Node.js 22.12+ on the Node 22 release line.
 - Prefer a current Node 22 release when scaffolding or debugging dependency install issues.
-- Datadog API and application credentials are required. The application key needs two scopes: **Actions API Access** (for backend function execution) and **Apps** (for uploading and publishing). See [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/) for details.
+- Local development and upload use OAuth by default. API and application keys are optional for local key-based auth and are still commonly used in CI/CD.
 
 Check Node:
 
@@ -44,17 +44,30 @@ Keep the generated project path consistent with the user's chosen repository lay
 
 ## Local Development
 
-### Credentials
+### OAuth Default
 
-The app needs a Datadog API key and application key with **Actions API Access** enabled. Find or create them at:
+Run the generated dev script directly:
+
+```bash
+npm run dev
+```
+
+When the dev server needs to call Datadog, such as when running a backend function locally, the Vite plugin uses OAuth by default. If authorization is required, the command opens a browser prompt. After authorization completes, the token is cached in the operating system credential store when supported.
+
+Open the local URL printed by the dev server, commonly `http://localhost:5173/`.
+
+### Optional API And Application Keys
+
+If the user wants key-based auth for local development or uploads, set both `DD_API_KEY` and `DD_APP_KEY`. When both are set, the generated app uses those keys instead of OAuth.
+
+The application key needs **Actions API Access** for backend function execution and **Apps** for uploading and publishing. See [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/) for details. Find or create keys at:
+
 - API keys: `https://app.datadoghq.com/organization-settings/api-keys`
 - Application keys: `https://app.datadoghq.com/organization-settings/application-keys`
 
-**Default flow — create `.env.local` and open in editor:**
+Do not ask the user to provide actual key values in the conversation. Instead, create `.env.local` with placeholders if they want file-based local key auth:
 
-Do not ask the user to provide actual key values in the conversation. Instead:
-
-1. Confirm `.env.local` is gitignored — check `.gitignore` for `*.local` or `.env.local` before writing. The scaffolder includes this by default.
+1. Confirm `.env.local` is gitignored. Check `.gitignore` for `*.local` or `.env.local` before writing. The scaffolder includes this by default.
 2. Write the file to the app root with placeholders:
 
 ```
@@ -68,11 +81,9 @@ DD_APP_KEY=REPLACE_WITH_YOUR_APP_KEY
 cursor .env.local 2>/dev/null || code .env.local 2>/dev/null || open .env.local
 ```
 
-4. Tell the user to replace the placeholder values with their real keys, and provide these links to find or create them:
-   - API keys: `https://app.datadoghq.com/organization-settings/api-keys`
-   - Application keys: `https://app.datadoghq.com/organization-settings/application-keys` (Actions API Access must be enabled)
+4. Tell the user to replace the placeholder values with their real keys.
 
-Vite reads `.env.local` automatically, so once real values are in place, `npm run dev` and `npm run upload` pick up credentials without any shell exports.
+Vite reads `.env.local` automatically, so once real values are in place, `npm run dev` and `npm run upload` use those keys without shell exports. If either key is absent, the commands continue to use OAuth by default.
 
 **Optional shortcut (macOS only) — clipboard → file:** If the user asks for an alternative to editing the file, offer to write each key directly from the clipboard. The value goes clipboard → file without appearing in the conversation or tool output. Explain that the command being run is still visible in the transcript. Ask the user to copy their `DD_API_KEY` value to the clipboard first, then:
 
@@ -82,8 +93,6 @@ printf "DD_API_KEY=" >> .env.local && pbpaste >> .env.local && printf "\n" >> .e
 ```
 
 Repeat for `DD_APP_KEY`. Confirm the user has the correct value on their clipboard before running each step.
-
-Open the local URL printed by the dev server, commonly `http://localhost:5173/`.
 
 ## Generated Project Shape
 

--- a/dd-apps/datadog-app/references/querying-data/getting-started.md
+++ b/dd-apps/datadog-app/references/querying-data/getting-started.md
@@ -69,7 +69,7 @@ Use discovery tooling before writing app code:
 
 - Start with the public DDSQL Data Directory for documented datasets and table functions.
 - Prefer Datadog MCP DDSQL, data directory, table search, schema, or product-specific exploration tools when they are available in the current session. Use MCP results to confirm table names, columns, supported filters, and access before generating SQL.
-- For shell-based validation, use the Datadog API directly with your `DD_API_KEY` and `DD_APP_KEY` credentials.
+- For shell-based validation against the Datadog API directly, use `DD_API_KEY` and `DD_APP_KEY`. Normal scaffolded local app development uses OAuth by default.
 
 Do not rely on guessed table names, guessed columns, or `information_schema`. Treat a bounded preview query as the final proof that the table path, schema, access, and syntax work in the target org/site.
 
@@ -95,4 +95,4 @@ For exact Action Catalog imports, file layout, and app-code patterns, rely on th
 
 - Keep data access in backend functions, not frontend code.
 - Do not accept raw frontend SQL, raw `ORDER BY`, or unbounded limits.
-- Ensure `DD_API_KEY` and `DD_APP_KEY` are exported with Actions API Access when running local development or discovery commands.
+- Keep data discovery and backend calls server-side. Normal scaffolded local development uses OAuth by default; direct API shell commands still need API/application keys unless the tool provides its own auth.

--- a/dd-apps/datadog-app/references/troubleshooting.md
+++ b/dd-apps/datadog-app/references/troubleshooting.md
@@ -4,13 +4,15 @@ Use this when the user is diagnosing auth, upload, Node, site, or backend functi
 
 ## Authentication Errors
 
-Symptoms include 401s, `Missing authentication token`, backend function call failures, or the Vite plugin logging `Auth credentials not configured`.
+Symptoms include 401s, `Missing authentication token`, backend function call failures, OAuth browser flow failures, cached token failures, or the Vite plugin logging `Auth credentials not configured`.
 
-- Verify `DD_API_KEY` and `DD_APP_KEY` are set — either in `.env.local` at the app root or exported in the shell.
-- Confirm the application key has Actions API Access enabled.
-- Confirm credentials match the Datadog site configured in `vite.config.ts`.
+- For the default OAuth flow, rerun the command and complete the browser authorization prompt.
+- Confirm the Datadog site configured in `vite.config.ts` matches the site used for OAuth.
+- If the cached OAuth token is invalid or belongs to the wrong site, rerun the command and complete authorization again.
+- If secure token storage is unavailable, install the optional keyring package requested by the warning, such as `@napi-rs/keyring`, or expect to reauthorize more often.
+- For key-based auth, verify both `DD_API_KEY` and `DD_APP_KEY` are set. The application key needs Actions API Access for backend function execution and Apps for uploading.
 
-**`.env.local` not being picked up:** The scaffolded `vite.config.ts` reads credentials via `process.env`, which does not include `.env.local` values at config evaluation time. Fix by switching to Vite's `loadEnv`:
+**Optional key-based `.env.local` not being picked up:** The generated config should read local env files before deciding whether to use API/application keys. If an older app reads credentials via `process.env` at config evaluation time, switch to Vite's `loadEnv`:
 
 ```ts
 import { defineConfig, loadEnv } from 'vite';
@@ -30,20 +32,20 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-After updating `vite.config.ts`, restart the dev server — credentials will be read from `.env.local` without any shell exports.
+After updating `vite.config.ts`, restart the dev server. Credentials will be read from `.env.local` without shell exports, and OAuth remains the default when either key is absent.
 
 ## Upload Fails With 403 "you do not have access to this app"
 
 The build and source map upload succeed but asset upload to App Builder fails with `HTTP 403 Forbidden: you do not have access to this app`.
 
-This is an application key permissions issue. The app key needs **two** scopes enabled — not just one:
+For key-based auth, this is usually an application key permissions issue. The app key needs **two** scopes enabled:
 
 1. **Actions API Access** — required for backend function execution during local dev.
 2. **Apps** (or **App Builder**) — required for uploading and publishing app assets.
 
 Fix: go to `https://app.datadoghq.com/organization-settings/application-keys`, find your key, and confirm both scopes are enabled. If the Apps scope is missing, create a new key with both scopes.
 
-After updating the key, re-run `npm run upload`.
+After updating the key, re-run `npm run upload`. For OAuth, confirm the authorized user has access to upload the app.
 
 ## Build Succeeds But Nothing Uploads
 
@@ -55,7 +57,8 @@ After updating the key, re-run `npm run upload`.
 ## Build Fails With Missing Credentials
 
 - Current scaffold versions may make `npm run build` exercise Datadog upload behavior.
-- Ensure `DD_API_KEY` and `DD_APP_KEY` are exported before running build commands that touch Datadog.
+- Complete the OAuth browser flow before running build commands that touch Datadog.
+- If using key-based auth, ensure both `DD_API_KEY` and `DD_APP_KEY` are set.
 - For credential-free validation, prefer `npm run typecheck` when available.
 
 ## Lint Fails Before Checking Code
@@ -73,12 +76,14 @@ After updating the key, re-run `npm run upload`.
 ## Datadog Site Mismatch
 
 - Inspect `vite.config.ts` for the configured Datadog site.
+- If using OAuth, complete authorization against the same site.
 - Ensure CI uses the same site configuration as local development.
 
 ## Backend Function Issues
 
 - Confirm backend files match `*.backend.ts` or `*.backend.js`.
-- Confirm local development or upload commands have Actions API credentials (`DD_API_KEY`, `DD_APP_KEY` with Actions API Access).
+- For local development, run `npm run dev` and complete OAuth authorization when prompted.
+- If using key-based auth, confirm both `DD_API_KEY` and `DD_APP_KEY` are set and the application key has Actions API Access.
 - Prefer `@datadog/action-catalog` typed actions when available.
 - Check frontend imports reference the backend module path exactly.
 

--- a/dd-apps/datadog-app/references/upgrading.md
+++ b/dd-apps/datadog-app/references/upgrading.md
@@ -79,11 +79,11 @@ npm run lint
 npm run build
 ```
 
-For backend function or upload-related changes, also test with credentials:
+For backend function or upload-related changes, also test the OAuth-backed commands:
 
 ```bash
-export DD_API_KEY="<YOUR_API_KEY>"
-export DD_APP_KEY="<YOUR_APPLICATION_KEY>"
 npm run dev
 npm run upload
 ```
+
+To verify the optional key-based path, set both `DD_API_KEY` and `DD_APP_KEY` before running the same commands.

--- a/dd-apps/datadog-app/references/workflow-http-trigger.md
+++ b/dd-apps/datadog-app/references/workflow-http-trigger.md
@@ -13,7 +13,7 @@ Use this when a Datadog App backend function needs to trigger a Datadog Workflow
 
 ## Inspect The Workflow
 
-Before wiring an app to a workflow, inspect the workflow's published shape using curl with your Datadog API credentials:
+Before wiring an app to a workflow, inspect the workflow's published shape. Direct curl calls to the Datadog API use API/application keys even though normal scaffolded local app development uses OAuth by default:
 
 ```bash
 workflow_id="<WORKFLOW_ID>"
@@ -204,5 +204,5 @@ If a polling request fails, surface the error or response body to the caller. Do
 
 - `input parameter "<name>" not in workflow input schema`: update `meta.payload` keys to match `attributes.spec.inputSchema.parameters`.
 - `Expected trigger type TRIGGER_TYPE_API not found`: add and publish an API trigger on the workflow.
-- 401, 403, or missing authentication errors: confirm `DD_API_KEY` and `DD_APP_KEY` are exported, the app key has Actions API Access, and the app's Datadog site matches the API host and connection.
+- 401, 403, or missing authentication errors: for the direct curl inspection, confirm `DD_API_KEY` and `DD_APP_KEY` are exported, the app key has Actions API Access, and the app's Datadog site matches the API host and connection. For local app execution, rerun `npm run dev` and complete OAuth authorization.
 - Empty or missing outputs: inspect the full workflow instance response and the workflow's `outputSchema`.


### PR DESCRIPTION
## Motivation

Datadog Apps now support OAuth for local development and upload commands, so the public Datadog Apps skill should guide users toward the default OAuth-backed flow instead of requiring API/application keys up front.

## Changes

This updates the public Datadog Apps skill to describe `npm run dev` and `npm run upload` as OAuth-first. API/application keys are still documented as an optional key-based override for local dev/upload and remain the explicit path for CI/CD and direct Datadog API curl examples. Troubleshooting guidance now covers OAuth authorization, cached token/site mismatch, secure storage warnings, and the optional key-based path.

## QA Instructions

Review the Datadog Apps skill docs and confirm the getting started, upload, troubleshooting, upgrade, data-query, and workflow guidance consistently distinguish default OAuth behavior from optional API/application key usage.

## Blast Radius

Documentation-only skill update. This affects AI assistant guidance for developers building Datadog Apps; it does not change app runtime behavior.

## Documentation

- Datadog Apps OAuth support is reflected in the skill guidance.