### PR TITLE
Add Browser SDK upgrade skills for v4→v5 and v5→v6

### DIFF
--- a/dd-browser-sdk/SKILL.md
+++ b/dd-browser-sdk/SKILL.md
@@ -20,9 +20,19 @@ RUM, Logs, and Session Replay instrumentation for browser applications.
 
 | Task | Skill |
 |------|-------|
+| Upgrade from v4 to v5 | `dd-browser-sdk/upgrade-v5` |
+| Upgrade from v5 to v6 | `dd-browser-sdk/upgrade-v6` |
 | Upgrade from v6 to v7 | `dd-browser-sdk/upgrade-v7` |
 
 ## Routing
+
+**Upgrading from v4 to v5** (removed options like `proxyUrl`, `sampleRate`, `replaySampleRate`, `premiumSampleRate`, `allowedTracingOrigins`, deprecated APIs like `addRumGlobalContext`, `removeUser`, or `/v4/` CDN paths):
+
+**Immediately read** `.claude/skills/dd-browser-sdk/upgrade-v5/SKILL.md` — do not proceed from memory.
+
+**Upgrading from v5 to v6** (removed options like `useCrossSiteSessionCookie`, `sendLogsAfterSessionExpiration`, dropping IE11 support, or `/v5/` CDN paths):
+
+**Immediately read** `.claude/skills/dd-browser-sdk/upgrade-v6/SKILL.md` — do not proceed from memory.
 
 **Upgrading from v6 to v7** (removed options like `betaEncodeCookieOptions`, `allowFallbackToLocalStorage`, `trackBfcacheViews`, `usePciIntake`, or `/v6/` CDN paths):
 

--- a/dd-browser-sdk/upgrade-v5/SKILL.md
+++ b/dd-browser-sdk/upgrade-v5/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: upgrade-browser-sdk-v5
+description: >
+  Upgrade Datadog Browser SDK from v4 to v5. Use when encountering removed options like
+  proxyUrl, sampleRate, replaySampleRate, premiumSampleRate, allowedTracingOrigins, or
+  deprecated APIs like addRumGlobalContext, removeUser, or when a project references
+  datadoghq-browser-agent.com CDN with /v4/ paths.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,browser-sdk,rum,logs,migration,v5,upgrade
+---
+
+# Upgrade Datadog Browser SDK to v5
+
+Systematic migration guide from v4 to v5. Follow steps 1-7 in order. Each step includes a search pattern to find affected code.
+
+## Step 1: Update SDK version
+
+**CDN setup** — update script `src` URLs:
+
+| v4 pattern                                               | v5 replacement                                           |
+| -------------------------------------------------------- | -------------------------------------------------------- |
+| `datadoghq-browser-agent.com/us1/v4/datadog-rum.js`      | `datadoghq-browser-agent.com/us1/v5/datadog-rum.js`      |
+| `datadoghq-browser-agent.com/us1/v4/datadog-logs.js`     | `datadoghq-browser-agent.com/us1/v5/datadog-logs.js`     |
+| `datadoghq-browser-agent.com/us1/v4/datadog-rum-slim.js` | `datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js` |
+
+Replace `us1` with your site: `eu1`, `us3`, `us5`, `ap1`. For US1-FED, the pattern is flat with no site prefix: `datadog-rum-v5.js`, `datadog-logs-v5.js`, `datadog-rum-slim-v5.js`. Note: AP2 is not available for v5 — upgrade to v6 first if you need AP2.
+
+Search: `grep -r "datadoghq-browser-agent.com.*v4" --include="*.html" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx"`
+
+**npm setup** — update `package.json` dependencies:
+
+```
+"@datadog/browser-rum": "^5.0.0"
+"@datadog/browser-logs": "^5.0.0"
+"@datadog/browser-rum-slim": "^5.0.0"
+```
+
+Then run your package manager (`npm install`, `yarn install`, etc.) and rebuild.
+
+Also upgrade framework integrations to v5 if used: `@datadog/browser-rum-react`.
+
+Search: `grep -r "@datadog/browser-" --include="package.json" .`
+
+## Step 2: Replace deprecated init parameters
+
+These v4 parameter names no longer exist in v5. Replace them:
+
+| Deprecated parameter (v4) | Replacement (v5)          |
+| ------------------------- | ------------------------- |
+| `proxyUrl`                | `proxy`                   |
+| `sampleRate`              | `sessionSampleRate`       |
+| `allowedTracingOrigins`   | `allowedTracingUrls`      |
+| `tracingSampleRate`       | `traceSampleRate`         |
+| `trackInteractions`       | `trackUserInteractions`   |
+| `premiumSampleRate`       | `sessionReplaySampleRate` |
+| `replaySampleRate`        | `sessionReplaySampleRate` |
+
+Search: `grep -rn 'proxyUrl\|sampleRate\|allowedTracingOrigins\|tracingSampleRate\|trackInteractions\|premiumSampleRate\|replaySampleRate' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+**Note**: `sampleRate` matches broadly. Look specifically for init config objects — `sessionSampleRate` is the v5 name for the session sampling rate.
+
+## Step 3: Replace deprecated public APIs
+
+These v4 API method names no longer exist in v5:
+
+### RUM APIs
+
+| Deprecated API (v4)             | Replacement (v5)                     |
+| ------------------------------- | ------------------------------------ |
+| `DD_RUM.removeUser`             | `DD_RUM.clearUser`                   |
+| `DD_RUM.addRumGlobalContext`    | `DD_RUM.setGlobalContextProperty`    |
+| `DD_RUM.removeRumGlobalContext` | `DD_RUM.removeGlobalContextProperty` |
+| `DD_RUM.getRumGlobalContext`    | `DD_RUM.getGlobalContext`            |
+| `DD_RUM.setRumGlobalContext`    | `DD_RUM.setGlobalContext`            |
+
+### Logs APIs
+
+| Deprecated API (v4)                 | Replacement (v5)                      |
+| ----------------------------------- | ------------------------------------- |
+| `DD_LOGS.addLoggerGlobalContext`    | `DD_LOGS.setGlobalContextProperty`    |
+| `DD_LOGS.removeLoggerGlobalContext` | `DD_LOGS.removeGlobalContextProperty` |
+| `DD_LOGS.getLoggerGlobalContext`    | `DD_LOGS.getGlobalContext`            |
+| `DD_LOGS.setLoggerGlobalContext`    | `DD_LOGS.setGlobalContext`            |
+| `logger.addContext`                 | `logger.setContextProperty`           |
+| `logger.removeContext`              | `logger.removeContextProperty`        |
+
+Search: `grep -rn 'removeUser\|addRumGlobalContext\|removeRumGlobalContext\|getRumGlobalContext\|setRumGlobalContext\|addLoggerGlobalContext\|removeLoggerGlobalContext\|getLoggerGlobalContext\|setLoggerGlobalContext\|\.addContext\|\.removeContext' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+## Step 4: Update Session Replay configuration
+
+v5 changes several Session Replay defaults and behaviors:
+
+### 4a. `defaultPrivacyLevel` changed to `"mask"`
+
+In v4, the default was `mask-user-input`. In v5, **all content is masked by default**.
+
+To preserve v4 behavior (only mask user input):
+
+```js
+DD_RUM.init({
+  defaultPrivacyLevel: 'mask-user-input',
+})
+```
+
+### 4b. Recording starts automatically
+
+Sessions sampled for Session Replay are now automatically recorded. You no longer need to call `startSessionReplayRecording()`.
+
+To preserve v4 behavior (manual recording start):
+
+```js
+DD_RUM.init({
+  startSessionReplayRecordingManually: true,
+})
+```
+
+### 4c. Default `sessionReplaySampleRate` is now `0`
+
+In v4, the default replay sample rate was 100. In v5, it's `0` — no replays unless you set it explicitly.
+
+**Action**: Ensure `sessionReplaySampleRate` is explicitly set in your init config:
+
+```js
+DD_RUM.init({
+  sessionReplaySampleRate: 100, // or your desired rate
+})
+```
+
+### 4d. `trackResources` and `trackLongTasks` must be explicit
+
+When using `sessionReplaySampleRate` (instead of the removed `replaySampleRate` or `premiumSampleRate`), resources and long tasks are no longer collected by default. Enable them explicitly — **unless** the v4 config already set them to `false` intentionally:
+
+```js
+DD_RUM.init({
+  sessionReplaySampleRate: 100,
+  trackResources: true, // omit if v4 explicitly had trackResources: false
+  trackLongTasks: true, // omit if v4 explicitly had trackLongTasks: false
+})
+```
+
+Search: `grep -rn 'sessionReplaySampleRate\|startSessionReplayRecording\|defaultPrivacyLevel\|trackResources\|trackLongTasks' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+Also search for all RUM init calls to catch projects that omit these options and rely on v4 defaults: `grep -rn 'DD_RUM\.init\|datadogRum\.init' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`. For each init call, verify that `sessionReplaySampleRate`, `defaultPrivacyLevel`, and `trackResources`/`trackLongTasks` are explicitly set.
+
+## Step 5: Update changed APIs and behaviors
+
+### 5a. `beforeSend` must return a boolean
+
+`beforeSend` callback functions should return `true` to keep the event or `false` to discard it. If no value is returned, the event is kept. This resolves TypeScript compilation errors.
+
+```js
+beforeSend: (event, context) => {
+  // return true to keep, false to discard
+  return true
+}
+```
+
+### 5b. `beforeSend` action context: `context.event` → `context.events`
+
+With frustration signals, an action event can be associated with multiple DOM events. `context.event` is replaced by `context.events` (array).
+
+```js
+// v4
+beforeSend: (event, context) => {
+  if (event.type === 'action') {
+    const domEvent = context.event
+  }
+}
+
+// v5
+beforeSend: (event, context) => {
+  if (event.type === 'action') {
+    const domEvents = context.events // array
+  }
+}
+```
+
+### 5c. `beforeSend` performance entry is now a `PerformanceEntry` object
+
+The `performanceEntry` in `beforeSend` context is now the raw `PerformanceEntry` object, not a JSON representation. The `PerformanceEntryRepresentation` type has been removed.
+
+### 5d. `startTime` removed from XHR `beforeSend` context
+
+The `context.startTime` property has been removed from XHR resource `beforeSend` context. Use the `performanceEntry` instead.
+
+### 5e. `view.in_foreground_periods` removed from `beforeSend`
+
+This attribute is now computed by the backend. Remove any `beforeSend` code that accesses `view.in_foreground_periods`.
+
+### 5f. Frustration signals collected automatically
+
+Set `trackUserInteractions: true` to collect all user interactions, including frustration signals. The `trackFrustrations` parameter is no longer needed.
+
+### 5g. Resource method names are uppercase
+
+Resource `method` field is now always uppercase (e.g., `GET`, `POST`). Update any dashboards or monitors filtering on `resource.method`.
+
+### 5h. `session.plan` field removed
+
+The `session.plan` field (`lite`/`premium`) is removed in v5 and not emitted on any event type. Replace any dashboard or monitor filter on `session.plan` with the new replay fields:
+
+- `@session.sampled_for_replay:true` — session was sampled for Session Replay
+- `@session.has_replay:true` — session has an actual replay recording
+
+Search: `grep -rn 'beforeSend\|trackFrustrations\|PerformanceEntryRepresentation\|in_foreground_periods\|context\.event\b\|startTime' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+## Step 6: Handle trusted events
+
+v5 only listens to user-generated (trusted) events. Script-generated events are ignored by default.
+
+If you rely on programmatic events (e.g., `dispatchEvent`), add the `__ddIsTrusted` attribute:
+
+```js
+// JavaScript
+const click = new Event('click')
+click.__ddIsTrusted = true
+document.dispatchEvent(click)
+```
+
+```ts
+// TypeScript
+const click = new Event('click') as Event & { __ddIsTrusted?: boolean }
+click.__ddIsTrusted = true
+document.dispatchEvent(click)
+```
+
+Or allow all untrusted events globally:
+
+```js
+DD_RUM.init({
+  allowUntrustedEvents: true,
+})
+```
+
+Search: `grep -rn 'dispatchEvent\|new Event\|new MouseEvent\|new KeyboardEvent\|\.click()' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+## Step 7: Update infrastructure
+
+### CSP `connect-src` domains changed
+
+v5 sends data to new intake domains. Update your Content Security Policy:
+
+| Datadog site | New `connect-src` domain                   |
+| ------------ | ------------------------------------------ |
+| US1          | `https://browser-intake-datadoghq.com`     |
+| US3          | `https://browser-intake-us3-datadoghq.com` |
+| US5          | `https://browser-intake-us5-datadoghq.com` |
+| EU1          | `https://browser-intake-datadoghq.eu`      |
+| US1-FED      | `https://browser-intake-ddog-gov.com`      |
+| US2-FED      | `https://browser-intake-us2-ddog-gov.com`  |
+| AP1          | `https://browser-intake-ap1-datadoghq.com` |
+
+### CORS headers for distributed tracing
+
+v5 adds `tracecontext` as a default propagator. If you use `allowedTracingUrls`, your server must accept the `traceparent` header. Add it to your existing `Access-Control-Allow-Headers` — do not replace the full list:
+
+```
+# Add traceparent alongside your existing headers
+Access-Control-Allow-Headers: <existing-headers>, traceparent
+```
+
+### Logs: `error.origin` removed
+
+Update dashboards/monitors using `error.origin` to use `origin` instead.
+
+### Logs: console error prefix removed
+
+The `"console error:"` prefix is removed from log messages. Update queries using this prefix to use `@origin:console` instead.
+
+### Logs: main logger decoupled
+
+Runtime errors, network logs, report logs, and console logs no longer inherit the main logger's context, level, or handler. Use global context and dedicated init parameters instead.
+
+Search for main logger configuration that may have been relying on this inheritance: `grep -rn 'DD_LOGS\.logger\.setLevel\|DD_LOGS\.logger\.setHandler\|DD_LOGS\.logger\.setContext\|DD_LOGS\.logger\.setContextProperty' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`. For each match, verify the setting is intentional for the main logger only — it will no longer affect runtime errors, network logs, or console logs.
+
+## Common Mistakes
+
+| Mistake                                                                                      | What goes wrong                                                                                                             | Fix                                                                                                      |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Setting `sessionReplaySampleRate > 0` without enabling `trackResources` and `trackLongTasks` | Resources and long tasks are silently not collected — they no longer default to `true` when using `sessionReplaySampleRate` | Always add `trackResources: true, trackLongTasks: true` alongside any non-zero `sessionReplaySampleRate` |
+| Using `context.event` instead of `context.events` in `beforeSend` for action events          | Action context property renamed — `context.event` is `undefined`, DOM event details are lost                                | Update to `context.events` (array); iterate if you need all associated DOM events                        |
+| Not updating CSP `connect-src` to the new v5 intake domains                                  | SDK silently fails to send data — old intake domains are no longer valid                                                    | Update `connect-src` to the v5 intake domain for your site (see Step 7)                                  |
+
+## Verification checklist
+
+After upgrading, confirm:
+
+- [ ] SDK loads without console errors
+- [ ] No references to removed init parameters (`proxyUrl`, `sampleRate`, `replaySampleRate`, etc.)
+- [ ] No references to removed APIs (`addRumGlobalContext`, `removeUser`, etc.)
+- [ ] `beforeSend` callbacks return boolean values
+- [ ] `beforeSend` action handlers use `context.events` (not `context.event`)
+- [ ] `trackResources` and `trackLongTasks` explicitly set if using `sessionReplaySampleRate`
+- [ ] Session Replay recording works (if `sessionReplaySampleRate` > 0)
+- [ ] Distributed tracing working (no CORS errors from `traceparent` header)
+- [ ] CSP `connect-src` updated to new intake domains
+- [ ] Dashboards/monitors updated for uppercase `resource.method`
+- [ ] No queries using `error.origin` (use `origin` instead)

--- a/dd-browser-sdk/upgrade-v6/SKILL.md
+++ b/dd-browser-sdk/upgrade-v6/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: upgrade-browser-sdk-v6
+description: >
+  Upgrade Datadog Browser SDK from v5 to v6. Use when encountering removed options like
+  useCrossSiteSessionCookie, sendLogsAfterSessionExpiration, or when dropping IE11 support,
+  or when a project references datadoghq-browser-agent.com CDN with /v5/ paths.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,browser-sdk,rum,logs,migration,v6,upgrade
+---
+
+# Upgrade Datadog Browser SDK to v6
+
+Systematic migration guide from v5 to v6. Follow steps 1-6 in order. Each step includes a search pattern to find affected code.
+
+## Step 1: Update SDK version
+
+**CDN setup** — update script `src` URLs:
+
+| v5 pattern                                               | v6 replacement                                           |
+| -------------------------------------------------------- | -------------------------------------------------------- |
+| `datadoghq-browser-agent.com/us1/v5/datadog-rum.js`      | `datadoghq-browser-agent.com/us1/v6/datadog-rum.js`      |
+| `datadoghq-browser-agent.com/us1/v5/datadog-logs.js`     | `datadoghq-browser-agent.com/us1/v6/datadog-logs.js`     |
+| `datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js` | `datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js` |
+
+Replace `us1` with your site: `eu1`, `us3`, `us5`, `ap1`, `ap2`. For US1-FED, the pattern is flat with no site prefix: `datadog-rum-v6.js`, `datadog-logs-v6.js`, `datadog-rum-slim-v6.js`.
+
+Search: `grep -r "datadoghq-browser-agent.com.*v5" --include="*.html" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx"`
+
+**npm setup** — update `package.json` dependencies:
+
+```
+"@datadog/browser-rum": "^6.0.0"
+"@datadog/browser-logs": "^6.0.0"
+"@datadog/browser-rum-slim": "^6.0.0"
+```
+
+Then run your package manager (`npm install`, `yarn install`, etc.) and rebuild.
+
+Also upgrade framework integrations to v6 if used: `@datadog/browser-rum-react`.
+
+Search: `grep -r "@datadog/browser-" --include="package.json" .`
+
+## Step 2: Remove deprecated options
+
+### Removed from Core (affects both RUM and Logs)
+
+| Option                      | Action                                               |
+| --------------------------- | ---------------------------------------------------- |
+| `useCrossSiteSessionCookie` | Replace with `usePartitionedCrossSiteSessionCookie`. |
+
+### Removed from Logs
+
+| Option                           | Action                                                                                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `sendLogsAfterSessionExpiration` | Delete. In v6, logs are always sent after session expiration (without a session ID). The option is no longer needed. |
+
+Search: `grep -rn 'useCrossSiteSessionCookie\|sendLogsAfterSessionExpiration' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+## Step 3: Update changed defaults
+
+v6 changes several default behaviors. Review each and adjust if needed:
+
+### 3a. `trackUserInteractions`, `trackResources`, and `trackLongTasks` default to `true`
+
+In v5, these were `false` by default. In v6, they are enabled out of the box. This does not impact billing.
+
+To preserve v5 behavior, explicitly disable **only the options that were not already enabled in v5**. If an option was already `true` in v5, leave it unchanged:
+
+```js
+DD_RUM.init({
+  trackUserInteractions: false, // only if not already true in v5
+  trackResources: false, // only if not already true in v5
+  trackLongTasks: false, // only if not already true in v5
+})
+```
+
+### 3b. `traceContextInjection` defaults to `"sampled"`
+
+In v5, trace context was injected for all requests. In v6, it's only injected for sampled traces. If your `traceSampleRate` is 100% (the default), this has no impact.
+
+To preserve v5 behavior:
+
+```js
+DD_RUM.init({
+  traceContextInjection: 'all',
+})
+```
+
+### 3c. `tracestate` header added with `tracecontext` propagator
+
+The `tracecontext` propagator now sends an additional `tracestate` header. Your server must accept it. Add it to your existing `Access-Control-Allow-Headers` — do not replace the full list:
+
+```
+# Add tracestate alongside your existing headers
+Access-Control-Allow-Headers: <existing-headers>, traceparent, tracestate
+```
+
+### 3d. `site` parameter is strongly typed
+
+The `site` option has a stricter TypeScript type. If you pass a non-standard value, you get a type error. Use `proxy` for non-standard intake URLs instead.
+
+Search: `grep -rn 'trackUserInteractions\|trackResources\|trackLongTasks\|traceContextInjection\|tracestate\|allowedTracingUrls\|propagatorTypes' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+Also search for all RUM init calls to catch projects that omit these options and relied on the v5 `false` defaults: `grep -rn 'DD_RUM\.init\|datadogRum\.init' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`. For each init call, check whether `trackUserInteractions`, `trackResources`, and `trackLongTasks` are explicitly set — if omitted, they now default to `true` in v6.
+
+## Step 4: Handle Session Replay lazy loading
+
+Session Replay is now lazy-loaded using dynamic imports. The module loads only for sessions sampled for replay, reducing bundle size for others.
+
+### npm setup
+
+Ensure your bundler supports dynamic imports (code splitting). Most modern bundlers do:
+
+- **Webpack**: [Code splitting docs](https://webpack.js.org/guides/code-splitting/#dynamic-imports)
+- **Esbuild**: [Splitting option](https://esbuild.github.io/api/#splitting)
+- **Rollup**: [Code splitting docs](https://rollupjs.org/tutorial/#code-splitting)
+- **Parcel**: [Code splitting docs](https://parceljs.org/features/code-splitting)
+
+### CDN setup
+
+No code changes needed. The SDK dynamically loads an additional chunk when recording (e.g., `datadogRecorder-<hash>-datadog-rum.js`). Update CSP `script-src` rules if needed to allow the chunk.
+
+## Step 5: Review behavioral changes (no code required, but may need attention)
+
+| Change                                       | Impact                                                                                                             | Action if needed                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| IE11 support dropped                         | SDK built with ES2018 target. Polyfills removed.                                                                   | Keep using v5 if IE11 support is required.                              |
+| Long Animation Frames replace Long Tasks     | On supported browsers, Long Animation Frames are collected instead of Long Tasks. Event type is still `long_task`. | Review if you inspect long task event details.                          |
+| Session cookie expiration extended to 1 year | Supports anonymous user tracking.                                                                                  | Set `trackAnonymousUser: false` to opt out.                             |
+| `RegExp` and `Event` objects sanitized       | These are no longer serialized as-is in context/attributes.                                                        | Use string representations if you were passing RegExp or Event objects. |
+| Webpack `ChunkLoadError` no longer collected | Reduces noise from SDK chunk loading failures.                                                                     | No action needed.                                                       |
+
+## Step 6: Update infrastructure
+
+- **Browser support**: ES2018 baseline. IE11 is no longer supported.
+- **CORS**: Add `tracestate` to your existing `Access-Control-Allow-Headers` if using the `tracecontext` propagator (do not replace the full list): `Access-Control-Allow-Headers: <existing-headers>, traceparent, tracestate`
+- **CSP**: Allow the dynamically loaded Session Replay chunk (e.g., `datadogRecorder-*-datadog-rum.js`) in `script-src` rules.
+- **Bundler config**: Ensure your bundler supports dynamic imports for Session Replay lazy loading.
+
+## Common Mistakes
+
+| Mistake                                                                           | What goes wrong                                                                                           | Fix                                                                                                                |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Defensively disabling `trackUserInteractions`, `trackResources`, `trackLongTasks` | Disables features the project needs — these now default to `true`, which is usually the desired behavior  | Only set these to `false` if the project explicitly did not want them; leave them unset to accept the new defaults |
+| Missing `tracestate` in `Access-Control-Allow-Headers`                            | The `tracecontext` propagator now sends a `tracestate` header — cross-origin requests are blocked by CORS | Add `tracestate` alongside `traceparent` in your server's `Access-Control-Allow-Headers`                           |
+| Not updating CSP `script-src` for the lazy-loaded Session Replay chunk            | Recording silently fails on CSP-restricted pages — the dynamic chunk is blocked                           | Allow `datadogRecorder-*-datadog-rum.js` in `script-src`                                                           |
+
+## Verification checklist
+
+After upgrading, confirm:
+
+- [ ] SDK loads without console errors
+- [ ] No references to removed options (`useCrossSiteSessionCookie`, `sendLogsAfterSessionExpiration`)
+- [ ] Session Replay recordings working (if used)
+- [ ] Distributed tracing working (no CORS errors from `tracestate` header)
+- [ ] Bundle size decreased (IE11 polyfills removed)
+- [ ] Long tasks still collected (now as Long Animation Frames on supported browsers)
+- [ ] No TypeScript errors from `site` parameter typing

--- a/dd-browser-sdk/upgrade-v7/SKILL.md
+++ b/dd-browser-sdk/upgrade-v7/SKILL.md
@@ -3,6 +3,7 @@ name: upgrade-browser-sdk-v7
 description: >
   Upgrade Datadog Browser SDK from v6 to v7. Use when encountering removed options like
   betaEncodeCookieOptions, allowFallbackToLocalStorage, trackBfcacheViews, usePciIntake,
+  changed APIs like forwardErrorsToLogs, startDurationVital, stopDurationVital,
   or when a project references datadoghq-browser-agent.com CDN with /v6/ paths.
 metadata:
   version: "1.0.0"
@@ -25,9 +26,9 @@ Systematic migration guide from v6 to v7. Follow steps 1-6 in order. Each step i
 | `datadoghq-browser-agent.com/us1/v6/datadog-logs.js`     | `datadoghq-browser-agent.com/us1/v7/datadog-logs.js`     |
 | `datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js` | `datadoghq-browser-agent.com/us1/v7/datadog-rum-slim.js` |
 
-Replace `us1` with your site: `eu1`, `us3`, `us5`, `ap1`, `ap2`. For US1-FED, the pattern is flat: `datadog-rum-v7.js` (no site prefix).
+Replace `us1` with your site: `eu1`, `us3`, `us5`, `ap1`, `ap2`. For US1-FED, the pattern is flat with no site prefix: `datadog-rum-v7.js`, `datadog-logs-v7.js`, `datadog-rum-slim-v7.js`.
 
-Search: `grep -r "datadoghq-browser-agent.com.*v6" --include="*.html" --include="*.js" --include="*.ts" --include="*.tsx"`
+Search: `grep -r "datadoghq-browser-agent.com.*v6" --include="*.html" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx"`
 
 **npm setup** — update `package.json` dependencies:
 
@@ -41,7 +42,7 @@ Then run your package manager (`npm install`, `yarn install`, etc.) and rebuild.
 
 Also upgrade framework integrations to v7: `@datadog/browser-rum-react`, `@datadog/browser-rum-angular`, `@datadog/browser-rum-vue`, `@datadog/browser-rum-nextjs`.
 
-Search: `grep -r "@datadog/browser-" package.json`
+Search: `grep -r "@datadog/browser-" --include="package.json" .`
 
 ## Step 2: Add `crossorigin="anonymous"` (CDN only)
 
@@ -59,7 +60,7 @@ script.crossOrigin = 'anonymous' // Must set BEFORE setting src
 script.src = 'https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js'
 ```
 
-Search: `grep -rn "datadoghq-browser-agent" --include="*.html" --include="*.js" --include="*.ts"`
+Search: `grep -rn "datadoghq-browser-agent" --include="*.html" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx"`
 
 Check every match for the `crossorigin` attribute (HTML) or `.crossOrigin` property (JS).
 
@@ -88,65 +89,128 @@ Search init calls for these options and apply replacements:
 | -------------- | ----------------------------------------------------------------------------------------------------- |
 | `usePciIntake` | Delete. Standard intake is now PCI compliant. Update CSP if you had PCI-specific domains allowlisted. |
 
-Search: `grep -rn 'betaEncodeCookieOptions|allowFallbackToLocalStorage|trackBfcacheViews|trackEarlyRequests|betaTrackActionsInShadowDom|usePciIntake' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.html"`
+Search: `grep -rn 'betaEncodeCookieOptions\|allowFallbackToLocalStorage\|trackBfcacheViews\|trackEarlyRequests\|betaTrackActionsInShadowDom\|usePciIntake' --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
 
 ## Step 4: Update changed APIs
 
 ### 4a. `forwardErrorsToLogs` + `forwardConsoleLogs` (Logs)
 
-These are now **independent**. In v6, `forwardErrorsToLogs: true` silently forwarded `console.error()`. In v7, it only controls unhandled errors.
+These are now **independent**. In v6, `forwardErrorsToLogs: true` had a side effect: it also forwarded `console.error()` calls to Logs. In v7, that side effect is removed.
 
-**If you use `forwardErrorsToLogs: true`**, add `"error"` to your `forwardConsoleLogs` array to preserve v6 behavior:
+- `forwardErrorsToLogs` — controls forwarding of **unhandled errors** (uncaught exceptions, unhandled rejections) and **network errors** to Logs. **Keep this unchanged.**
+- `forwardConsoleLogs` — controls forwarding of **`console.error()` calls** to Logs. Add `'error'` here to restore the v6 side effect.
+
+**Only add `forwardConsoleLogs: ['error']` when `forwardErrorsToLogs` is `true` or omitted** — in v6 the side effect only applied when the option was enabled (explicitly or via the default). If `forwardErrorsToLogs: false`, there was no side effect to restore; leave it unchanged.
 
 ```js
+// v6 — forwardErrorsToLogs: true (explicit or omitted, which defaults to true)
 DD_LOGS.init({
   forwardErrorsToLogs: true,
-  forwardConsoleLogs: ['error', 'warn'], // add 'error' explicitly
+  forwardConsoleLogs: ['warn'], // example: existing levels
+})
+
+// v7 — add 'error' to restore the side effect; preserve any existing levels
+DD_LOGS.init({
+  forwardErrorsToLogs: true, // unchanged
+  forwardConsoleLogs: ['warn', 'error'], // add 'error'
+})
+
+// v6 — forwardErrorsToLogs: false → no side effect existed; nothing to add
+DD_LOGS.init({
+  forwardErrorsToLogs: false, // leave unchanged, do NOT add forwardConsoleLogs: ['error']
 })
 ```
 
-Search: `grep -rn "forwardErrorsToLogs" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.html"`
+Do **not** replace `forwardErrorsToLogs` with `forwardConsoleLogs` — they control different things.
+
+Search for explicit config: `grep -rn "forwardErrorsToLogs" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+Also search for Logs init calls that may be relying on the default (`forwardErrorsToLogs` defaults to `true` in v6, so omitting it still had the side effect): `grep -rn "DD_LOGS\.init\|datadogLogs\.init" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`
+
+For any Logs init call where `forwardErrorsToLogs` is `true` or omitted, and `forwardConsoleLogs` does not already include `'error'` or `'all'`, add `'error'` to preserve v6 behavior.
 
 ### 4b. `startDurationVital` / `stopDurationVital` (RUM)
 
-The `DurationVitalReference` object is replaced by a `vitalKey` string:
+The `DurationVitalReference` object is replaced by a `vitalKey` string. **`startDurationVital` now returns `void`** — the v7 API is fire-and-forget; the vital name string is all you need.
 
 ```js
-// v6
-const ref = DD_RUM.startDurationVital('checkout')
+// v5/v6 — ref-based (CDN: DD_RUM, npm: datadogRum)
+var ref = DD_RUM.startDurationVital('checkout_flow')
+// ... async work ...
 DD_RUM.stopDurationVital(ref)
 
 // v7
-DD_RUM.startDurationVital('checkout', { vitalKey: 'checkout-key' })
-DD_RUM.stopDurationVital('checkout', { vitalKey: 'checkout-key' })
+DD_RUM.startDurationVital('checkout_flow', { vitalKey: 'checkout_flow' })
+DD_RUM.stopDurationVital('checkout_flow', { vitalKey: 'checkout_flow' })
 ```
 
-Search: `grep -rn 'startDurationVital|stopDurationVital|DurationVitalReference' --include="*.js" --include="*.ts" --include="*.tsx"`
+**This silently breaks in CDN/plain JS projects.** TypeScript catches it with a type error; plain JS does not. `ref` becomes `undefined` and `stopDurationVital(undefined)` is a no-op — the vital starts but never stops, so the event is never emitted.
+
+**Step 1 — find all `startDurationVital`/`stopDurationVital` usages** (both CDN and npm patterns, all file types):
+
+```
+grep -rn 'startDurationVital\|stopDurationVital\|DurationVitalReference' \
+  --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" \
+  --include="*.html" --include="*.svelte" --include="*.vue"
+```
+
+**Step 2 — find every variable that captures the return value** (this is the failure point):
+
+```
+grep -rEn '(var|const|let)\s+\w+\s*=\s*.+startDurationVital|[\w.]+\s*=\s*(window\.)?DD_RUM\.startDurationVital|[\w.]+\s*=\s*datadogRum\.startDurationVital' \
+  --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" \
+  --include="*.svelte" --include="*.vue"
+```
+
+For every match: remove the variable assignment and update all uses of that variable in the corresponding `stopDurationVital` call to pass the vital name string directly.
+
+**Step 3 — if the SDK is wrapped in a utility** (e.g. `startTiming` / `stopTiming`):
+
+1. Update the wrapper — pass `vitalKey` to `startDurationVital`, return nothing.
+2. Find callers that capture the wrapper return value:
+
+```
+grep -rEn '(var|const|let)\s+\w+\s*=\s*.+[Ss]tart[Tt]iming|(var|const|let)\s+\w+\s*=\s*.+[Ss]tart.+[Vv]ital' \
+  --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" \
+  --include="*.html" --include="*.svelte" --include="*.vue"
+```
+
+3. Remove the capture and update the stop call to pass the vital name string directly:
+
+```js
+// Caller — before
+var ref = startTiming('checkout_flow')
+stopTiming(ref) // undefined in v7 → vital never stops
+
+// Caller — after
+startTiming('checkout_flow')
+stopTiming('checkout_flow')
+```
 
 ### 4c. Plugin API: `strategy` removed (RUM)
 
 The `strategy` field has been removed from the plugin API. If you use `@datadog/browser-rum-react` or other plugin integrations, upgrade them to v7.
 
-Search: `grep -rn "strategy" --include="*.js" --include="*.ts" --include="*.tsx"` (look for plugin definitions)
+Search: `grep -rn "strategy" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx"` (look for plugin definitions)
 
 ## Step 5: Review behavioral changes (no code required, but may need attention)
 
 These are **default changes** — no code breaks, but behavior differs from v6:
 
-| Change                                                               | Impact                                                                                     | Action if needed                                                                                                     |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `defaultPrivacyLevel` defaults to `"mask-user-input"` (was `"mask"`) | Less restrictive masking out of the box. Only user input is masked.                        | Set `defaultPrivacyLevel: "mask"` to preserve full masking.                                                          |
-| `enablePrivacyForActionName` defaults to `true`                      | Click action names follow privacy level. May be masked.                                    | Use the [Datadog build plugin](https://github.com/DataDog/build-plugins) or set `enablePrivacyForActionName: false`. |
-| `propagateTraceBaggage` defaults to `true`                           | CORS: cross-origin APIs must allow `baggage` header.                                       | Add `"baggage"` to `Access-Control-Allow-Headers`, or set `propagateTraceBaggage: false`.                            |
-| Deterministic sampling                                               | Sampling computed from session ID + rate, not stored. Consistent across pages.             | Review if you use different sample rates on different pages.                                                         |
-| FID removed                                                          | First Input Delay no longer collected.                                                     | Use INP (Interaction to Next Paint) instead.                                                                         |
-| `session_renewal` view loading type                                  | Session-renewed views have `@view.loading_type:session_renewal` instead of `route_change`. | Update dashboards/monitors filtering on `@view.loading_type`.                                                        |
-| Document resource `initiatorType` changed                            | `"initial_document"` becomes `"navigation"`. Duration may differ slightly.                 | Update any code inspecting document resource `performanceEntry`.                                                     |
-| Action names may change                                              | Tree walker strategy always used (including Shadow DOM).                                   | Review if you have monitors based on specific action names.                                                          |
-| Cancelled request errors removed (Logs)                              | Aborted fetch/XHR no longer generate network error logs.                                   | No action needed — reduces noise.                                                                                    |
-| Logs always requires session storage                                 | Without cookies or localStorage, Logs SDK won't start.                                     | Use `sessionPersistence: 'memory'` for worker environments.                                                          |
-| Session Replay: Change Records                                       | New serialization format. More accurate, less bandwidth.                                   | Update if you depend on raw segment format.                                                                          |
-| Async chunk names prefixed with `datadog`                            | e.g., `datadogRecorder-<hash>-datadog-rum.js`, `datadogProfiler-<hash>-datadog-rum.js`.    | Update CSP `script-src` rules or caching configs (allow `datadog*-datadog-rum.js`).                                  |
+| Change                                                               | Impact                                                                                                                                                                                                                                                                                                                                                                                    | Action if needed                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultPrivacyLevel` defaults to `"mask-user-input"` (was `"mask"`) | Less restrictive masking out of the box. Only user input is masked.                                                                                                                                                                                                                                                                                                                       | Set `defaultPrivacyLevel: "mask"` to preserve full masking.                                                                                                                                                                                        |
+| `enablePrivacyForActionName` defaults to `true`                      | Action names are derived from `textContent` (not `innerText`) — CSS `text-transform` is no longer applied. A button with `style="text-transform: capitalize"` and raw text `"audio"` yields `"Audio"` in v6 but `"audio"` in v7. Names may also be masked based on privacy level. **Note:** setting this to `false` does not restore CSS-aware extraction — v7 always uses `textContent`. | Add `data-dd-action-name` attributes to elements whose display names relied on CSS transforms, or update monitors to match raw text values. Use the [Datadog build plugin](https://github.com/DataDog/build-plugins) for annotation-based control. |
+| `propagateTraceBaggage` defaults to `true`                           | CORS: cross-origin APIs must allow `baggage` header.                                                                                                                                                                                                                                                                                                                                      | Add `"baggage"` to `Access-Control-Allow-Headers`, or set `propagateTraceBaggage: false`.                                                                                                                                                          |
+| Deterministic sampling                                               | Sampling computed from session ID + rate, not stored. Consistent across pages.                                                                                                                                                                                                                                                                                                            | Review if you use different sample rates on different pages.                                                                                                                                                                                       |
+| FID removed                                                          | First Input Delay no longer collected.                                                                                                                                                                                                                                                                                                                                                    | Use INP (Interaction to Next Paint) instead.                                                                                                                                                                                                       |
+| `session_renewal` view loading type                                  | Session-renewed views have `@view.loading_type:session_renewal` instead of `route_change`.                                                                                                                                                                                                                                                                                                | Update dashboards/monitors filtering on `@view.loading_type`.                                                                                                                                                                                      |
+| Document resource `initiatorType` changed                            | `"initial_document"` becomes `"navigation"`. Duration may differ slightly.                                                                                                                                                                                                                                                                                                                | Update any code inspecting document resource `performanceEntry`.                                                                                                                                                                                   |
+| Action names may change                                              | Tree walker + `textContent` always used in v7 (including Shadow DOM) — CSS `text-transform` is never reflected regardless of `enablePrivacyForActionName`. Monitors with case-sensitive filters on visually-transformed names may break.                                                                                                                                                  | Add `data-dd-action-name` attributes to affected elements, or update monitors to match raw text values.                                                                                                                                            |
+| Cancelled request errors removed (Logs)                              | Aborted fetch/XHR no longer generate network error logs.                                                                                                                                                                                                                                                                                                                                  | No action needed — reduces noise.                                                                                                                                                                                                                  |
+| Logs always requires session storage                                 | Without cookies or localStorage, Logs SDK won't start.                                                                                                                                                                                                                                                                                                                                    | Use `sessionPersistence: 'memory'` for worker environments.                                                                                                                                                                                        |
+| Session Replay: Change Records                                       | New serialization format. More accurate, less bandwidth.                                                                                                                                                                                                                                                                                                                                  | Update if you depend on raw segment format.                                                                                                                                                                                                        |
+| Async chunk names prefixed with `datadog`                            | e.g., `datadogRecorder-<hash>-datadog-rum.js`, `datadogProfiler-<hash>-datadog-rum.js`.                                                                                                                                                                                                                                                                                                   | Update CSP `script-src` rules or caching configs (allow `datadog*-datadog-rum.js`).                                                                                                                                                                |
 
 ## Step 6: Update infrastructure
 
@@ -155,8 +219,17 @@ These are **default changes** — no code breaks, but behavior differs from v6:
   - Update chunk names like `datadog*-datadog-rum.js` (e.g. `datadogRecorder`, `datadogProfiler`).
   - If you removed `usePciIntake`, update CSP for standard intake domain.
 - **Cookies**: Add `_dd_s_v2` to cookie allowlists. The SDK auto-migrates from `_dd_s` on first load. Rollback to v6 starts new sessions.
-- **CORS** (if using `allowedTracingUrls`): Add `"baggage"` to `Access-Control-Allow-Headers` on traced origins — or set `propagateTraceBaggage: false`.
+- **CORS**: Search for tracing config: `grep -rn "allowedTracingUrls\|propagateTraceBaggage" --include="*.js" --include="*.ts" --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.vue" --include="*.svelte"`. For any project with `allowedTracingUrls` and no explicit `propagateTraceBaggage: false`, add `"baggage"` to your existing `Access-Control-Allow-Headers` on traced origins — or set `propagateTraceBaggage: false` to opt out.
 - **Browser support**: Minimum Chrome 80+, Firefox 78+, Safari 14+ (ES2020). ~0.048% less coverage.
+
+## Common Mistakes
+
+| Mistake                                                                    | What goes wrong                                                                                                     | Fix                                                                                                                                                |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Replacing `forwardErrorsToLogs: true` with `forwardConsoleLogs: ['error']` | Unhandled errors (uncaught exceptions, unhandled rejections) stop being forwarded to Logs                           | Keep `forwardErrorsToLogs: true` unchanged and add `forwardConsoleLogs: ['error']` alongside it — they control different things                    |
+| Updating `startDurationVital` wrapper but not its callers                  | Callers pass the old ref variable (now `undefined`) to `stopDurationVital` — vital never stops, event never emitted | After updating the wrapper, search for every caller that captures the return value and update the stop call to pass the vital name string directly |
+| Missing `vitalKey` option on `stopDurationVital`                           | v7 `stopDurationVital` requires `{ vitalKey: string }` to identify which vital to stop                              | Pass the same string used in `startDurationVital`: `stopDurationVital('name', { vitalKey: 'name' })`                                               |
+| Not checking CDN/plain JS files for ref-based vitals                       | TypeScript projects surface this as a type error; plain JS silently breaks                                          | Run the Step 2 grep explicitly — don't rely on type errors to find all sites                                                                       |
 
 ## Verification checklist
 
@@ -169,3 +242,4 @@ After upgrading, confirm:
 - [ ] Distributed tracing working (no CORS errors from baggage header)
 - [ ] No `_dd_s` cookie remaining after first page load (should be `_dd_s_v2`)
 - [ ] Action names acceptable under new privacy defaults
+- [ ] No variables capturing the return value of `startDurationVital` (or wrappers around it) — all stop calls use the vital name string directly


### PR DESCRIPTION
Adds two new migration skills to complement the existing `upgrade-v7` skill.

## What

- `dd-browser-sdk/upgrade-v5/SKILL.md` — v4 to v5 migration (292 lines): replaces deprecated init params (`proxyUrl`, `sampleRate`, etc.), replaces removed public APIs (`addRumGlobalContext`, `removeUser`, etc.), updates Session Replay defaults, handles trusted events, and CSP/CORS changes.
- `dd-browser-sdk/upgrade-v6/SKILL.md` — v5 to v6 migration (153 lines): removes `useCrossSiteSessionCookie` / `sendLogsAfterSessionExpiration`, updates changed defaults (`trackUserInteractions` etc. now default to `true`), handles Session Replay lazy loading, and drops IE11 support.
- `dd-browser-sdk/SKILL.md` — updated Skills table and Routing section with entries for both new skills.

## Source

Skills ported from `DataDog/browser-sdk` branch `adlrb/migration-skills-v4-v5-v5-v6` (PR #4640). Frontmatter updated to match the `agent-skills` convention established by `upgrade-v7`.