### PR TITLE
feat(dd-apps): add OAuth as default auth for local dev, API keys as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-browser-sdk** | Browser SDK: RUM, Logs, Session Replay, profiling, product analytics, error tracking, version migration |
 | **dd-audit** | Audit Trail investigations: who changed what, key compromise, cost spike root cause, compliance evidence (SOC 2/PCI), AI activity auditing |
 | **dd-software-delivery** | CI/CD workflow skills — unblock PR pipelines, triage flaky tests (MCP + pup) |
+| **dd-apps** | Build Datadog Apps — scaffold, run locally, upload, publish, CI/CD, DDSQL data access |
 
 ## Install
 
@@ -345,6 +346,62 @@ unblock-pr my-feature-branch github.com/org/repo
 # Triage a specific flaky test
 triage-flaky-test TestMyFunc
 triage-flaky-test com.example.MyTest github.com/org/repo
+```
+
+### Datadog Apps (dd-apps)
+
+The `dd-apps` directory contains a skill for building [Datadog Apps](https://docs.datadoghq.com/developers/apps/) — locally-developed web apps built with TypeScript and React that integrate with Datadog surfaces.
+
+| Skill | Purpose |
+|-------|---------|
+| `datadog-app` | Scaffold, run locally, build, upload, publish, set up CI/CD, trigger Workflow Automation, and query data with DDSQL or Action Catalog |
+
+#### Prerequisites
+
+A Datadog account with an API key and application key that have Actions API Access enabled. See [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/).
+
+```bash
+export DD_API_KEY="<YOUR_API_KEY>"
+export DD_APP_KEY="<YOUR_APPLICATION_KEY>"
+```
+
+Node.js 20.19+ or 22.12+ is required. Use Volta, nvm, or fnm to manage versions.
+
+#### Install
+
+```bash
+# Claude Code
+cp -r dd-apps/datadog-app ~/.claude/skills
+```
+
+Or via npx:
+
+```bash
+npx skills add datadog-labs/agent-skills \
+  --skill datadog-app \
+  --full-depth -y
+```
+
+#### Usage
+
+```
+# Scaffold a new app
+Scaffold a new Datadog App called my-app
+
+# Run locally
+Run my Datadog App locally
+
+# Upload and publish
+Upload my app to Datadog
+How do I publish my app?
+
+# Troubleshoot
+I'm getting a 401 error when uploading
+My backend function isn't working
+
+# Query data
+Query my app datastore with DDSQL
+Trigger a Workflow Automation workflow from a backend function
 ```
 
 ## Quick Reference

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,7 @@ Essential Datadog skills for AI agents.
 | **dd-llmo** | LLM Observability traces, experiments, evals |
 | **dd-browser-sdk** | Browser SDK setup, RUM, Logs, Session Replay, version migration |
 | **dd-software-delivery** | CI/CD workflow skills — unblock PR, triage flaky tests |
+| **dd-apps**              | Build Datadog Apps — scaffold, run, upload, publish, CI/CD |
 
 ## Install
 

--- a/dd-apps/datadog-app/SKILL.md
+++ b/dd-apps/datadog-app/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: datadog-app
+description: Guides developers building Datadog Apps with TypeScript, React, the @datadog/apps scaffolder, and @datadog/vite-plugin. Use when a user wants to scaffold, run, debug, upgrade, build, deploy, publish, deploy without publishing (draft upload), publish a specific version, set up OAuth or API key authentication, set up CI/CD, trigger/poll Workflow Automation, choose DDSQL or Action Catalog for backend data access, or query app datastores with DDSQL, including backend function and auth troubleshooting.
+---
+
+# Datadog Apps
+
+Use this skill when a developer is building a Datadog Apps project with TypeScript, React, published packages, and the normal production Datadog site. If the user is modifying Datadog platform packages or testing package source changes, use a platform-engineer-oriented workflow instead.
+
+## Overview
+
+Datadog Apps are locally developed web apps built with React and TypeScript or JavaScript. Use Apps when a project needs source control, code review, CI/CD, multi-engineer collaboration, AI-assisted local development, custom UI or logic, or backend code that integrates with services beyond low-code App Builder. Apps share App Builder's permissions model and can be embedded in Datadog surfaces such as dashboards and the Internal Developer Portal.
+
+## Reference Routing
+
+Read only the reference needed for the user's task:
+
+| User task | Read |
+| --- | --- |
+| Create, scaffold, configure prerequisites, set up OAuth or API key auth, or run locally | `references/getting-started.md` |
+| Build, deploy, publish, deploy without publishing, publish a specific version, configure Datadog site, or understand deploy output | `references/build-deploy-publish.md` |
+| Add or update GitHub Actions deployment | `references/cicd.md` |
+| Trigger or poll Workflow Automation from a backend function | `references/workflow-http-trigger.md` |
+| Get started querying data from a Datadog App | `references/querying-data/getting-started.md` |
+| Understand or configure Action Catalog connections | `references/querying-data/connections.md` |
+| Query Datadog App datastores with DDSQL | `references/querying-data/ddsql/datastores.md` |
+| Upgrade Datadog Apps dependencies or compare with a freshly scaffolded app | `references/upgrading.md` |
+| Diagnose auth, OAuth, deploy, Node, site, backend function failures, or `.env.local` credentials not being picked up | `references/troubleshooting.md` |
+
+## Boundaries
+
+- After scaffolding or when working inside an existing app, read the app project's `AGENTS.md` before making changes.
+- For backend function implementation details, rely on the generated app project's `AGENTS.md`; this skill only covers local development credentials and troubleshooting.
+- Preserve the app project's existing package manager, scripts, Datadog site, and repository conventions.
+- Do not cover Datadog package/platform development in this skill.
+- Low-code App Builder to Datadog Apps migration guidance is future work. Do not invent a migration process yet.

--- a/dd-apps/datadog-app/references/build-deploy-publish.md
+++ b/dd-apps/datadog-app/references/build-deploy-publish.md
@@ -1,0 +1,98 @@
+# Build, Deploy, And Publish
+
+Use this when the user needs to build, deploy, publish, configure the Datadog site, or interpret deploy output.
+
+## Build And Deploy
+
+Inspect the generated `package.json` scripts before choosing a command; scaffolder behavior can change. Use `typecheck` for a credential-free TypeScript check when available:
+
+```bash
+npm run typecheck
+```
+
+**Using OAuth (default for local dev):**
+
+If OAuth credentials are cached from local dev, no environment variables are needed:
+
+```bash
+npm run deploy
+```
+
+**Using API keys (CI and environments without OAuth):**
+
+```bash
+export DD_API_KEY="<YOUR_API_KEY>"
+export DD_APP_KEY="<YOUR_APPLICATION_KEY>"
+npm run deploy
+```
+
+`npm run deploy` builds the app, uploads it, and publishes the new version live. A successful deploy prints a Datadog URL for the app.
+
+### Deploy without publishing
+
+To upload a new version as a draft without making it live — useful for staging environments or CI pipelines with a separate approval step:
+
+```bash
+npm run deploy -- --no-publish
+```
+
+After a deploy without publish, the new version appears in the App Builder version history but does not go live.
+
+## Publish
+
+To publish an already-uploaded version without rebuilding:
+
+```bash
+npm run publish
+```
+
+This publishes the most recently uploaded version (read from `.datadog-app-version.json` in the project root, written automatically after each `deploy`).
+
+To publish a specific version by ID:
+
+```bash
+npm run publish -- --version <version-id>
+```
+
+When using `--version` without a cache file, set `DD_APPS_IDENTIFIER` to the app's identifier so the CLI knows which app to publish.
+
+## Older scaffolded projects
+
+Projects scaffolded before `@datadog/vite-plugin` 3.2.0 may not have the `deploy` and `publish` scripts. Add them to `package.json`:
+
+```json
+{
+    "scripts": {
+        "deploy": "datadog-apps deploy",
+        "publish": "datadog-apps publish"
+    }
+}
+```
+
+Requires `@datadog/vite-plugin` >= 3.2.0.
+
+## Environment variables
+
+- `DD_API_KEY`: Datadog API key.
+- `DD_APP_KEY`: Datadog application key.
+- `DD_APPS_IDENTIFIER`: override the app identifier (useful for `publish --version` without a cache file).
+- `DD_APPS_PUBLISH`: set to `false` to deploy without publishing. The `--no-publish` flag does this automatically.
+- `DD_APPS_VERSION_NAME`: optional unique uploaded version name.
+
+## Datadog Site
+
+For non-US1 sites, set the Datadog site in `vite.config.ts` so local development and deploys target the right site:
+
+```ts
+datadogVitePlugin({
+  auth: {
+    site: '<YOUR_DATADOG_SITE>',
+  },
+});
+```
+
+## Manage
+
+After deploy, the app appears in the App Builder app list. From there users can also manage name, description, permissions, and embed the app in Datadog surfaces.
+
+Locally built Apps cannot be edited with the low-code App Builder drag-and-drop UI. Update local code and re-deploy instead.

--- a/dd-apps/datadog-app/references/cicd.md
+++ b/dd-apps/datadog-app/references/cicd.md
@@ -1,0 +1,46 @@
+# CI/CD
+
+Use this when the user wants to deploy a Datadog Apps project from GitHub Actions.
+
+## GitHub Actions
+
+Use `DataDog/apps-github-action` to build and upload the app on pushes to the deployment branch. Keep `app-directory` aligned with the app's path in the repository.
+
+```yaml
+name: Continuous Deployment
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-app:
+    name: Deploy Datadog App
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+
+      - name: Deploy
+        uses: DataDog/apps-github-action@v0.0.2
+        with:
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          datadog-app-key: ${{ secrets.DATADOG_APP_KEY }}
+          app-directory: .
+```
+
+Store `DATADOG_API_KEY` and `DATADOG_APP_KEY` as [encrypted secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) in the repository or organization settings.
+
+## Site Configuration
+
+For non-US1 organizations, configure the Datadog site in `vite.config.ts`. The upload action reads app configuration during build, so keep CI and local configuration aligned.

--- a/dd-apps/datadog-app/references/getting-started.md
+++ b/dd-apps/datadog-app/references/getting-started.md
@@ -1,0 +1,106 @@
+# Getting Started
+
+Use this when the user wants to create, scaffold, configure prerequisites, or run a Datadog Apps project locally.
+
+## Prerequisites
+
+- Use Node.js 20.19+ on the Node 20 release line, or Node.js 22.12+ on the Node 22 release line.
+- Prefer a current Node 22 release when scaffolding or debugging dependency install issues.
+- Datadog API and application credentials are required. The application key needs two scopes: **Actions API Access** (for backend function execution) and **Apps** (for uploading and publishing). See [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/) for details.
+
+Check Node:
+
+```bash
+node --version
+```
+
+## Scaffold
+
+Choose where to create the app project before running the scaffolder.
+
+Create a project with the published scaffolder:
+
+```bash
+npm create @datadog/apps@latest
+```
+
+Follow the prompts, then enter the generated app directory.
+
+## Non-Interactive Scaffolding
+
+Non-interactive scaffolding is the preferred way to create an app through this skill. AI agents can run the scaffolder directly for the user after collecting the required details. First inspect the current CLI options:
+
+```bash
+npm create @datadog/apps@latest -- --help
+```
+
+Use the help output to collect the required details from the user, such as target directory, template, and whether to accept defaults or overwrite an existing directory. Then run the scaffolder with explicit options. For example:
+
+```bash
+npm create @datadog/apps@latest -- my-app --template vite-react -y
+```
+
+Keep the generated project path consistent with the user's chosen repository layout.
+
+## Local Development
+
+### Credentials
+
+Newly scaffolded apps use **OAuth by default**. If no API keys are configured, the Vite plugin opens a browser window on the first `npm run dev` run, authenticates via Datadog login, and caches the token locally in the system keyring. No credentials need to be set up in advance.
+
+**Default flow — OAuth:**
+
+Just run the dev server:
+
+```bash
+npm run dev
+```
+
+On the first run, a browser window opens for Datadog login. After authorizing, the token is cached and reused on subsequent runs without re-authentication.
+
+**Fallback — API keys:**
+
+Use API keys when OAuth isn't available — for example in headless CI environments, restricted networks, or if the OAuth flow fails. Create a `.env.local` file at the app root:
+
+Do not ask the user to provide actual key values in the conversation. Instead:
+
+1. Confirm `.env.local` is gitignored — check `.gitignore` for `*.local` or `.env.local` before writing. The scaffolder includes this by default.
+2. Write the file to the app root with placeholders:
+
+```
+DD_API_KEY=REPLACE_WITH_YOUR_API_KEY
+DD_APP_KEY=REPLACE_WITH_YOUR_APP_KEY
+```
+
+3. Open the file immediately in the user's editor:
+
+```bash
+cursor .env.local 2>/dev/null || code .env.local 2>/dev/null || open .env.local
+```
+
+4. Tell the user to replace the placeholder values with their real keys, and provide these links:
+   - API keys: `https://app.datadoghq.com/organization-settings/api-keys`
+   - Application keys: `https://app.datadoghq.com/organization-settings/application-keys` — the key needs two scopes: **Actions API Access** (backend function execution) and **Apps** (uploading and publishing)
+
+Vite reads `.env.local` automatically — once real values are in place, `npm run dev` uses API keys instead of OAuth.
+
+**Optional shortcut (macOS only) — clipboard → file:** If the user asks for an alternative to editing the file, offer to write each key directly from the clipboard. The value goes clipboard → file without appearing in the conversation or tool output. Explain that the command being run is still visible in the transcript. Ask the user to copy their `DD_API_KEY` value to the clipboard first, then:
+
+```bash
+grep -v "^DD_API_KEY=" .env.local > .env.local.tmp && mv .env.local.tmp .env.local
+printf "DD_API_KEY=" >> .env.local && pbpaste >> .env.local && printf "\n" >> .env.local
+```
+
+Repeat for `DD_APP_KEY`. Confirm the user has the correct value on their clipboard before running each step.
+
+Open the local URL printed by the dev server, commonly `http://localhost:5173/`.
+
+## Generated Project Shape
+
+Scaffolded projects commonly include:
+
+- `src/App.tsx`: root React UI.
+- `src/**/*.backend.ts`: server-side backend functions.
+- `vite.config.ts`: Datadog Vite plugin configuration.
+- `package.json`: scripts such as `dev`, `build`, `deploy`, and `publish`.
+- `AGENTS.md`: project-local instructions for AI coding assistants. Read this after scaffolding and before making app-specific changes; it may include project conventions, scripts, and development guidance.

--- a/dd-apps/datadog-app/references/querying-data/connections.md
+++ b/dd-apps/datadog-app/references/querying-data/connections.md
@@ -1,0 +1,47 @@
+# Connections
+
+Use this when a Datadog App or Workflow Automation action needs credentials for a Datadog, cloud, SaaS, generic HTTP, or third-party integration.
+
+Connections are part of the Action Catalog ecosystem. They provide reusable authentication configuration for actions that need credentials. Some actions can use credentials from a Datadog integration tile; other actions need explicit connection credentials.
+
+Public docs:
+
+- [Connections](https://docs.datadoghq.com/actions/connections/)
+- [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/)
+- [Action Connection API](https://docs.datadoghq.com/api/latest/action-connection/)
+- [Action Catalog](https://docs.datadoghq.com/actions/action_interface/)
+
+## When Connections Matter
+
+Use Connections guidance when:
+
+- An Action Catalog action has a `connectionId` or Connection field.
+- The app calls a generic HTTP action with custom authentication.
+- The app needs credentials for an integration that does not inherit auth from a Datadog integration tile.
+- Different apps or workflows should use different credential scopes.
+- The workflow needs connection groups or identifier tags to resolve the right account or environment.
+
+Some integrations, such as GitHub, Jira, Microsoft Teams, Opsgenie, PagerDuty, Slack, and Statuspage, may inherit credentials from their integration tile. For other integrations or custom actions, set up a connection.
+
+## Discovery
+
+Before telling an agent to wire an action:
+
+- Identify which Action Catalog action will be used.
+- Check whether the action requires a connection, supports integration tile auth, or can run without credentials.
+- Find or create the relevant connection in Datadog Connections.
+- Confirm the connection is scoped with only the permissions needed for the app or workflow.
+- Copy the Connection ID from the connection details when the app implementation needs a stable ID.
+
+Connections are managed in Datadog at `https://app.datadoghq.com/actions/connections`.
+
+## Security Guidance
+
+- Do not ask users to paste API keys, passwords, OAuth secrets, private keys, or other credentials into an AI conversation.
+- Do not create connections directly from an AI agent when doing so would require secrets to enter the agent context, shell history, logs, or generated files.
+- Have a human create or update connections in the Datadog UI, or use an approved secret-handling workflow that keeps credential material out of AI-visible context.
+- Prefer granular connections for different apps, workflows, environments, or permission scopes.
+- Do not reuse a high-privilege connection for unrelated actions.
+- Restrict who can edit, resolve, or use a connection.
+- Treat connection IDs as configuration, not secrets; the credentials remain stored in Datadog.
+- Leave exact app-code organization for connection IDs to the generated app scaffold's `AGENTS.md`.

--- a/dd-apps/datadog-app/references/querying-data/ddsql/datastores.md
+++ b/dd-apps/datadog-app/references/querying-data/ddsql/datastores.md
@@ -1,0 +1,74 @@
+# Querying App Datastores With DDSQL
+
+Use this when a Datadog App needs to query a Datadog App datastore from backend code.
+
+Prefer DDSQL for datastore reads that need projection, filters, sorting, pagination, counts, grouping, or derived fields. Use datastore actions directly for writes, deletes, simple single-item reads, or workflows that need action-specific behavior rather than SQL-shaped data retrieval.
+
+Public docs:
+
+- [Datastores](https://docs.datadoghq.com/actions/datastores/)
+- [Use Datastores with Apps and Workflows](https://docs.datadoghq.com/actions/datastores/use/)
+- [Datastore Access and Authentication](https://docs.datadoghq.com/actions/datastores/auth/)
+- [Actions Datastores API](https://docs.datadoghq.com/api/latest/actions-datastores/)
+- [List datastore items API](https://docs.datadoghq.com/api/latest/actions-datastores/list-datastore-items/)
+
+## Discover The Datastore
+
+Before writing view queries:
+
+- Locate the datastore ID from app configuration, existing backend code, generated app metadata, or the Datadog UI.
+- Inspect the datastore write path to identify canonical field names and rough types.
+- Confirm columns with small DDSQL probes that project only a few fields and use `LIMIT`.
+- Keep the discovered column list close to backend query templates so future edits do not rediscover schema from frontend code.
+
+Stop and inspect more if the datastore ID, columns, or key fields are not known.
+
+## Query Shape
+
+This is an observed DDSQL query shape, not a substitute for schema/spec discovery. Before generating app code, confirm that the current environment exposes `dd.actions_datastores`, inspect its required arguments and column typing, and validate a minimal bounded query.
+
+```sql
+SELECT key, summary, status
+FROM dd.actions_datastores(
+  id => '<datastore-id>',
+  columns => ARRAY ['key', 'summary', 'status']
+) AS (
+  key VARCHAR,
+  summary VARCHAR,
+  status VARCHAR
+)
+WHERE status = 'Open'
+ORDER BY key
+LIMIT 100;
+```
+
+Use the pattern this way:
+
+- Project only columns needed by the active view.
+- Declare the returned column schema after the datastore function call.
+- Push `WHERE`, `ORDER BY`, `LIMIT`, and aggregates into DDSQL where supported.
+- Validate a minimal query before wiring the backend function; if the table function is not exposed, use Datastore actions/API instead.
+
+## Performance Pattern
+
+Use DDSQL to avoid treating a datastore as a full export source:
+
+- Load startup metadata first.
+- Load filter options separately.
+- Load only the active tab or route.
+- Bound list responses with `LIMIT`, pagination, or virtualization.
+- Fetch heavy fields such as descriptions, blobs, or relationship payloads only for detail views.
+
+This replaces the slow pattern of loading the full datastore into the browser, building a local database, and querying it client-side.
+
+## Backend Safety
+
+- Use fixed query templates.
+- Map frontend filters to allowlisted datastore columns.
+- Clamp numeric inputs.
+- Do not accept raw frontend SQL.
+- Do not accept raw frontend `ORDER BY` fields.
+- Avoid selecting heavy fields in list queries.
+- Return only display fields needed for the active screen.
+
+For exact backend execution imports, prefer the generated app project's `AGENTS.md` and installed package APIs over examples from memory.

--- a/dd-apps/datadog-app/references/querying-data/getting-started.md
+++ b/dd-apps/datadog-app/references/querying-data/getting-started.md
@@ -1,0 +1,98 @@
+# Getting Started Querying Data
+
+Use this first when a Datadog App needs to read, transform, or mutate data and the right backend data access pattern is not yet clear.
+
+Datadog Apps backend functions commonly use two data access paths:
+
+- DDSQL: SQL for Datadog-visible data. Prefer this for read paths when the data is DDSQL-visible and the app needs projection, filtering, joins, grouping, ordering, limits, offsets, JSON/regex functions, window functions, or tag access.
+- Action Catalog: typed actions for Datadog, cloud providers, SaaS tools, generic HTTP, and other integrations. Prefer this for mutations, product workflows, simple single-record reads, or sources that are not DDSQL-visible.
+- Connections: reusable credentials and auth configuration for Action Catalog actions in App Builder and Workflow Automation. Use them when an action needs integration-specific credentials.
+
+Public docs:
+
+- [DDSQL Reference](https://docs.datadoghq.com/ddsql_reference/)
+- [DDSQL Data Directory](https://docs.datadoghq.com/ddsql_reference/data_directory/)
+- [Action Catalog](https://docs.datadoghq.com/actions/action_interface/)
+- [`@datadog/action-catalog` npm package](https://www.npmjs.com/package/@datadog/action-catalog)
+- [Connections](https://docs.datadoghq.com/actions/connections/)
+- [App Builder Access and Authentication](https://docs.datadoghq.com/actions/app_builder/access_and_auth/)
+- [Datastores](https://docs.datadoghq.com/actions/datastores/)
+- [Use Datastores with Apps and Workflows](https://docs.datadoghq.com/actions/datastores/use/)
+
+## Progressive Discovery
+
+Use this root file only when the right data access path is not clear. Source-specific details for Action Catalog connections and Datadog App datastores are outside this overview and are routed directly from `SKILL.md`.
+
+| Question | Next step |
+| --- | --- |
+| Is this a read from DDSQL-visible data? | Continue to the DDSQL section below. |
+| Is this a mutation or integration workflow? | Continue to the Action Catalog section below. |
+
+## DDSQL
+
+DDSQL can read Datadog data exposed through documented datasets and table functions. Check the DDSQL Data Directory and schema tooling before writing queries.
+
+For reads, check DDSQL first. If the data is exposed in the DDSQL Data Directory, through a DDSQL table function, or through a verified app datastore or Reference Table path, DDSQL usually gives the app more control and smaller responses than broad product-specific list actions.
+
+Prefer DDSQL when the app needs:
+
+- Projection of only needed columns.
+- Filtering, sorting, limits, or offsets.
+- Joins across DDSQL-visible sources.
+- Counts, grouping, aggregation, or derived fields.
+- JSON, regex, window, date/time, or tag operations.
+- Bounded previews for schema and access validation.
+
+DDSQL-visible Datadog product datasets include, but are not limited to:
+
+- Logs, APM Spans, RUM Events, Events, Audit Trail, CI Pipelines, and CI Tests.
+- Hosts, Containers, Services, Systems, Queues, Frontend Apps, Product Analytics, and LLM Observability.
+- Database metadata such as Database Instances, MySQL, PostgreSQL, and SQL Server logical databases, schemas, and tables.
+- Network Device Flows, Network Devices, Network Monitoring, Security Findings, and Security Inventory Libraries.
+- Cloud and Kubernetes inventory datasets from AWS, Azure, GCP, Kubernetes, and OCI.
+- Table functions for logs, metrics scalar/timeseries, cloud cost scalar/timeseries, and other documented DDSQL sources.
+- App datastores and Reference Tables when confirmed in the target org/site.
+
+Before writing DDSQL, identify:
+
+- Data source name and ID or namespace.
+- Confirmed table/path, such as a dataset name, table function, datastore ID, or `reference_tables.<table_name>`.
+- Confirmed columns and rough DDSQL types.
+- Key fields, row count, status, and access when tooling exposes them.
+- One bounded preview query that proves the source is queryable.
+
+If these are unknown, inspect more or ask the user instead of guessing schemas from memory.
+
+### Inspect Tables And Schemas
+
+Use discovery tooling before writing app code:
+
+- Start with the public DDSQL Data Directory for documented datasets and table functions.
+- Prefer Datadog MCP DDSQL, data directory, table search, schema, or product-specific exploration tools when they are available in the current session. Use MCP results to confirm table names, columns, supported filters, and access before generating SQL.
+- For shell-based validation, use the Datadog API directly with your `DD_API_KEY` and `DD_APP_KEY` credentials.
+
+Do not rely on guessed table names, guessed columns, or `information_schema`. Treat a bounded preview query as the final proof that the table path, schema, access, and syntax work in the target org/site.
+
+Backend DDSQL should use fixed SQL templates, allowlisted frontend inputs, clamped limits, escaped literals or supported parameterization, and display-ready response rows. Verify the exact DDSQL execution API or action import against the generated app project's `AGENTS.md` and installed packages before writing app code.
+
+## Action Catalog
+
+Backend functions can call Action Catalog actions through `@datadog/action-catalog`. The catalog provides reusable, typed actions for Datadog APIs, infrastructure providers, SaaS tools, generic HTTP, and other integrations, so app code does not need to hand-roll API clients for supported workflows.
+
+Use Action Catalog actions for:
+
+- Mutations: create, update, delete, trigger, invoke, approve, assign, resolve, send, or start operations.
+- Product workflows that map to an existing action.
+- Simple single-record reads where the typed action response is exactly what the UI needs.
+- External systems or integrations that are not DDSQL-visible.
+- Workflows that require a connection or integration-specific auth behavior.
+
+Prefer DDSQL for read-heavy paths when the same data is DDSQL-visible and the app needs projection, filtering, joins, aggregation, ordering, or pagination.
+
+For exact Action Catalog imports, file layout, and app-code patterns, rely on the generated app scaffold's `AGENTS.md` and installed package APIs. This skill should explain the Datadog product model and decision tree, not own app implementation structure.
+
+## Shared Safety
+
+- Keep data access in backend functions, not frontend code.
+- Do not accept raw frontend SQL, raw `ORDER BY`, or unbounded limits.
+- Ensure `DD_API_KEY` and `DD_APP_KEY` are exported with Actions API Access when running local development or discovery commands.

--- a/dd-apps/datadog-app/references/troubleshooting.md
+++ b/dd-apps/datadog-app/references/troubleshooting.md
@@ -1,0 +1,105 @@
+# Troubleshooting
+
+Use this when the user is diagnosing auth, deploy, Node, site, or backend function failures.
+
+## Authentication Errors
+
+Symptoms include 401s, `Missing authentication token`, backend function call failures, or the Vite plugin logging `Auth credentials not configured`.
+
+**OAuth (default):**
+
+- If the browser window didn't open, your environment may not support OAuth — headless terminals and some remote environments can't launch a browser. Fall back to API keys (see below).
+- If the OAuth token has expired, re-authentication happens automatically on the next `npm run dev` run. If it doesn't prompt, delete the cached token from the system keyring and run again.
+- If OAuth keeps failing, set `DD_API_KEY` and `DD_APP_KEY` in `.env.local` to switch to API key auth.
+
+**API keys (fallback):**
+
+- Verify `DD_API_KEY` and `DD_APP_KEY` are set — either in `.env.local` at the app root or exported in the shell.
+- Confirm the application key has both **Actions API Access** and **Apps** scopes enabled.
+- Confirm credentials match the Datadog site configured in `vite.config.ts`.
+
+**`.env.local` not being picked up:** The scaffolded `vite.config.ts` reads credentials via `process.env`, which does not include `.env.local` values at config evaluation time. Fix by switching to Vite's `loadEnv`:
+
+```ts
+import { defineConfig, loadEnv } from 'vite';
+
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), '');
+    return {
+        plugins: [
+            datadogVitePlugin({
+                auth: {
+                    apiKey: env.DD_API_KEY,
+                    appKey: env.DD_APP_KEY,
+                },
+            }),
+        ],
+    };
+});
+```
+
+After updating `vite.config.ts`, restart the dev server — credentials will be read from `.env.local` without any shell exports.
+
+## Upload Fails With 403 "you do not have access to this app"
+
+The build and source map upload succeed but asset upload to App Builder fails with `HTTP 403 Forbidden: you do not have access to this app`.
+
+This is an application key permissions issue. The app key needs **two** scopes enabled — not just one:
+
+1. **Actions API Access** — required for backend function execution during local dev.
+2. **Apps** (or **App Builder**) — required for uploading and publishing app assets.
+
+Fix: go to `https://app.datadoghq.com/organization-settings/application-keys`, find your key, and confirm both scopes are enabled. If the Apps scope is missing, create a new key with both scopes.
+
+After updating the key, re-run `npm run deploy`.
+
+## Build Succeeds But Nothing Deploys
+
+- When the intent is to deploy, use `npm run deploy`; do not rely on `npm run build` as the deploy path.
+- Confirm `dryRun` in `vite.config.ts` is not set to `true`.
+- Check whether the deploy output printed a Datadog app URL.
+- Confirm `DD_APPS_UPLOAD_ASSETS` is set — `npm run deploy` does this automatically.
+
+## Build Fails With Missing Credentials
+
+- Current scaffold versions may make `npm run build` exercise Datadog deploy behavior.
+- Ensure OAuth credentials are cached (run `npm run dev` first to trigger the OAuth flow), or set `DD_API_KEY` and `DD_APP_KEY` before running build commands that touch Datadog.
+- For credential-free validation, prefer `npm run typecheck` when available.
+
+## Lint Fails Before Checking Code
+
+- Some scaffold versions install ESLint 9 while generating legacy `.eslintrc.cjs`.
+- If lint fails with an ESLint config-file error before checking source code, do not treat it as an app logic failure.
+- Run `npm run typecheck` and `npm run build`, and report the scaffold lint mismatch to the Datadog Apps maintainers.
+
+## Node Or Scaffolding Errors
+
+- The generated app guidance expects Node.js 20.19+ on the Node 20 release line, or Node.js 22.12+ on the Node 22 release line.
+- If errors persist on a supported version, use a current Node 22 release.
+- Use Volta, nvm, fnm, or the Node installer to switch versions.
+
+## Datadog Site Mismatch
+
+- Inspect `vite.config.ts` for the configured Datadog site.
+- Ensure CI uses the same site configuration as local development.
+
+## Backend Function Issues
+
+- Confirm backend files match `*.backend.ts` or `*.backend.js`.
+- Confirm local development or deploy commands have Actions API credentials (`DD_API_KEY`, `DD_APP_KEY` with Actions API Access).
+- Prefer `@datadog/action-catalog` typed actions when available.
+- Check frontend imports reference the backend module path exactly.
+
+## Browser Debugging
+
+If Playwright is available, headed mode can be useful for troubleshooting local app behavior because it shows the browser session while preserving automation and console/network inspection:
+
+```bash
+npx playwright test --headed
+```
+
+Adapt the command to the app's configured test scripts when they exist.
+
+## Getting Help
+
+If the user is stuck or has additional Datadog Apps questions, direct them to open an issue at https://github.com/DataDog/datadog-apps-claude-plugin/issues or visit the [Datadog developer documentation](https://docs.datadoghq.com/developers/apps/).

--- a/dd-apps/datadog-app/references/upgrading.md
+++ b/dd-apps/datadog-app/references/upgrading.md
@@ -1,0 +1,89 @@
+# Upgrading
+
+Use this when the user wants to upgrade an existing Datadog Apps project or pull in behavior available from the latest app scaffolder.
+
+## Primary Datadog Packages
+
+Focus on these Datadog packages first:
+
+- `@datadog/vite-plugin`: Datadog Vite integration used for local development, build, and upload behavior.
+- `@datadog/action-catalog`: typed Action Catalog client used by backend functions.
+
+Preserve the app's existing package manager and lockfile style.
+
+## Before Upgrading
+
+Read release notes or package metadata before changing versions:
+
+```bash
+npm view @datadog/vite-plugin version repository.url homepage bugs.url
+npm view @datadog/action-catalog version repository.url homepage bugs.url
+```
+
+Then check the package's release notes, changelog, GitHub releases, or npm package page for breaking changes, new features, migration notes, and peer dependency changes. If release notes are not available, inspect the version history and package metadata before choosing a target version.
+
+Inspect the current app:
+
+```bash
+npm outdated @datadog/vite-plugin @datadog/action-catalog
+npm ls @datadog/vite-plugin @datadog/action-catalog
+```
+
+If the app does not use npm, run the equivalent package-manager commands.
+
+## Upgrade
+
+For npm projects:
+
+```bash
+npm install @datadog/action-catalog@latest
+npm install -D @datadog/vite-plugin@latest
+```
+
+After upgrading, check and preserve:
+
+- `vite.config.ts` Datadog plugin configuration, especially `auth.site`.
+- `package.json` scripts such as `dev`, `build`, and `upload`.
+- Existing backend function imports from `@datadog/action-catalog/...`.
+- Project-local instructions in `AGENTS.md`.
+
+## Compare Against A Fresh Scaffold
+
+If the user asks for a feature that may come from the latest scaffolder, create a temporary baseline app and compare it with the existing project instead of guessing.
+
+Create a baseline outside the app repo:
+
+```bash
+tmp_dir="$(mktemp -d)"
+npm create @datadog/apps@latest -- "$tmp_dir/base-app" --template vite-react -y --skip-post-scaffold
+```
+
+Compare relevant files:
+
+```bash
+diff -ru "$tmp_dir/base-app/package.json" package.json
+diff -ru "$tmp_dir/base-app/vite.config.ts" vite.config.ts
+diff -ru "$tmp_dir/base-app/AGENTS.md" AGENTS.md
+diff -ru "$tmp_dir/base-app/src" src
+```
+
+Port only the specific scaffolder changes needed for the user's goal. Do not replace the app wholesale or discard existing app logic.
+
+## Verification
+
+Run the project's normal checks after upgrading:
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
+```
+
+For backend function or upload-related changes, also test with credentials:
+
+```bash
+export DD_API_KEY="<YOUR_API_KEY>"
+export DD_APP_KEY="<YOUR_APPLICATION_KEY>"
+npm run dev
+npm run upload
+```

--- a/dd-apps/datadog-app/references/workflow-http-trigger.md
+++ b/dd-apps/datadog-app/references/workflow-http-trigger.md
@@ -1,0 +1,208 @@
+# Workflow HTTP Trigger
+
+Use this when a Datadog App backend function needs to trigger a Datadog Workflow Automation workflow and poll the workflow instance result.
+
+## Requirements
+
+- Use a backend function, not frontend code. Backend functions can call `@datadog/action-catalog`.
+- Use the generic HTTP action from `@datadog/action-catalog/http/http`.
+- The HTTP action requires a connection ID for an HTTP connection configured in your Datadog org. Create or find a generic HTTP connection at `https://app.datadoghq.com/actions/connections` and copy its ID.
+- Keep the app's configured Datadog site aligned with the Workflow API host. US1 apps use `https://api.datadoghq.com`.
+- The target workflow must be published and must include an API trigger. In the workflow spec, look for a trigger object containing `apiTrigger`.
+- Workflow inputs must match the workflow input schema exactly.
+
+## Inspect The Workflow
+
+Before wiring an app to a workflow, inspect the workflow's published shape using curl with your Datadog API credentials:
+
+```bash
+workflow_id="<WORKFLOW_ID>"
+curl -sS --fail-with-body \
+  "https://api.datadoghq.com/api/v2/workflows/${workflow_id}" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -H "Accept: application/json" \
+| jq "{
+    id: .data.id,
+    name: .data.attributes.name,
+    published: .data.attributes.published,
+    inputSchema: .data.attributes.spec.inputSchema,
+    outputSchema: .data.attributes.spec.outputSchema,
+    hasApiTrigger: any(.data.attributes.spec.triggers[]?; has(\"apiTrigger\"))
+  }"
+```
+
+Use this output to confirm:
+
+- `published` is `true`.
+- `inputSchema.parameters` contains the input names and types the app will send.
+- `outputSchema.parameters` describes expected outputs.
+- `hasApiTrigger` is `true`.
+
+Do not copy browser UI curl cookies, CSRF tokens, or `_authentication_token` values into app code. Those belong to browser session-authenticated UI calls, not Datadog Apps backend functions.
+
+## Trigger And Poll From A Backend Function
+
+Inputs go under `meta.payload`; do not send the workflow inputs as the raw JSON body.
+
+Replace `YOUR_HTTP_CONNECTION_ID` with the ID of an HTTP connection from your Datadog org (`https://app.datadoghq.com/actions/connections`).
+
+```ts
+import { request } from "@datadog/action-catalog/http/http";
+
+const DATADOG_HTTP_CONNECTION_ID = "<YOUR_HTTP_CONNECTION_ID>";
+const DATADOG_API_BASE_URL = "https://api.datadoghq.com";
+const DEFAULT_POLL_TIMEOUT_MS = 120_000;
+const INITIAL_POLL_DELAY_MS = 250;
+const POLL_DELAY_MULTIPLIER = 1.05;
+
+const jsonHeaders = [
+  { key: "Accept", value: ["application/json"] },
+  { key: "Content-Type", value: ["application/json"] },
+];
+
+type WorkflowInstanceResponse = {
+  data?: {
+    id?: string;
+    attributes?: {
+      endTimestamp?: string | null;
+      outputs?: unknown;
+      instanceStatus?: {
+        detailsKind?: string;
+        displayName?: string;
+      };
+    };
+  };
+};
+
+type WorkflowRunResult = {
+  instanceId?: string;
+  statusKind?: string;
+  displayStatus?: string;
+  outputs?: unknown;
+  body: unknown;
+};
+
+type PollWorkflowOptions = {
+  timeoutMs?: number;
+};
+
+function workflowInstancesUrl(workflowId: string) {
+  return `${DATADOG_API_BASE_URL}/api/v2/workflows/${workflowId}/instances`;
+}
+
+function getStatusKind(body: unknown): string | undefined {
+  return (body as WorkflowInstanceResponse | undefined)?.data?.attributes
+    ?.instanceStatus?.detailsKind;
+}
+
+function isRunningStatus(statusKind?: string) {
+  return !statusKind || statusKind === "IN_PROGRESS";
+}
+
+function createSleepWithExponentialBackoff(
+  initialDelayMs: number,
+  multiplier: number,
+) {
+  let delay = initialDelayMs / multiplier;
+
+  return () => {
+    delay *= multiplier;
+
+    // Randomize by plus or minus 20% to avoid synchronized polling.
+    const jitterRange = delay * 0.4;
+    const jitter = Math.random() * jitterRange - jitterRange / 2;
+    const randomizedDelay = delay + jitter;
+
+    return new Promise<void>((resolve) =>
+      setTimeout(resolve, randomizedDelay),
+    );
+  };
+}
+
+function toRunResult(body: unknown): WorkflowRunResult {
+  const response = body as WorkflowInstanceResponse | undefined;
+
+  return {
+    instanceId: response?.data?.id,
+    statusKind: response?.data?.attributes?.instanceStatus?.detailsKind,
+    displayStatus: response?.data?.attributes?.instanceStatus?.displayName,
+    outputs: response?.data?.attributes?.outputs,
+    body,
+  };
+}
+
+export async function triggerWorkflow(
+  workflowId: string,
+  payload: Record<string, unknown>,
+): Promise<WorkflowRunResult> {
+  const response = await request({
+    connectionId: DATADOG_HTTP_CONNECTION_ID,
+    inputs: {
+      verb: "POST",
+      url: workflowInstancesUrl(workflowId),
+      requestHeaders: jsonHeaders,
+      responseParsing: "json",
+      errorOnStatus: ["400-599"],
+      body: JSON.stringify({
+        meta: {
+          payload,
+        },
+      }),
+    },
+  });
+
+  return toRunResult(response.body);
+}
+
+export async function pollWorkflowInstance(
+  workflowId: string,
+  instanceId: string,
+  { timeoutMs = DEFAULT_POLL_TIMEOUT_MS }: PollWorkflowOptions = {},
+): Promise<WorkflowRunResult> {
+  const expiresAt = Date.now() + timeoutMs;
+  const sleepWithBackoff = createSleepWithExponentialBackoff(
+    INITIAL_POLL_DELAY_MS,
+    POLL_DELAY_MULTIPLIER,
+  );
+
+  while (Date.now() < expiresAt) {
+    await sleepWithBackoff();
+
+    const response = await request({
+      connectionId: DATADOG_HTTP_CONNECTION_ID,
+      inputs: {
+        verb: "GET",
+        url: `${workflowInstancesUrl(workflowId)}/${instanceId}`,
+        requestHeaders: jsonHeaders,
+        responseParsing: "json",
+        errorOnStatus: ["400-599"],
+      },
+    });
+
+    const result = toRunResult(response.body);
+
+    if (!isRunningStatus(result.statusKind)) {
+      return result;
+    }
+
+  }
+
+  throw new Error(`Workflow instance ${instanceId} did not finish in time`);
+}
+```
+
+Treat `statusKind === "SUCCEEDED"` as success. Treat `INSTANCE_ERROR`, `STEP_ERROR`, `CANCELED`, and other non-running statuses as terminal failures, and return or log the full response body so the caller can inspect `errorDetail`, `stepStateAssociations`, and any partial outputs.
+
+The polling loop mirrors App Builder's async query polling pattern: it waits `250ms` before the first poll, grows by multiplier `1.05`, and applies random plus or minus 20% jitter to avoid synchronized polling. Waiting before the first poll also avoids transient `INSTANCE_NOT_FOUND` responses immediately after a successful trigger. The default `120s` timeout follows App Builder's default frontend timeout pattern.
+
+If a polling request fails, surface the error or response body to the caller. Do not replace it with a generic polling failure because the workflow instance body often contains the useful `errorDetail`.
+
+`data.attributes.outputs` may be present after a successful run, but the full response body is the source of truth.
+
+## Troubleshooting
+
+- `input parameter "<name>" not in workflow input schema`: update `meta.payload` keys to match `attributes.spec.inputSchema.parameters`.
+- `Expected trigger type TRIGGER_TYPE_API not found`: add and publish an API trigger on the workflow.
+- 401, 403, or missing authentication errors: confirm `DD_API_KEY` and `DD_APP_KEY` are exported, the app key has Actions API Access, and the app's Datadog site matches the API host and connection.
+- Empty or missing outputs: inspect the full workflow instance response and the workflow's `outputSchema`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ macro_rules! skill {
     };
 }
 
+pub static DD_APPS_SUB_SKILLS: &[(&str, &str)] = &[
+    ("datadog-app/SKILL.md", skill!("dd-apps/datadog-app/SKILL.md")),
+];
+
 pub const DD_APM_SKILL: &str = skill!("dd-apm/SKILL.md");
 
 pub static DD_APM_SUB_SKILLS: &[(&str, &str)] = &[


### PR DESCRIPTION
## What does this PR do?

Updates the \`datadog-app\` skill to reflect that Datadog Apps now support OAuth as the default authentication method for local development. API keys remain supported as a fallback for CI and headless environments.

## Changes

- **\`getting-started.md\`** — Rewrites the credentials section to lead with OAuth ("just run \`npm run dev\`"), with API keys as an explicitly labelled fallback
- **\`build-deploy-publish.md\`** — Adds OAuth and API key sections to the deploy flow; OAuth for local, API keys for CI
- **\`troubleshooting.md\`** — Adds an OAuth troubleshooting subsection (browser didn't open, token expired, how to fall back to API keys); updates credential error guidance for both flows
- **\`SKILL.md\`** — Updates description and routing table to include OAuth setup and troubleshooting as trigger phrases

## Context

Newly scaffolded apps (\`npm create @datadog/apps@latest\`) auto-detect whether API keys are present and fall back to OAuth if not — the vite plugin opens a browser window, the developer authenticates via Datadog login, and the token is cached in the system keyring. The old skill only documented the API key path, which would confuse developers who scaffolded a new app and ran \`npm run dev\` without setting up keys.