### PR TITLE
Add agent-observability-auto-experiment skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ npx skills add datadog-labs/agent-skills \
   --skill agent-observability-eval-bootstrap \
   --skill agent-observability-eval-pipeline \
   --skill agent-observability-session-classify \
+  --skill agent-observability-auto-experiment \
   --skill k9-ownership-byod-setup \
   --full-depth -y
 ```
 
 ### Agent Observability (LLMO)
 
-The `agent-observability` directory contains six skills for working with Agent Observability data:
+The `agent-observability` directory contains seven skills for working with Agent Observability data:
 
 | Skill | Purpose |
 |-------|---------|
@@ -94,6 +95,7 @@ The `agent-observability` directory contains six skills for working with Agent O
 | `agent-observability-eval-bootstrap` | Generate evaluator code from traces, optionally seeded by RCA output. Also emits a dataset from traces in `--emit-dataset` mode. |
 | `agent-observability-eval-pipeline` | Eight-phase pipeline: classify → RCA → bootstrap evaluators → create dataset → publish → generate experiment → run → analyze. Stop early with `--stop-after`. |
 | `agent-observability-session-classify` | Classify whether user intent was satisfied in a session (trace + RUM signals) |
+| `agent-observability-auto-experiment` | Local hill-climb: baseline-eval a prompt/file against LLM-Obs data, make one focused change, re-score with the same harness, keep it only if it beats the best, repeat |
 
 **Eval pipeline flow:**
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -47,6 +47,8 @@ the run's state + audit trail):
   "goal": "...", "evaluators": "...", "ml_app": "...",
   "dataset_id": "...", "trace_ids": [...],
   "max_iterations": 2,
+  "reps": 3,
+  "min_delta": 0.02,
   "iteration_results": [],
   "final_result": {}
 }
@@ -89,8 +91,10 @@ Copy `references/eval_harness_template.py` to `.auto_experiment/eval_harness.py`
 `generate_output` (run the REAL code under test from `files_to_optimize`) and `judge` (a REAL
 LLM-as-judge, judge-selection order in the rubric). **No score literals anywhere.**
 
-Run it against the **original, unmodified** code. `before_score` = the printed mean over scoreable
-lines. It is a computed number, never a literal — obey the scoring policy.
+Run it against the **original, unmodified** code with `AUTO_EXP_REPS` (= config `reps`, default 3):
+the harness re-runs the whole eval R times and prints `{mean, stdev, rep_means, ...}`.
+`before_score` = the printed `mean`; also record `stdev` (the noise floor). Both computed numbers,
+never literals — obey the scoring policy and the **Noise & keep/discard policy** in the rubric.
 
 Commit `eval_harness.py`, `data.jsonl`, `eval_results.jsonl`.
 
@@ -104,9 +108,11 @@ code. `after_score` = the new printed mean. Re-write `eval_results.jsonl`. Write
 (schema in the rubric) to `.auto_experiment/result.json` and commit it **in the same commit** as
 the change. `delta = after_score - before_score`.
 
-Decide `is_best` per the optimization direction in `goal`. If iteration 1 improved on the
-baseline, it becomes the best (`best_sha` = this commit, `best_score` = after_score). Append the
-row to `config.json` `iteration_results`.
+Decide `is_best` per the optimization direction in `goal` **and the Noise & keep/discard policy**:
+keep only if `|after_score − before_score| > max(pooled_stdev, min_delta)`. A within-noise gain is
+`is_best: false` (discarded), not kept. If iteration 1 clears the band, it becomes the best
+(`best_sha` = this commit, `best_score` = after_score). Append the row to `config.json`
+`iteration_results`.
 
 Then report this iteration's score to LLM-Obs (tag `iteration:1`) — see **Report each iteration's
 score to LLM-Obs**.
@@ -127,8 +133,10 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
 4. Make **ONE new change, different from every previous attempt** (you can see prior attempts in
    `iteration_results`). Commit it.
 5. Re-run the SAME harness → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
-6. **Keep or discard**: if `is_best` (beats the best per the goal direction) → update
-   `best_sha`/`best_score`, decision `kept`. Else `discarded`. Append the row.
+6. **Keep or discard**: keep only if the delta clears the noise band (`|after_score − before_score|
+   > max(pooled_stdev, min_delta)`, per the Noise policy) in the goal's direction → update
+   `best_sha`/`best_score`, decision `kept`. A within-noise gain or a regression → `discarded`.
+   Append the row.
 7. Report this iteration's score to LLM-Obs (tag `iteration:<n>`) — see **Report each iteration's
    score to LLM-Obs**.
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -82,11 +82,13 @@ is out of scope, say so (that's a finding) — do not silently tweak in-scope-bu
    invoked — read it, don't ask the user). See **Report each iteration's score to LLM-Obs**.
 5. **Record the run context on the experiment before iterations start.** Call
    `update_llmobs_experiment` once with `experiment_id` = `$DD_AUTO_EXPERIMENT_ID` (skip if unset)
-   and `metadata` set to a JSON struct containing the repo name and the scratch branch name, e.g.
-   `{"repo": "<repo>", "branch": "<scratch-branch>"}`. Derive `repo` from the git remote
-   (`basename -s .git $(git remote get-url origin)`, or `owner/repo`) and `branch` from the branch
-   created in step 2. `metadata` **replaces** existing metadata, so include both keys in the one
-   call. Do this in Setup, before Step 1.
+   and `metadata` set to a JSON struct containing the repo name, the scratch branch name, and the
+   model running this skill, e.g.
+   `{"repo": "<repo>", "branch": "<scratch-branch>", "model": "<model>"}`. Derive `repo` from the
+   git remote (`basename -s .git $(git remote get-url origin)`, or `owner/repo`), `branch` from the
+   branch created in step 2, and `model` = the `provider/model-id` of the model/agent driving this
+   session (e.g. `openai/gpt-4-turbo`, `anthropic/claude-opus-4-8`). `metadata` **replaces**
+   existing metadata, so include all three keys in the one call. Do this in Setup, before Step 1.
 
 ## Execution model — orchestrator + fresh per-iteration sub-agents
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -237,8 +237,14 @@ Rules:
 ## Stop conditions & guards
 
 - Stop when `iteration == max_iterations`.
+- **Plateau within noise — stop early.** If the last **3** iterations all landed `discarded`
+  *within the noise band* (no delta cleared `max(pooled_stdev, min_delta)`), stop and report the
+  current best with `stop_reason: "plateau (deltas within noise)"`. Continuing past a noise plateau
+  just burns budget generating within-noise wiggle; escalate instead (a new census bucket, a
+  different dimension, or accept the ceiling). Distinguish this from a real regression streak.
 - **A change with no computable score is `no_change`, never a fabricated number** (harness won't
-  run / no new commit / judge unreachable). Record the blocker in `reasoning`.
+  run / no new commit / judge unreachable / feasibility probe reached 0). Record the blocker in
+  `reasoning`.
 - Track consecutive `no_change` iterations; after **5 in a row**, stop early and report the best
   result so far with a stop reason (do not keep burning iterations).
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -103,9 +103,16 @@ never literals — obey the scoring policy and the **Noise & keep/discard policy
 
 Commit `eval_harness.py`, `data.jsonl`, `data.val.jsonl`, `data.test.jsonl`, `eval_results.jsonl`.
 
+### Step 2.5 — Census the baseline failures
+Before changing anything, decompose **where the baseline loses** per the rubric's **Baseline
+failure census**: bucket every failing datapoint by root cause, write `.auto_experiment/census.json`,
+commit it, and surface the ranked buckets. This tells you which lever is worth pulling — and whether
+the dominant failure mode is even reachable by editing `files_to_optimize`.
+
 ### Step 3 — Improve
-Read `files_to_optimize`. Make **ONE focused change** toward `goal`. Commit it on the scratch
-branch with a message explaining what changed and why.
+Read `files_to_optimize`. Make **ONE focused change** toward `goal`, aimed at the **largest census
+bucket you can plausibly move** (name that bucket in the iteration's `reasoning`). Commit it on the
+scratch branch with a message explaining what changed and why.
 
 ### Step 4 — Compute AFTER (re-run the SAME harness)
 Re-run `.auto_experiment/eval_harness.py` (same `evaluate_line`, same data) against the changed
@@ -136,7 +143,7 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
    nothing kept yet). Do NOT re-run the baseline.
 3. Reuse the data from `data.jsonl` and the committed `eval_harness.py` — do not reload or rebuild.
 4. Make **ONE new change, different from every previous attempt** (you can see prior attempts in
-   `iteration_results`). Commit it.
+   `iteration_results`), aimed at a named `census.json` bucket. Commit it.
 5. Re-run the SAME harness → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
 6. **Keep or discard**: keep only if the delta clears the noise band (`|after_score − before_score|
    > max(pooled_stdev, min_delta)`, per the Noise policy) in the goal's direction → update

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -86,6 +86,11 @@ Extract input/output per the **messages-source guidance** in `references/rubrics
 **data-selection guidance**: keep only traces with a scoreable target span; exclude infra/setup
 spans from the set entirely.
 
+Then **split once, deterministically** (hash of datapoint id, ~70/30) into
+`.auto_experiment/data.val.jsonl` (the hill-climb gate) and `.auto_experiment/data.test.jsonl`
+(held out) — see the rubric's **Held-out split**. Every iteration scores on `val`
+(`AUTO_EXP_DATA=.auto_experiment/data.val.jsonl`); `test` is run only in the final report.
+
 ### Step 2 — Build the harness and compute BEFORE (baseline)
 Copy `references/eval_harness_template.py` to `.auto_experiment/eval_harness.py` and fill in
 `generate_output` (run the REAL code under test from `files_to_optimize`) and `judge` (a REAL
@@ -96,7 +101,7 @@ the harness re-runs the whole eval R times and prints `{mean, stdev, rep_means, 
 `before_score` = the printed `mean`; also record `stdev` (the noise floor). Both computed numbers,
 never literals — obey the scoring policy and the **Noise & keep/discard policy** in the rubric.
 
-Commit `eval_harness.py`, `data.jsonl`, `eval_results.jsonl`.
+Commit `eval_harness.py`, `data.jsonl`, `data.val.jsonl`, `data.test.jsonl`, `eval_results.jsonl`.
 
 ### Step 3 — Improve
 Read `files_to_optimize`. Make **ONE focused change** toward `goal`. Commit it on the scratch
@@ -205,10 +210,16 @@ Rules:
    `{ "baseline_score", "best_score", "best_iteration", "best_sha", "iterations_run",
    "stop_reason", "reasoning" }` (reasoning = what was tried across all iterations, what worked,
    what didn't, why the winner won).
-2. Print a per-iteration table (iteration, delta, decision, sha) and name the best commit.
-3. **If nothing beat the baseline**: report the baseline as the best result and leave the original
-   code in place (`best_sha` empty). Do not fabricate an improvement.
-4. Tell the user the scratch branch + best commit so they can open a PR from it if they want.
+2. **Held-out `test` comparison (the real headline).** Run the harness once on the **baseline**
+   commit and once on the **best** commit against `.auto_experiment/data.test.jsonl`
+   (`AUTO_EXP_DATA=.auto_experiment/data.test.jsonl`), both at `reps` reps. Report the
+   baseline-vs-best `test` delta with its noise band as the run's result — the `val` hill-climb
+   gain is not the headline. If `test` did not clear the noise band even though `val` did, say so
+   explicitly (the win did not generalize) and treat baseline as best.
+3. Print a per-iteration table (iteration, val delta, decision, sha) and name the best commit.
+4. **If nothing beat the baseline on `test`**: report the baseline as the best result and leave the
+   original code in place (`best_sha` empty). Do not fabricate an improvement.
+5. Tell the user the scratch branch + best commit so they can open a PR from it if they want.
 
 ## Notes
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -151,7 +151,7 @@ Commit `eval_harness.py`, `data.jsonl`, `data.val.jsonl`, `data.test.jsonl`, `ev
 Then **report the baseline to LLM-Obs as iteration 0** — before you start the first iteration.
 Submit exactly one eval-metric datapoint with `score_value` = `before_score` and tags
 `["iteration:0", "git.commit.sha:<baseline_commit_sha>", "decision:baseline"]` (the sha is the
-commit you just made). Same call shape and rules as **Report each iteration's score to LLM-Obs**;
+**full 40-character** hash of the commit you just made — `git rev-parse HEAD`, not a short hash). Same call shape and rules as **Report each iteration's score to LLM-Obs**;
 this is the only submission with `iteration:0` and `decision:baseline`.
 
 ### Step 2.5 — Census the baseline failures
@@ -239,8 +239,10 @@ Call `submit_llmobs_experiment_events` with a single metric shaped exactly like 
   - `timestamp_ms`: the current wall-clock time as an epoch timestamp in **milliseconds**.
   - `tags`: `["iteration:<n>", "git.commit.sha:<sha>", "decision:<decision>"]`, where `<n>` is this
     iteration's number (`1` for the first improvement, `2` for the next, and so on), `<sha>` is the
-    full Git commit SHA of the commit this iteration created for its change (i.e. `git rev-parse
-    HEAD` after committing the iteration), and `<decision>` is this iteration's keep/discard
+    **full 40-character** Git commit SHA of the commit this iteration created for its change — the
+    complete hash from `git rev-parse HEAD` after committing the iteration (e.g.
+    `fd0fbab7c1232e125df7b22d9df856a2ef73ab65`), **never the abbreviated 7/8-char short hash** — and
+    `<decision>` is this iteration's keep/discard
     decision recorded in `iteration_results` (`kept` or `discarded`; `baseline` for iteration 0).
   - `reasoning`: this iteration's `reasoning` string from `iteration_results` — what was tried,
     which census bucket it targeted, and why it was kept or discarded (for iteration 0, that it is

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -113,8 +113,10 @@ Then **split once, deterministically** (hash of datapoint id, ~70/30) into
 
 ### Step 2 — Build the harness and compute BEFORE (baseline)
 Copy `references/eval_harness_template.py` to `.auto_experiment/eval_harness.py` and fill in
-`generate_output` (run the REAL code under test from `files_to_optimize`) and `judge` (a REAL
-LLM-as-judge, judge-selection order in the rubric). **No score literals anywhere.**
+`generate_output` (run the REAL code under test from `files_to_optimize`) and `judge`. **Prefer a
+deterministic ground-truth metric** (reference output / programmatic checker / pipeline count) and
+use an LLM-as-judge only when no ground truth exists — see the rubric's **Metric selection**. **No
+score literals anywhere.**
 
 Run it against the **original, unmodified** code with `AUTO_EXP_REPS` (= config `reps`, default 3):
 the harness re-runs the whole eval R times and prints `{mean, stdev, rep_means, ...}`.

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -223,10 +223,11 @@ Call `submit_llmobs_experiment_events` with a single metric shaped exactly like 
   - `score_value`: the score this iteration produced (`after_score`) — the number computed by the
     harness, never a literal or a rounded-for-display value.
   - `timestamp_ms`: the current wall-clock time as an epoch timestamp in **milliseconds**.
-  - `tags`: `["iteration:<n>", "git.commit.sha:<sha>"]`, where `<n>` is this iteration's number
-    (`1` for the first improvement, `2` for the next, and so on) and `<sha>` is the full Git
-    commit SHA of the commit this iteration created for its change (i.e. `git rev-parse HEAD`
-    after committing the iteration).
+  - `tags`: `["iteration:<n>", "git.commit.sha:<sha>", "decision:<decision>"]`, where `<n>` is this
+    iteration's number (`1` for the first improvement, `2` for the next, and so on), `<sha>` is the
+    full Git commit SHA of the commit this iteration created for its change (i.e. `git rev-parse
+    HEAD` after committing the iteration), and `<decision>` is this iteration's keep/discard
+    decision recorded in `iteration_results` (`kept` or `discarded`).
   - Do **not** include `span_id`, `categorical_value`, or `boolean_value`.
 
 Example arguments for iteration 5 whose harness computed a score of `0.72`:
@@ -240,7 +241,7 @@ Example arguments for iteration 5 whose harness computed a score of `0.72`:
       "metric_type": "score",
       "score_value": 0.72,
       "timestamp_ms": 1752430000000,
-      "tags": ["iteration:5", "git.commit.sha:33ec6e0959bd46b0ea9c337cf6a28a763d3eeb0a"]
+      "tags": ["iteration:5", "git.commit.sha:33ec6e0959bd46b0ea9c337cf6a28a763d3eeb0a", "decision:kept"]
     }
   ]
 }

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -60,6 +60,9 @@ the run's state + audit trail):
    best commit at the end.
 3. Write `.auto_experiment/config.json`. Add `.auto_experiment/` output files to nothing special
    — they are committed on purpose (they are the audit trail).
+4. This run reports one score per iteration to the LLM-Obs experiment identified by the
+   `DD_AUTO_EXPERIMENT_ID` environment variable (set in the environment before this skill is
+   invoked — read it, don't ask the user). See **Report each iteration's score to LLM-Obs**.
 
 ## Iteration 1 — baseline + first improvement
 
@@ -105,6 +108,9 @@ Decide `is_best` per the optimization direction in `goal`. If iteration 1 improv
 baseline, it becomes the best (`best_sha` = this commit, `best_score` = after_score). Append the
 row to `config.json` `iteration_results`.
 
+Then report this iteration's score to LLM-Obs (tag `iteration:1`) — see **Report each iteration's
+score to LLM-Obs**.
+
 ## Iterations 2+ — hill climb
 
 Mirrors `build_followup_prompt`. Baseline is already known — **do not recompute it**.
@@ -123,6 +129,59 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
 5. Re-run the SAME harness → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
 6. **Keep or discard**: if `is_best` (beats the best per the goal direction) → update
    `best_sha`/`best_score`, decision `kept`. Else `discarded`. Append the row.
+7. Report this iteration's score to LLM-Obs (tag `iteration:<n>`) — see **Report each iteration's
+   score to LLM-Obs**.
+
+## Report each iteration's score to LLM-Obs (every scored iteration)
+
+Once you have a computed score for an iteration, submit **exactly one** eval-metric datapoint to
+LLM-Obs with the `submit_llmobs_experiment_events` MCP tool. Do this once per iteration, right
+after the score is computed and the iteration's commit / `result.json` is written — including
+iteration 1.
+
+Call `submit_llmobs_experiment_events` with a single metric shaped exactly like this:
+
+- `experiment_id`: the value of the `DD_AUTO_EXPERIMENT_ID` environment variable (read it from the
+  environment; do not ask the user and do not invent one). If it is unset or empty, skip the
+  submission and note that in the iteration `reasoning`.
+- `metrics`: an array containing exactly one object with these fields and no others:
+  - `label`: always the literal string `auto_experiment_score`.
+  - `metric_type`: `score`.
+  - `score_value`: the score this iteration produced (`after_score`) — the number computed by the
+    harness, never a literal or a rounded-for-display value.
+  - `timestamp_ms`: the current wall-clock time as an epoch timestamp in **milliseconds**.
+  - `tags`: `["iteration:<n>", "git.commit.sha:<sha>"]`, where `<n>` is this iteration's number
+    (`1` for the first improvement, `2` for the next, and so on) and `<sha>` is the full Git
+    commit SHA of the commit this iteration created for its change (i.e. `git rev-parse HEAD`
+    after committing the iteration).
+  - Do **not** include `span_id`, `categorical_value`, or `boolean_value`.
+
+Example arguments for iteration 5 whose harness computed a score of `0.72`:
+
+```json
+{
+  "experiment_id": "<value of $DD_AUTO_EXPERIMENT_ID>",
+  "metrics": [
+    {
+      "label": "auto_experiment_score",
+      "metric_type": "score",
+      "score_value": 0.72,
+      "timestamp_ms": 1752430000000,
+      "tags": ["iteration:5", "git.commit.sha:33ec6e0959bd46b0ea9c337cf6a28a763d3eeb0a"]
+    }
+  ]
+}
+```
+
+Rules:
+
+- **Exactly one metric per iteration.** Never submit more than one metric for the same iteration
+  and never batch several iterations into one call.
+- **Only for scored iterations.** A `no_change` iteration has no computed score, so there is no
+  `score_value` to send — skip the submission for it (emitting a `score` metric without a real
+  score would violate the scoring policy). Record the skip in `reasoning`.
+- The value you submit is the same computed `after_score` recorded in `result.json`; the two must
+  always agree.
 
 ## Stop conditions & guards
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -66,6 +66,26 @@ the run's state + audit trail):
    `DD_AUTO_EXPERIMENT_ID` environment variable (set in the environment before this skill is
    invoked — read it, don't ask the user). See **Report each iteration's score to LLM-Obs**.
 
+## Execution model — orchestrator + fresh per-iteration sub-agents
+
+Split the two roles so context stays clean and iterations don't anchor on each other:
+
+- **You are the orchestrator.** You own the durable state (`config.json`, `census.json`, `best_sha`,
+  the branch), the harness, and every keep/discard decision. You do NOT accumulate the raw work of
+  each attempt in your own context.
+- **Each improvement iteration runs in a FRESH sub-agent** (spawn via the Agent tool). Hand it a
+  compact briefing — not your whole transcript: the `goal`/`evaluators`, `files_to_optimize`, the
+  ranked `census.json` buckets (+ the bucket to target this iteration), the current `best_sha`, and
+  **one-line summaries of prior attempts** (what was tried → kept/discarded, from `iteration_results`)
+  so it won't repeat them. Its job: make ONE change + return a short summary (what it changed, which
+  bucket, feasibility-probe result). You (orchestrator) run the harness, apply the noise gate +
+  mechanism audit, commit/keep/discard, and update state.
+- **Why:** a fresh bounded context per iteration avoids anchoring on dead ideas and stops the
+  orchestrator's context from bloating over a long run — the same reason the production loop spawns a
+  new `claude --print` per iteration instead of one long-lived agent. If sub-agents are unavailable,
+  emulate it: before each iteration, re-read only the briefing above and deliberately ignore the
+  narrative of previous attempts beyond their one-line outcomes.
+
 ## Iteration 1 — baseline + first improvement
 
 Mirrors `build_initial_prompt`. Four steps, in order.

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -242,6 +242,9 @@ Call `submit_llmobs_experiment_events` with a single metric shaped exactly like 
     full Git commit SHA of the commit this iteration created for its change (i.e. `git rev-parse
     HEAD` after committing the iteration), and `<decision>` is this iteration's keep/discard
     decision recorded in `iteration_results` (`kept` or `discarded`; `baseline` for iteration 0).
+  - `reasoning`: this iteration's `reasoning` string from `iteration_results` — what was tried,
+    which census bucket it targeted, and why it was kept or discarded (for iteration 0, that it is
+    the baseline). Use the same text recorded in `result.json`; do not fabricate.
   - Do **not** include `span_id`, `categorical_value`, or `boolean_value`.
 
 Example arguments for iteration 5 whose harness computed a score of `0.72`:
@@ -254,6 +257,7 @@ Example arguments for iteration 5 whose harness computed a score of `0.72`:
       "label": "auto_experiment_score",
       "metric_type": "score",
       "score_value": 0.72,
+      "reasoning": "Rewrote the retrieval query builder to include entity synonyms (targeting the 'missed-retrieval' census bucket); cleared the noise band and passed the mechanism audit, so kept.",
       "timestamp_ms": 1752430000000,
       "tags": ["iteration:5", "git.commit.sha:33ec6e0959bd46b0ea9c337cf6a28a763d3eeb0a", "decision:kept"]
     }

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -29,7 +29,7 @@ working directory.
 
 | Field | Meaning | Default |
 |---|---|---|
-| `files_to_optimize` | file(s) whose code you change each iteration | **required** |
+| `files_to_optimize` | the **edit scope**: one or more files, a **folder**, or globs. **Any code inside the scope is fair game to modify** — tool/retrieval code, the pipeline, config, data-shaping, or prompts — not just prompt wording. Everything outside the scope is off-limits. | **required** |
 | `goal` | what "better" means; the judge rubric + optimization direction | **required** |
 | `evaluators` | explicit evaluator/rubric text, if any | falls back to `goal` |
 | `model` | judge model id | **the Claude model selected in this session** (see rubric) |
@@ -54,9 +54,24 @@ the run's state + audit trail):
 }
 ```
 
+## Scope — optimize the whole selected surface, not just the prompt
+
+`files_to_optimize` is a **scope**, not a prompt pointer. It may be a set of files, a directory, or
+globs — expand a directory to its editable files (e.g. every `*.py` under it) and treat **all of
+them as the code under test**. Within that scope you may change **anything that moves the metric**:
+retrieval/tool code, request logic, filtering, output shape, ranking, config, or prompts. Let the
+**failure census** decide *which* file the lever lives in — do **not** default to rewording a
+prompt. In practice the biggest wins are often in tool/retrieval code (what the model can fetch),
+not prompt phrasing; a prompt-only search finds nothing when the headroom is in the tools.
+
+**Hard scope guard:** never edit a file outside `files_to_optimize`. If the census's dominant lever
+is out of scope, say so (that's a finding) — do not silently tweak in-scope-but-irrelevant files.
+
 ## Setup
 
 1. Confirm a clean-ish working tree (stash or warn on unrelated changes). Note the starting SHA.
+   If `files_to_optimize` names a folder/globs, resolve it to the concrete editable file list and
+   record that list in `config.json` (it is the scope for every iteration + the restore boundary).
 2. Create a scratch branch off `base_branch` for the experiment (e.g.
    `auto-experiment/<short-goal>`). All iteration commits land here; the user reviews/keeps the
    best commit at the end.
@@ -74,7 +89,8 @@ Split the two roles so context stays clean and iterations don't anchor on each o
   the branch), the harness, and every keep/discard decision. You do NOT accumulate the raw work of
   each attempt in your own context.
 - **Each improvement iteration runs in a FRESH sub-agent** (spawn via the Agent tool). Hand it a
-  compact briefing — not your whole transcript: the `goal`/`evaluators`, `files_to_optimize`, the
+  compact briefing — not your whole transcript: the `goal`/`evaluators`, the full editable **scope**
+  (`files_to_optimize` expanded — it may change ANY file in scope, not just a prompt), the
   ranked `census.json` buckets (+ the bucket to target this iteration), the current `best_sha`, and
   **one-line summaries of prior attempts** (what was tried → kept/discarded, from `iteration_results`)
   so it won't repeat them. Its job: make ONE change + return a short summary (what it changed, which
@@ -132,9 +148,12 @@ commit it, and surface the ranked buckets. This tells you which lever is worth p
 the dominant failure mode is even reachable by editing `files_to_optimize`.
 
 ### Step 3 — Improve
-Read `files_to_optimize`. Make **ONE focused change** toward `goal`, aimed at the **largest census
-bucket you can plausibly move** (name that bucket in the iteration's `reasoning`). Commit it on the
-scratch branch with a message explaining what changed and why.
+Read the whole scope (`files_to_optimize`, expanded). Make **ONE focused change** toward `goal`,
+aimed at the **largest census bucket you can plausibly move** (name that bucket in the iteration's
+`reasoning`), **in whichever in-scope file holds the lever** — edit the tool/retrieval code if the
+census says the misses are retrieval, the output/format code if they're formatting, and so on. Do
+**not** default to rewording a prompt when the lever is elsewhere. Commit it on the scratch branch
+with a message explaining what changed and why.
 
 Before the (expensive) full eval, run a **feasibility probe** per the rubric's **Feasibility probe**:
 the cheapest offline check that this change *could* move a failing census bucket. If the probe
@@ -172,7 +191,8 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
    nothing kept yet). Do NOT re-run the baseline.
 3. Reuse the data from `data.jsonl` and the committed `eval_harness.py` — do not reload or rebuild.
 4. Make **ONE new change, different from every previous attempt** (you can see prior attempts in
-   `iteration_results`), aimed at a named `census.json` bucket. Commit it.
+   `iteration_results`), aimed at a named `census.json` bucket, **in whichever in-scope file holds
+   the lever** (tool/retrieval/pipeline/config/prompt — not prompt-only). Commit it.
 5. **Feasibility probe first** (rubric): cheap offline check the change can move its target bucket;
    if it reaches 0 failing datapoints, record `no_change` and skip the full eval. Otherwise re-run
    the SAME harness on `val` → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -32,6 +32,7 @@ working directory.
 | `files_to_optimize` | file(s) whose code you change each iteration | **required** |
 | `goal` | what "better" means; the judge rubric + optimization direction | **required** |
 | `evaluators` | explicit evaluator/rubric text, if any | falls back to `goal` |
+| `model` | judge model id | **the Claude model selected in this session** (see rubric) |
 | `ml_app` | Datadog LLM-Obs app to pull traces from | required unless `dataset_id`/`trace_ids` given |
 | data source | `dataset_id` \| `trace_ids` \| recent traces for `ml_app` | see priority below |
 | `max_iterations` | how many changes to try (clamp **1–50**) | **2** |

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -80,6 +80,13 @@ is out of scope, say so (that's a finding) — do not silently tweak in-scope-bu
 4. This run reports one score per iteration to the LLM-Obs experiment identified by the
    `DD_AUTO_EXPERIMENT_ID` environment variable (set in the environment before this skill is
    invoked — read it, don't ask the user). See **Report each iteration's score to LLM-Obs**.
+5. **Record the run context on the experiment before iterations start.** Call
+   `update_llmobs_experiment` once with `experiment_id` = `$DD_AUTO_EXPERIMENT_ID` (skip if unset)
+   and `metadata` set to a JSON struct containing the repo name and the scratch branch name, e.g.
+   `{"repo": "<repo>", "branch": "<scratch-branch>"}`. Derive `repo` from the git remote
+   (`basename -s .git $(git remote get-url origin)`, or `owner/repo`) and `branch` from the branch
+   created in step 2. `metadata` **replaces** existing metadata, so include both keys in the one
+   call. Do this in Setup, before Step 1.
 
 ## Execution model — orchestrator + fresh per-iteration sub-agents
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -127,9 +127,11 @@ the change. `delta = after_score - before_score`.
 
 Decide `is_best` per the optimization direction in `goal` **and the Noise & keep/discard policy**:
 keep only if `|after_score − before_score| > max(pooled_stdev, min_delta)`. A within-noise gain is
-`is_best: false` (discarded), not kept. If iteration 1 clears the band, it becomes the best
-(`best_sha` = this commit, `best_score` = after_score). Append the row to `config.json`
-`iteration_results`.
+`is_best: false` (discarded), not kept. If the band is cleared, run the **Mechanism audit** (rubric)
+— diff this iteration's `eval_results.jsonl` against the baseline's (same-count denominator; the
+gain comes from datapoints the change touched) before keeping. If iteration 1 clears the band AND
+passes the audit, it becomes the best (`best_sha` = this commit, `best_score` = after_score). Append
+the row to `config.json` `iteration_results`.
 
 Then report this iteration's score to LLM-Obs (tag `iteration:1`) — see **Report each iteration's
 score to LLM-Obs**.
@@ -153,9 +155,11 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
    if it reaches 0 failing datapoints, record `no_change` and skip the full eval. Otherwise re-run
    the SAME harness on `val` → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
 6. **Keep or discard**: keep only if the delta clears the noise band (`|after_score − before_score|
-   > max(pooled_stdev, min_delta)`, per the Noise policy) in the goal's direction → update
-   `best_sha`/`best_score`, decision `kept`. A within-noise gain or a regression → `discarded`.
-   Append the row.
+   > max(pooled_stdev, min_delta)`, per the Noise policy) in the goal's direction **and passes the
+   Mechanism audit** (rubric) — diff `eval_results.jsonl` vs the best commit's
+   (`git show <best_sha>:.auto_experiment/eval_results.jsonl`); same denominator, gain from
+   datapoints the change touched. Then → update `best_sha`/`best_score`, decision `kept`. A
+   within-noise gain, a denominator artifact, or a regression → `discarded`. Append the row.
 7. Report this iteration's score to LLM-Obs (tag `iteration:<n>`) — see **Report each iteration's
    score to LLM-Obs**.
 

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -141,6 +141,12 @@ never literals — obey the scoring policy and the **Noise & keep/discard policy
 
 Commit `eval_harness.py`, `data.jsonl`, `data.val.jsonl`, `data.test.jsonl`, `eval_results.jsonl`.
 
+Then **report the baseline to LLM-Obs as iteration 0** — before you start the first iteration.
+Submit exactly one eval-metric datapoint with `score_value` = `before_score` and tags
+`["iteration:0", "git.commit.sha:<baseline_commit_sha>", "decision:baseline"]` (the sha is the
+commit you just made). Same call shape and rules as **Report each iteration's score to LLM-Obs**;
+this is the only submission with `iteration:0` and `decision:baseline`.
+
 ### Step 2.5 — Census the baseline failures
 Before changing anything, decompose **where the baseline loses** per the rubric's **Baseline
 failure census**: bucket every failing datapoint by root cause, write `.auto_experiment/census.json`,
@@ -210,7 +216,8 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
 Once you have a computed score for an iteration, submit **exactly one** eval-metric datapoint to
 LLM-Obs with the `submit_llmobs_experiment_events` MCP tool. Do this once per iteration, right
 after the score is computed and the iteration's commit / `result.json` is written — including
-iteration 1.
+iteration 1 and the **iteration-0 baseline** (see Step 2; there `score_value` = `before_score` and
+the decision tag is `decision:baseline`).
 
 Call `submit_llmobs_experiment_events` with a single metric shaped exactly like this:
 
@@ -227,7 +234,7 @@ Call `submit_llmobs_experiment_events` with a single metric shaped exactly like 
     iteration's number (`1` for the first improvement, `2` for the next, and so on), `<sha>` is the
     full Git commit SHA of the commit this iteration created for its change (i.e. `git rev-parse
     HEAD` after committing the iteration), and `<decision>` is this iteration's keep/discard
-    decision recorded in `iteration_results` (`kept` or `discarded`).
+    decision recorded in `iteration_results` (`kept` or `discarded`; `baseline` for iteration 0).
   - Do **not** include `span_id`, `categorical_value`, or `boolean_value`.
 
 Example arguments for iteration 5 whose harness computed a score of `0.72`:

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: agent-observability-auto-experiment
+description: >-
+  Run an iterative code-improvement hill-climb against real Datadog LLM-Obs data, locally, with
+  Claude Code as the agent. Establishes a baseline eval, makes one focused change, re-scores with
+  the same harness, keeps the change only if it beats the best, and repeats. Use when the user
+  says "run an auto experiment", "hill-climb this code", "iteratively improve X and measure the
+  delta", "optimize this prompt/file against my traces", "auto-optimize against LLM-Obs", or wants
+  the local equivalent of the auto_experiments worker. Works from an ml_app, a dataset_id, or a
+  list of trace_ids.
+---
+
+# auto-experiment — local hill-climb improvement loop
+
+This is the local, Claude-Code-driven version of the `auto_experiments` Temporal/Atlas worker
+(`domains/ml_observability/apps/apis/auto_experiments/`). There, a remote Bits/Code-Gen agent runs
+the loop; **here YOU (Claude Code) are the agent** and run it directly on the current git checkout.
+No Temporal, no Code-Gen API — just git commits, a local eval harness, and Datadog LLM-Obs MCP
+tools for the data.
+
+**Read `references/rubrics.md` in full before iteration 1 and keep it in mind every iteration.**
+It holds the non-negotiable rules (never invent a score; what to score; where the data lives; the
+harness spec; the metric schema). This file is the control loop; that file is the law.
+
+## Inputs (the experiment config)
+
+Collect these from the user (ask only for what is missing — infer the rest). Repo = current
+working directory.
+
+| Field | Meaning | Default |
+|---|---|---|
+| `files_to_optimize` | file(s) whose code you change each iteration | **required** |
+| `goal` | what "better" means; the judge rubric + optimization direction | **required** |
+| `evaluators` | explicit evaluator/rubric text, if any | falls back to `goal` |
+| `ml_app` | Datadog LLM-Obs app to pull traces from | required unless `dataset_id`/`trace_ids` given |
+| data source | `dataset_id` \| `trace_ids` \| recent traces for `ml_app` | see priority below |
+| `max_iterations` | how many changes to try (clamp **1–50**) | **2** |
+| `base_branch` | branch the baseline is measured on | current branch / `main` |
+
+Persist the config to `.auto_experiment/config.json` and update it as the run progresses (it is
+the run's state + audit trail):
+
+```json
+{
+  "repo_url": "...", "base_branch": "...", "files_to_optimize": [...],
+  "goal": "...", "evaluators": "...", "ml_app": "...",
+  "dataset_id": "...", "trace_ids": [...],
+  "max_iterations": 2,
+  "iteration_results": [],
+  "final_result": {}
+}
+```
+
+## Setup
+
+1. Confirm a clean-ish working tree (stash or warn on unrelated changes). Note the starting SHA.
+2. Create a scratch branch off `base_branch` for the experiment (e.g.
+   `auto-experiment/<short-goal>`). All iteration commits land here; the user reviews/keeps the
+   best commit at the end.
+3. Write `.auto_experiment/config.json`. Add `.auto_experiment/` output files to nothing special
+   — they are committed on purpose (they are the audit trail).
+
+## Iteration 1 — baseline + first improvement
+
+Mirrors `build_initial_prompt`. Four steps, in order.
+
+### Step 1 — Load the evaluation data
+Pick the data source in this priority order and materialize it to `.auto_experiment/data.jsonl`
+(one scoreable datapoint per line: the input, plus expected/reference output if present):
+
+1. **`dataset_id` present** → `get_llmobs_dataset_records` + `get_llmobs_full_dataset_records`.
+2. **else non-empty `trace_ids`** → `get_llmobs_trace` (full tree), `get_llmobs_span_details`,
+   `get_llmobs_span_content`.
+3. **else** → fetch the last ~30 LLM traces for `ml_app` (search LLM-Obs spans), and record the
+   trace IDs you used back into `config.json` `trace_ids` so later iterations reuse the SAME
+   corpus.
+
+Extract input/output per the **messages-source guidance** in `references/rubrics.md` (score the
+`messages` field on the child LLM span, not the thin root `input.value`). Apply the
+**data-selection guidance**: keep only traces with a scoreable target span; exclude infra/setup
+spans from the set entirely.
+
+### Step 2 — Build the harness and compute BEFORE (baseline)
+Copy `references/eval_harness_template.py` to `.auto_experiment/eval_harness.py` and fill in
+`generate_output` (run the REAL code under test from `files_to_optimize`) and `judge` (a REAL
+LLM-as-judge, judge-selection order in the rubric). **No score literals anywhere.**
+
+Run it against the **original, unmodified** code. `before_score` = the printed mean over scoreable
+lines. It is a computed number, never a literal — obey the scoring policy.
+
+Commit `eval_harness.py`, `data.jsonl`, `eval_results.jsonl`.
+
+### Step 3 — Improve
+Read `files_to_optimize`. Make **ONE focused change** toward `goal`. Commit it on the scratch
+branch with a message explaining what changed and why.
+
+### Step 4 — Compute AFTER (re-run the SAME harness)
+Re-run `.auto_experiment/eval_harness.py` (same `evaluate_line`, same data) against the changed
+code. `after_score` = the new printed mean. Re-write `eval_results.jsonl`. Write the metric object
+(schema in the rubric) to `.auto_experiment/result.json` and commit it **in the same commit** as
+the change. `delta = after_score - before_score`.
+
+Decide `is_best` per the optimization direction in `goal`. If iteration 1 improved on the
+baseline, it becomes the best (`best_sha` = this commit, `best_score` = after_score). Append the
+row to `config.json` `iteration_results`.
+
+## Iterations 2+ — hill climb
+
+Mirrors `build_followup_prompt`. Baseline is already known — **do not recompute it**.
+
+1. **Restore to the best-so-far**, so a discarded attempt cannot contaminate this one:
+   - if a commit was kept → `git reset --hard <best_sha>` (stays on the scratch branch; the
+     committed harness + data live in that commit, so they are preserved — do not recreate them).
+   - if nothing has been kept yet → `git checkout <base_branch> -- <files_to_optimize>` (restore
+     only the target files; the harness/data live only in the previous commit on this branch, so
+     a hard reset to base would delete them).
+2. `before_score` = the current best score (from `iteration_results`; iteration-1 baseline if
+   nothing kept yet). Do NOT re-run the baseline.
+3. Reuse the data from `data.jsonl` and the committed `eval_harness.py` — do not reload or rebuild.
+4. Make **ONE new change, different from every previous attempt** (you can see prior attempts in
+   `iteration_results`). Commit it.
+5. Re-run the SAME harness → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
+6. **Keep or discard**: if `is_best` (beats the best per the goal direction) → update
+   `best_sha`/`best_score`, decision `kept`. Else `discarded`. Append the row.
+
+## Stop conditions & guards
+
+- Stop when `iteration == max_iterations`.
+- **A change with no computable score is `no_change`, never a fabricated number** (harness won't
+  run / no new commit / judge unreachable). Record the blocker in `reasoning`.
+- Track consecutive `no_change` iterations; after **5 in a row**, stop early and report the best
+  result so far with a stop reason (do not keep burning iterations).
+
+## Final report
+
+1. Ask yourself the run-level wrap-up and write `final_result` into `config.json`:
+   `{ "baseline_score", "best_score", "best_iteration", "best_sha", "iterations_run",
+   "stop_reason", "reasoning" }` (reasoning = what was tried across all iterations, what worked,
+   what didn't, why the winner won).
+2. Print a per-iteration table (iteration, delta, decision, sha) and name the best commit.
+3. **If nothing beat the baseline**: report the baseline as the best result and leave the original
+   code in place (`best_sha` empty). Do not fabricate an improvement.
+4. Tell the user the scratch branch + best commit so they can open a PR from it if they want.
+
+## Notes
+
+- Every score is computed by running code. If you ever find yourself about to type a score
+  number, stop — run the harness instead.
+- Keep `.auto_experiment/` committed; it is the reproducible record of the run.

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -114,6 +114,11 @@ Read `files_to_optimize`. Make **ONE focused change** toward `goal`, aimed at th
 bucket you can plausibly move** (name that bucket in the iteration's `reasoning`). Commit it on the
 scratch branch with a message explaining what changed and why.
 
+Before the (expensive) full eval, run a **feasibility probe** per the rubric's **Feasibility probe**:
+the cheapest offline check that this change *could* move a failing census bucket. If the probe
+reaches 0 failing datapoints, record the iteration `no_change` with the probe result and skip to the
+next hypothesis — do **not** spend a full eval on a dead lever.
+
 ### Step 4 — Compute AFTER (re-run the SAME harness)
 Re-run `.auto_experiment/eval_harness.py` (same `evaluate_line`, same data) against the changed
 code. `after_score` = the new printed mean. Re-write `eval_results.jsonl`. Write the metric object
@@ -144,7 +149,9 @@ Mirrors `build_followup_prompt`. Baseline is already known — **do not recomput
 3. Reuse the data from `data.jsonl` and the committed `eval_harness.py` — do not reload or rebuild.
 4. Make **ONE new change, different from every previous attempt** (you can see prior attempts in
    `iteration_results`), aimed at a named `census.json` bucket. Commit it.
-5. Re-run the SAME harness → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
+5. **Feasibility probe first** (rubric): cheap offline check the change can move its target bucket;
+   if it reaches 0 failing datapoints, record `no_change` and skip the full eval. Otherwise re-run
+   the SAME harness on `val` → `after_score`. Re-write `eval_results.jsonl` + `result.json`, commit.
 6. **Keep or discard**: keep only if the delta clears the noise band (`|after_score − before_score|
    > max(pooled_stdev, min_delta)`, per the Noise policy) in the goal's direction → update
    `best_sha`/`best_score`, decision `kept`. A within-noise gain or a regression → `discarded`.

--- a/agent-observability/agent-observability-auto-experiment/SKILL.md
+++ b/agent-observability/agent-observability-auto-experiment/SKILL.md
@@ -294,6 +294,14 @@ Rules:
 4. **If nothing beat the baseline on `test`**: report the baseline as the best result and leave the
    original code in place (`best_sha` empty). Do not fabricate an improvement.
 5. Tell the user the scratch branch + best commit so they can open a PR from it if they want.
+6. **Mark the experiment finished in LLM-Obs.** Call `update_llmobs_experiment` with
+   `experiment_id` = `$DD_AUTO_EXPERIMENT_ID` (skip if unset) exactly once at the very end — after
+   the last iteration, or immediately whenever you give up early. Set `status: "completed"` for any
+   run that reached the final report (including one where baseline stayed best — a run that
+   finished cleanly is completed, not failed). Set `status: "failed"` with a short `error` when the
+   run could not finish — the harness never ran, setup was blocked, or you abandoned before any
+   scored iteration. This status update is separate from the per-iteration metric submissions; make
+   it once, last.
 
 ## Notes
 

--- a/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
+++ b/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
@@ -56,9 +56,15 @@ def generate_output(line: dict) -> "str | None":
 
 
 def judge(input_text: str, output_text: str) -> "tuple[float, str]":
-    """Real LLM-as-judge over (input, output). Returns (score in [0,1], justification).
+    """Score (input, output). Returns (score in [0,1], justification).
 
-    TODO: make a REAL judge call. Model selection (see rubrics.md):
+    PREFER A DETERMINISTIC GROUND-TRUTH CHECK (see rubrics.md "Metric selection"): if the datapoint
+    carries a reference/expected output or a programmatic checker exists (exact match, F1, set
+    overlap, a repo evaluator, a pipeline count), implement `judge` as that deterministic comparison
+    — it removes the judge's variance entirely. Fall back to an LLM-as-judge ONLY for open-ended
+    quality with no ground truth (then bump AUTO_EXP_REPS >= 5; the judge is the noisiest component).
+
+    TODO (LLM-judge fallback only): make a REAL judge call. Model selection (see rubrics.md):
       - If the config names a judge `model`, use it.
       - Else DEFAULT to the Claude model selected in the Claude Code session running this skill
         (the same model as the main loop), called via ANTHROPIC_API_KEY / CLAUDE_API_KEY or an

--- a/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
+++ b/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
@@ -11,18 +11,30 @@ Hard rules (see references/rubrics.md):
   * The harness is written ONCE and reused verbatim across iterations — only the code under
     test (imported by `generate_output`) changes between iterations.
 
-Usage: `python .auto_experiment/eval_harness.py`  -> writes eval_results.jsonl, prints the mean.
+Usage: `python .auto_experiment/eval_harness.py`  -> writes eval_results.jsonl, prints
+  {"mean", "stdev", "reps", "scored", "excluded", "rep_means"}.
+
+Noise: `generate_output` (and an LLM judge) are stochastic, so a single run's mean is a
+noisy estimate. The runner re-runs the WHOLE eval `AUTO_EXP_REPS` times (default 3) and
+reports the mean-of-reps plus the across-rep stdev — the loop uses that stdev as the
+noise floor for keep/discard (see references/rubrics.md "Noise & keep/discard policy").
+Point at a specific data split with `AUTO_EXP_DATA` (default data.jsonl).
 """
 
 from __future__ import annotations
 
 import json
 import os
+import statistics
 from pathlib import Path
 
 HERE = Path(__file__).parent
-DATA = HERE / "data.jsonl"
+DATA = Path(os.environ.get("AUTO_EXP_DATA") or (HERE / "data.jsonl"))
 RESULTS = HERE / "eval_results.jsonl"
+
+# How many times to re-run the full eval to estimate the noise floor. >=3 so the loop
+# can tell a real move from run-to-run wiggle. Same value across every iteration.
+REPS = max(1, int(os.environ.get("AUTO_EXP_REPS", "3")))
 
 # The optimization goal / evaluator text, copied from .auto_experiment/config.json.
 # Used verbatim as the judge rubric so scoring is reproducible.
@@ -75,27 +87,44 @@ def evaluate_line(line: dict) -> "dict | None":
     }
 
 
-def main() -> None:
-    scored: list[float] = []
+def _one_pass(lines: list) -> "tuple[list[dict], int]":
+    """Score every scoreable line ONCE. Returns (results, excluded_count)."""
+    results: list[dict] = []
     excluded = 0
-    with RESULTS.open("w") as out:
-        for raw in DATA.read_text().splitlines():
-            raw = raw.strip()
-            if not raw:
-                continue
-            line = json.loads(raw)
-            result = evaluate_line(line)
-            if result is None:
-                excluded += 1
-                continue
-            out.write(json.dumps(result) + "\n")
-            scored.append(result["score"])
-    if not scored:
-        raise SystemExit("no scoreable lines — cannot compute a mean (do NOT fabricate one)")
-    mean = sum(scored) / len(scored)
-    # This printed number is the before_score / after_score the loop reads. It is computed, never
-    # a literal. `excluded` must be reported in the iteration's reasoning.
-    print(json.dumps({"mean": mean, "scored": len(scored), "excluded": excluded}))
+    for line in lines:
+        result = evaluate_line(line)
+        if result is None:
+            excluded += 1
+            continue
+        results.append(result)
+    return results, excluded
+
+
+def main() -> None:
+    lines = [json.loads(r) for r in DATA.read_text().splitlines() if r.strip()]
+    rep_means: list[float] = []
+    last_results: list[dict] = []
+    excluded = 0
+    # Re-run the whole eval REPS times; each pass re-invokes the (stochastic) code under
+    # test + judge, so the spread across passes is the run-to-run noise floor.
+    for _ in range(REPS):
+        results, excluded = _one_pass(lines)
+        if not results:
+            raise SystemExit("no scoreable lines — cannot compute a mean (do NOT fabricate one)")
+        rep_means.append(sum(r["score"] for r in results) / len(results))
+        last_results = results
+    with RESULTS.open("w") as out:  # keep the last pass's per-line detail for audit
+        for r in last_results:
+            out.write(json.dumps(r) + "\n")
+    mean = statistics.mean(rep_means)
+    stdev = statistics.pstdev(rep_means) if len(rep_means) > 1 else 0.0
+    # `mean` is the before_score/after_score the loop reads; `stdev` is the noise floor the
+    # keep/discard gate compares the delta against. Both computed, never literals. `excluded`
+    # must be reported in the iteration's reasoning.
+    print(json.dumps({
+        "mean": mean, "stdev": stdev, "reps": REPS,
+        "scored": len(last_results), "excluded": excluded, "rep_means": rep_means,
+    }))
 
 
 if __name__ == "__main__":

--- a/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
+++ b/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
@@ -46,11 +46,14 @@ def generate_output(line: dict) -> "str | None":
 def judge(input_text: str, output_text: str) -> "tuple[float, str]":
     """Real LLM-as-judge over (input, output). Returns (score in [0,1], justification).
 
-    TODO: make a REAL judge call. Judge-selection order (see rubrics.md):
-      1. Internal Datadog judge — model gateway, or DD_API_KEY + DD_APP_KEY to run a Datadog
-         LLM Obs evaluator. Prefer this when available.
-      2. Else an external provider with whatever key is present: ANTHROPIC_API_KEY, then
-         OPENAI_API_KEY.
+    TODO: make a REAL judge call. Model selection (see rubrics.md):
+      - If the config names a judge `model`, use it.
+      - Else DEFAULT to the Claude model selected in the Claude Code session running this skill
+        (the same model as the main loop), called via ANTHROPIC_API_KEY / CLAUDE_API_KEY or an
+        internal Datadog/AI-gateway route.
+      - Only fall back to another provider (OPENAI_API_KEY) or a Datadog LLM Obs evaluator if the
+        session model cannot be reached.
+    Pin the resolved model id so the judge is identical across every iteration.
     Score `output_text` against GOAL. If no judge can be reached after genuinely trying, raise —
     do NOT return a fabricated number.
     """

--- a/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
+++ b/agent-observability/agent-observability-auto-experiment/references/eval_harness_template.py
@@ -1,0 +1,99 @@
+"""Skeleton for `.auto_experiment/eval_harness.py`.
+
+Copy this into `.auto_experiment/eval_harness.py` in iteration 1, then fill in the two TODOs:
+`generate_output` (run the REAL code under test) and `judge` (a REAL LLM-as-judge call).
+
+Hard rules (see references/rubrics.md):
+  * NO score literals / hard-coded score arrays anywhere in this file. Every score is returned
+    by `judge()` running over real data.
+  * Score only scoreable target lines; EXCLUDE non-target/infra lines from the mean entirely
+    (do not score them 0). The runner below skips a line when `generate_output` returns None.
+  * The harness is written ONCE and reused verbatim across iterations — only the code under
+    test (imported by `generate_output`) changes between iterations.
+
+Usage: `python .auto_experiment/eval_harness.py`  -> writes eval_results.jsonl, prints the mean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+HERE = Path(__file__).parent
+DATA = HERE / "data.jsonl"
+RESULTS = HERE / "eval_results.jsonl"
+
+# The optimization goal / evaluator text, copied from .auto_experiment/config.json.
+# Used verbatim as the judge rubric so scoring is reproducible.
+GOAL = os.environ.get("AUTO_EXP_GOAL", "<paste the experiment goal / evaluator rubric here>")
+
+
+def generate_output(line: dict) -> "str | None":
+    """Run the REAL code under test on ONE datapoint and return its output.
+
+    TODO: import the real entrypoint from the target file(s) and call it with the datapoint's
+    input. If the import fails (e.g. ddtrace.llmobs bus-errors in some sandboxes), copy the
+    needed function into this file with ONLY the offending import stubbed; reconstruct from
+    source as a last resort.
+
+    Return None to EXCLUDE this line from the eval set (non-target / infra line, or no scoreable
+    target span). Excluded lines are out of both numerator and denominator — never scored 0.
+    """
+    raise NotImplementedError("wire generate_output to the real code under test")
+
+
+def judge(input_text: str, output_text: str) -> "tuple[float, str]":
+    """Real LLM-as-judge over (input, output). Returns (score in [0,1], justification).
+
+    TODO: make a REAL judge call. Judge-selection order (see rubrics.md):
+      1. Internal Datadog judge — model gateway, or DD_API_KEY + DD_APP_KEY to run a Datadog
+         LLM Obs evaluator. Prefer this when available.
+      2. Else an external provider with whatever key is present: ANTHROPIC_API_KEY, then
+         OPENAI_API_KEY.
+    Score `output_text` against GOAL. If no judge can be reached after genuinely trying, raise —
+    do NOT return a fabricated number.
+    """
+    raise NotImplementedError("wire judge to a real LLM-as-judge call; never fabricate a score")
+
+
+def evaluate_line(line: dict) -> "dict | None":
+    """Score ONE datapoint. None => excluded from the eval set (not scored 0)."""
+    output = generate_output(line)
+    if output is None:
+        return None  # non-target / non-scoreable line — excluded from the mean
+    input_text = line.get("input") if isinstance(line.get("input"), str) else json.dumps(line.get("input"))
+    score, justification = judge(input_text, output)
+    return {
+        "input": (input_text or "")[:500],
+        "output": output[:500],
+        "score": float(score),
+        "justification": justification,
+    }
+
+
+def main() -> None:
+    scored: list[float] = []
+    excluded = 0
+    with RESULTS.open("w") as out:
+        for raw in DATA.read_text().splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            line = json.loads(raw)
+            result = evaluate_line(line)
+            if result is None:
+                excluded += 1
+                continue
+            out.write(json.dumps(result) + "\n")
+            scored.append(result["score"])
+    if not scored:
+        raise SystemExit("no scoreable lines — cannot compute a mean (do NOT fabricate one)")
+    mean = sum(scored) / len(scored)
+    # This printed number is the before_score / after_score the loop reads. It is computed, never
+    # a literal. `excluded` must be reported in the iteration's reasoning.
+    print(json.dumps({"mean": mean, "scored": len(scored), "excluded": excluded}))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -170,3 +170,21 @@ it in the same commit as the code change:
 `is_best` drives keep/discard and must reflect the optimization direction in `goal` (higher is
 better unless the goal says to minimize) **AND clear the noise band** (`|delta| > noise_band`) —
 a within-noise point-estimate gain is `is_best: false`. `reasoning` is mandatory and never empty.
+
+## Mechanism audit — confirm the change CAUSED the gain (`_mechanism_audit`)
+
+A rising mean is necessary but not sufficient to keep a change. Before setting `is_best: true`,
+confirm the improvement is **caused by the change**, not by an artifact:
+
+- **Per-datapoint diff.** Diff the best vs candidate `eval_results.jsonl`: which datapoints flipped
+  up, which down. The gain must come from datapoints the change plausibly touches (ideally in the
+  census bucket it targeted). A mean that rose while the targeted datapoints did **not** flip is a
+  red flag — the "gain" is probably noise or an unrelated wobble.
+- **Denominator guard.** Confirm `scored`/`excluded` counts are the SAME across best and candidate.
+  A higher mean from *fewer scored datapoints* (the change dropped hard cases out of the eval set)
+  is an artifact, not an improvement — discard it. (A real production loop was fooled exactly this
+  way: a "+0.1" that was only a shrinking denominator.)
+- **Causality on regressions too.** If controls/negatives regressed, check whether the change even
+  fired on them; a regression the change never touched is noise, one it caused is a real cost.
+- Record the audit outcome (which datapoints moved and why it is/ isn't causal) in `reasoning`. If
+  the audit fails, the iteration is `discarded` even though the point estimate rose.

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -49,6 +49,21 @@ answer / generation span). For each trace, locate the scoreable target span, the
   numerator AND the denominator. **Report how many traces you excluded and why** in `reasoning`;
   never exclude a scoreable datapoint to inflate the score.
 
+**Held-out split — hill-climb on `val`, prove on `test`.** After building the scoreable set, split
+it **once, deterministically** (e.g. by a hash of the datapoint id, ~70% / 30%) into
+`data.val.jsonl` and `data.test.jsonl`, committed alongside `data.jsonl`:
+
+- **`val`** is the ONLY split the hill-climb reads. Every iteration's `before/after_score` and the
+  keep/discard gate run on `val` (point the harness at it with `AUTO_EXP_DATA=.auto_experiment/data.val.jsonl`).
+- **`test`** is untouched during the loop. Run it **once at the very end**, on the baseline commit
+  and on the best commit, and report that baseline-vs-best `test` delta as the run's real result.
+- **Why:** hill-climbing directly on the full set overfits the loop to that set's noise, so a
+  within-noise "win" looks real. A change that only helps `val` but not held-out `test` is not a
+  real improvement — the `test` delta is the honest headline. If `val` improved but `test` did
+  not, say so plainly; do not report the `val` gain as the result.
+- Keep the split small enough to run in the iteration budget but large enough that per-split stdev
+  is meaningful; if the corpus is tiny, note the low power in `reasoning` rather than faking a split.
+
 ## Messages-source guidance — where the input/output lives (`_messages_source_guidance`)
 
 **`messages` is the source of truth — the root span's `input.value` is usually a thin/truncated

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -64,6 +64,26 @@ it **once, deterministically** (e.g. by a hash of the datapoint id, ~70% / 30%) 
 - Keep the split small enough to run in the iteration budget but large enough that per-split stdev
   is meaningful; if the corpus is tiny, note the low power in `reasoning` rather than faking a split.
 
+## Baseline failure census — localize the lever before you tweak (`_failure_census`)
+
+Before iteration 1's first change, decompose **where the baseline actually loses**, so iterations
+aim at a real failure mode instead of guessing. Blind prompt-tweaking is how a loop burns its
+budget re-discovering that wording changes are noise.
+
+- From the baseline `eval_results.jsonl`, bucket every **failing / low-scoring** datapoint by
+  **root cause**, not by score. Use judge justifications + the trace to assign each a short cause
+  tag. Generic buckets that fit most tasks: `wrong_retrieval` (needed input never fetched),
+  `wrong_reasoning` (had the input, drew the wrong conclusion), `format/parse` (right answer, wrong
+  shape), `refusal/empty`, `judge_disagreement` (output is fine, rubric is off), `data/label`
+  (the reference is wrong). Adapt the tags to the task.
+- Write the census to `.auto_experiment/census.json` (`{tag: count, examples: [ids]}`) and commit it.
+  Surface the ranked buckets.
+- **Every iteration must name the census bucket it targets** (in `result.json` `reasoning`) and be a
+  change plausibly able to move THAT bucket. If the dominant bucket is not reachable by editing
+  `files_to_optimize` (e.g. `data/label` errors, or a `wrong_retrieval` that needs a tool the code
+  can't call), say so — that is a finding (the ceiling is not prompt/code-reachable), not a reason
+  to keep tweaking the reachable-but-tiny buckets.
+
 ## Messages-source guidance — where the input/output lives (`_messages_source_guidance`)
 
 **`messages` is the source of truth — the root span's `input.value` is usually a thin/truncated

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -119,6 +119,22 @@ summary and MUST NOT be scored when a `messages` field exists somewhere in the t
 - If a messages field is too large to process directly, summarize it first, then score on the
   summary.
 
+## Metric selection — prefer deterministic ground truth over an LLM judge (`_metric_selection`)
+
+The scorer is itself a noise source. **When a deterministic, ground-truth metric is available, use
+it instead of an LLM judge** — it removes an entire layer of variance and can't be gamed:
+
+- If datapoints carry a **reference/expected output** (dataset `expected_output`, gold label), score
+  with an exact/programmatic check (exact match, F1, set overlap, a repo evaluator, `total_examples`
+  from a pipeline, etc.) — deterministic, `stdev ≈ 0` across reps from the judge side.
+- Use an **LLM-as-judge only when no ground truth exists** (open-ended quality). Then treat it as
+  the noisiest component: bump `AUTO_EXP_REPS` (≥5), pin the model + prompt, and expect a wider
+  noise band.
+- Either way the metric is **computed by running code** (scoring policy) — a deterministic checker
+  and an LLM judge are both legitimate `judge()` implementations; prefer the deterministic one.
+- State which metric kind you used in `reasoning`; a deterministic ground-truth metric is the
+  strongest evidence, an LLM judge the weakest.
+
 ## Eval-harness spec (`_eval_harness_skill`)
 
 Write a real, committed evaluation module `.auto_experiment/eval_harness.py` with:

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -15,6 +15,25 @@ A consequence for the loop: if a change is made but its score cannot be computed
 run, judge unreachable, etc.), that iteration is recorded as **no_change** with the blocker in
 `reasoning` — it is never scored with a fabricated number.
 
+## Noise & keep/discard policy (`_noise_policy`)
+
+⚠️ **A single eval run is a NOISY ESTIMATE, not a measurement.** The code under test and any
+LLM judge are stochastic, so the mean wiggles run-to-run. Treat every score as
+`mean ± stdev` over **`AUTO_EXP_REPS` (default 3) full re-runs of the eval on the same data**
+(the harness does this and prints `stdev` + `rep_means`). Consequences the loop MUST obey:
+
+- **Keep only a delta that clears the noise floor.** An iteration is `is_best` / kept only if
+  `after_mean` beats `best_mean` by more than the noise band —
+  `|after_mean − best_mean| > max(pooled_stdev, min_delta)`, where `pooled_stdev` is the larger
+  of the two runs' `stdev` and `min_delta` is a small floor from config (default `0.02` on a
+  0–1 metric). A delta **within** the noise band is **not** an improvement: record it `discarded`
+  (decision), not kept, no matter that the point estimate rose.
+- **Compare on the same footing.** `best_mean`/`best_stdev` come from a real R-rep harness run of
+  the current best, not a stale single number carried forward. When in doubt, re-run best and
+  candidate back-to-back so data/endpoint drift cancels.
+- **A within-noise "win" is the classic trap.** Point estimates of 15 vs 14 mean nothing when
+  stdev is ~2. Do not keep it, do not report it as an improvement.
+
 ## Data-selection guidance — what enters the eval set (`_data_selection_guidance`)
 
 **Choosing what to score.** Identify the **target unit** from the experiment `goal`/`evaluators`
@@ -83,14 +102,18 @@ it in the same commit as the code change:
 
 ```json
 {
-  "before_score": <float 0-1>,
-  "after_score": <float 0-1>,
+  "before_score": <float 0-1 — best_mean going in>,
+  "after_score": <float 0-1 — this iteration's mean over AUTO_EXP_REPS reps>,
+  "after_stdev": <float — across-rep stdev the harness printed (the noise floor)>,
+  "reps": <int — AUTO_EXP_REPS used>,
   "delta": <after_score minus before_score>,
-  "reasoning": "<REQUIRED — scoring method FIRST (how generate_output ran the code, how many scoreable lines evaluate_line ran over), then what was tested/failed/succeeded, how many traces were excluded and why, and any caveat about reproducing production; 2-4 sentences; never empty>",
+  "noise_band": <float — max(pooled_stdev, min_delta) used for the keep/discard gate>,
+  "reasoning": "<REQUIRED — scoring method FIRST (how generate_output ran the code, how many scoreable lines evaluate_line ran over, reps), then what was tested/failed/succeeded, how many traces were excluded and why, and any caveat about reproducing production; 2-4 sentences; never empty>",
   "best_score": <best metric value across all iterations, considering the optimization direction>,
-  "is_best": <REQUIRED — true if this iteration beats all previous ones, false otherwise; never omit>
+  "is_best": <REQUIRED — true ONLY if the delta clears the noise band (see Noise policy); false otherwise; never omit>
 }
 ```
 
 `is_best` drives keep/discard and must reflect the optimization direction in `goal` (higher is
-better unless the goal says to minimize). `reasoning` is mandatory and must never be empty.
+better unless the goal says to minimize) **AND clear the noise band** (`|delta| > noise_band`) —
+a within-noise point-estimate gain is `is_best: false`. `reasoning` is mandatory and never empty.

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -58,13 +58,17 @@ Write a real, committed evaluation module `.auto_experiment/eval_harness.py` wit
   `generate_output`, then runs the **LLM-as-judge** on (input, generated output) using the
   evaluator from the config (`evaluators` field, else `goal`), and **returns the computed
   score**. There must be **NO score literals / hard-coded arrays** anywhere in this file.
+  - **Judge model selection.** If the experiment config names a judge model, use it. **If no
+    model is specified, default to the Claude model selected in the Claude Code session that
+    invoked this skill** — i.e. the same model running this loop. Resolve that model id (the
+    session/main-loop model) and call it through whichever Anthropic credential is available
+    (`ANTHROPIC_API_KEY` / `CLAUDE_API_KEY`, or an internal Datadog/AI-gateway route). Only fall
+    back to another provider (e.g. `OPENAI_API_KEY`) or an internal Datadog LLM Obs evaluator if
+    the session model cannot be reached. Pin the resolved model id in `eval_harness.py` so the
+    judge is identical across every iteration, and state in `reasoning` which model you used.
   - **Figure out how to make a real judge call yourself**: probe for an available LLM
-    credential/endpoint and use whichever works. **Prefer an internal Datadog judge when
-    available** — an internal Datadog model gateway, or `DD_API_KEY` + `DD_APP_KEY` to run a
-    Datadog LLM Obs evaluator. Otherwise, call an external provider directly using whatever key
-    is present, e.g. `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. State in `reasoning` which judge
-    you used. If, after genuinely trying, no judge can be reached, STOP and report the blocker —
-    do NOT fabricate a score.
+    credential/endpoint and use whichever works. If, after genuinely trying, no judge can be
+    reached, STOP and report the blocker — do NOT fabricate a score.
 - a runner that applies `evaluate_line` to EVERY scoreable line of `data.jsonl` (per the
   exclusion rule above), writes each result to `.auto_experiment/eval_results.jsonl` (input
   snippet, output, score, justification), and prints the mean over scoreable lines.

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -1,0 +1,92 @@
+# Auto-experiment rubrics (non-negotiable)
+
+These rules are lifted from the production `auto_experiments` worker
+(`domains/ml_observability/apps/apis/auto_experiments/service/prompts.py`). They are the
+load-bearing parts of the loop — follow them verbatim. Paraphrasing here weakens the loop.
+
+## Scoring policy (`_scoring_policy`)
+
+⛔ **INVENTING SCORES IS FORBIDDEN.** Do NOT hard-code, estimate, guess, manually assign, or
+carry over score numbers. Every score MUST be the return value of actually running code over the
+data. Comments or arrays of "representative"/"fixed" scores are forbidden. If you cannot truly
+compute a score, STOP and report the blocker — never substitute a made-up number.
+
+A consequence for the loop: if a change is made but its score cannot be computed (harness won't
+run, judge unreachable, etc.), that iteration is recorded as **no_change** with the blocker in
+`reasoning` — it is never scored with a fabricated number.
+
+## Data-selection guidance — what enters the eval set (`_data_selection_guidance`)
+
+**Choosing what to score.** Identify the **target unit** from the experiment `goal`/`evaluators`
+— the span/operation that produces the artifact being optimized (e.g. the recommendation /
+answer / generation span). For each trace, locate the scoreable target span, then:
+
+- **Score every trace that contains a scoreable target span.** Do NOT subsample, truncate, or
+  drop scoreable datapoints for convenience.
+- **EXCLUDE traces that have no scoreable target span** (setup/infra spans such as
+  `mcp.initialize`, `session_summary`, health checks) from the eval set entirely — do NOT score
+  them 0.0. A non-target trace scored 0.0 drags the mean down and hides real changes.
+- The mean is computed over **scoreable datapoints only** — excluded traces are out of both the
+  numerator AND the denominator. **Report how many traces you excluded and why** in `reasoning`;
+  never exclude a scoreable datapoint to inflate the score.
+
+## Messages-source guidance — where the input/output lives (`_messages_source_guidance`)
+
+**`messages` is the source of truth — the root span's `input.value` is usually a thin/truncated
+summary and MUST NOT be scored when a `messages` field exists somewhere in the trace.**
+
+- Call `get_llmobs_span_details` and read its `content_info` map for each span. It shows which
+  fields exist and their size, e.g. `{"input": {"chars": 1520}, "messages": {"count": 12}}`.
+  Find the span whose `messages` count is highest — that span holds the full conversation history
+  (and often the system prompt).
+- Fetch it with `get_llmobs_span_content(field="messages")` (use `path` like `$.messages` to
+  extract). Do the same for the output side (`field="output"` / its messages).
+- The full `messages` typically lives on a **child LLM span**, not the root span — drill into the
+  trace tree (`get_llmobs_trace` / `expand_llmobs_spans`) and inspect child spans, do not stop at
+  the root. Only fall back to `input.value` / `output.value` when NO span exposes `messages`.
+- If a messages field is too large to process directly, summarize it first, then score on the
+  summary.
+
+## Eval-harness spec (`_eval_harness_skill`)
+
+Write a real, committed evaluation module `.auto_experiment/eval_harness.py` with:
+
+- `generate_output(line)` — runs the **real code under test** to produce the output for ONE
+  datapoint (import the real entrypoint; if the import bus-errors / fails, a copy of the needed
+  function with ONLY the offending import stubbed; reconstruct from source as a last resort).
+- `evaluate_line(line) -> {"output": ..., "score": <float 0-1>, "justification": ...}` — calls
+  `generate_output`, then runs the **LLM-as-judge** on (input, generated output) using the
+  evaluator from the config (`evaluators` field, else `goal`), and **returns the computed
+  score**. There must be **NO score literals / hard-coded arrays** anywhere in this file.
+  - **Figure out how to make a real judge call yourself**: probe for an available LLM
+    credential/endpoint and use whichever works. **Prefer an internal Datadog judge when
+    available** — an internal Datadog model gateway, or `DD_API_KEY` + `DD_APP_KEY` to run a
+    Datadog LLM Obs evaluator. Otherwise, call an external provider directly using whatever key
+    is present, e.g. `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. State in `reasoning` which judge
+    you used. If, after genuinely trying, no judge can be reached, STOP and report the blocker —
+    do NOT fabricate a score.
+- a runner that applies `evaluate_line` to EVERY scoreable line of `data.jsonl` (per the
+  exclusion rule above), writes each result to `.auto_experiment/eval_results.jsonl` (input
+  snippet, output, score, justification), and prints the mean over scoreable lines.
+
+The harness is built **once** in iteration 1 and **reused verbatim** in every later iteration —
+only the code under test changes between iterations.
+
+## Metric JSON schema — `.auto_experiment/result.json` (`_return_metric_block`)
+
+After each scored iteration, write this exact object to `.auto_experiment/result.json` and commit
+it in the same commit as the code change:
+
+```json
+{
+  "before_score": <float 0-1>,
+  "after_score": <float 0-1>,
+  "delta": <after_score minus before_score>,
+  "reasoning": "<REQUIRED — scoring method FIRST (how generate_output ran the code, how many scoreable lines evaluate_line ran over), then what was tested/failed/succeeded, how many traces were excluded and why, and any caveat about reproducing production; 2-4 sentences; never empty>",
+  "best_score": <best metric value across all iterations, considering the optimization direction>,
+  "is_best": <REQUIRED — true if this iteration beats all previous ones, false otherwise; never omit>
+}
+```
+
+`is_best` drives keep/discard and must reflect the optimization direction in `goal` (higher is
+better unless the goal says to minimize). `reasoning` is mandatory and must never be empty.

--- a/agent-observability/agent-observability-auto-experiment/references/rubrics.md
+++ b/agent-observability/agent-observability-auto-experiment/references/rubrics.md
@@ -84,6 +84,24 @@ budget re-discovering that wording changes are noise.
   can't call), say so — that is a finding (the ceiling is not prompt/code-reachable), not a reason
   to keep tweaking the reachable-but-tiny buckets.
 
+## Feasibility probe — prove reachability before you pay for a full eval (`_feasibility_probe`)
+
+A full eval is the expensive step (R reps × every datapoint × real code + judge). Before spending
+it on a hypothesis, run the **cheapest possible offline check that the lever CAN move the metric** —
+an upper bound, not a measurement. Only run the full eval on hypotheses that pass.
+
+- The probe answers "if this change worked perfectly, could it flip any currently-failing
+  datapoint?" Examples: for a retrieval change, does the needed signal even exist in reach (a
+  read-only API/tool call on the census's failing ids)? For a prompt change, on 2–3 failing
+  examples does the edited prompt visibly change the output in the intended direction (a handful of
+  direct model calls, not the full harness)?
+- A probe that reaches **0** of the failing datapoints means the hypothesis is dead — record it
+  `no_change` with the probe result in `reasoning` and move on **without** spending a full eval.
+  (This is exactly how the production effort rejected semantic-search and dependency-graph levers in
+  minutes instead of hours.)
+- Keep probes read-only and offline where possible; never let a probe mutate `files_to_optimize`
+  or the committed harness/data.
+
 ## Messages-source guidance — where the input/output lives (`_messages_source_guidance`)
 
 **`messages` is the source of truth — the root span's `input.value` is usually a thin/truncated


### PR DESCRIPTION
## What

Adds a new skill **`agent-observability-auto-experiment`** to the `agent-observability` directory.

It's a local, Claude-Code-driven hill-climb improvement loop: establish a baseline eval against real Datadog LLM-Obs data (from an `ml_app`, `dataset_id`, or `trace_ids`), make one focused change to code in the edit scope, re-score with the **same** committed harness, keep the change only if it beats the best beyond the noise band, and repeat. This is the local equivalent of the `auto_experiments` Temporal/Atlas worker — no Temporal or Code-Gen API, just git commits + a local eval harness + LLM-Obs MCP tools.

## Contents

- `SKILL.md` — the control loop (setup, iteration 1 baseline+improve, iterations 2+ hill-climb, stop conditions, final report)
- `references/rubrics.md` — non-negotiable rules (scoring policy, data selection, messages-source guidance, harness spec, metric schema)
- `references/eval_harness_template.py` — starting template for the per-run eval harness

Ported from the dd-source `.claude/skills/auto-experiment` skill; frontmatter `name` changed to `agent-observability-auto-experiment` to match the directory convention. README updated (install list, count, skill table).

## LLM-Obs experiment reporting

Each run reports to the LLM-Obs experiment named by `DD_AUTO_EXPERIMENT_ID`:

- **Baseline as iteration 0** — before the first improvement, emit one eval-metric event with the baseline score (`iteration:0`, `decision:baseline`).
- **One eval-metric per scored iteration** — `submit_llmobs_experiment_events`, tagged `iteration:<n>`, `git.commit.sha:<sha>`, `decision:<baseline|kept|discarded>`, plus a `reasoning` field (what was tried, which census bucket, keep/discard rationale).
- **`git.commit.sha` is the full 40-char hash** (`git rev-parse HEAD`), never the short hash.
- **Run context as metadata** — before iterations start, set experiment `metadata` to `{repo, branch}` via `update_llmobs_experiment`.
- **Lifecycle status** — at run end set `update_llmobs_experiment` status `completed` (reached final report, baseline-best counts) or `failed` + `error` (harness never ran / setup blocked / gave up before any scored iteration).

Note: the `reasoning` field depends on dd-source#20673 (staging).

## Verification

Ran end-to-end against a live staging experiment (`bbd21f5a-…`). Confirmed on real events:

- iteration:0 baseline emitted with computed `score_value`, `decision:baseline`
- iteration:1 emitted with `decision:kept`, full 40-char `git.commit.sha`, populated `reasoning`
- iter1 `score_value` − baseline = the delta reported in `reasoning` (self-consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)