### PR TITLE
fix(dd-apm): replace removed `pup fleet instrumented-pods list` in k8s-ssi skills

### DIFF
--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -104,7 +104,6 @@ Fill in every value from live command output. Do not leave any placeholder unfil
 | Datadog Agent | `<N>` pod(s) Running in `<AGENT_NAMESPACE>` | OK |
 | SSI enabled | Targeting namespace `<APP_NAMESPACE>`, language `<LANGUAGE>` v`<MAJOR_VERSION>` | OK |
 | Init container injected | `datadog-lib-<language>-init` present in pod spec | OK |
-| Pod instrumented | `<POD_NAME>` in `pup fleet instrumented-pods list` | OK |
 | Tracer reporting | Service `<SERVICE_NAME>`, `<LANGUAGE>`, tracer v`<TRACER_VERSION>` | OK |
 | APM service visible | `<SERVICE_NAME>` in env `<ENV>` | OK |
 | Traces arriving | `<N>` trace(s) found in the last hour | OK |

--- a/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
+++ b/dd-apm/k8s-ssi/onboarding-summary/SKILL.md
@@ -78,10 +78,6 @@ kubectl get datadogagent datadog -n <AGENT_NAMESPACE> \
 kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
   -o jsonpath='{.items[0].spec.initContainers[*].name}'
 
-# Pod confirmed instrumented — init containers in pod spec
-kubectl get pod -l app=<APP_LABEL> -n <APP_NAMESPACE> \
-  -o jsonpath='{.items[0].spec.initContainers[*].name}'
-
 # Service visible and traced in APM
 DD_SITE=<DD_SITE> pup apm services list --env <ENV> --from 1h
 

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -98,7 +98,7 @@ Read this before investigating. It gives you the mental model to reason about no
 5. Application process loads the library automatically on startup via `LD_PRELOAD`
 
 **What each diagnostic layer can see:**
-- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no tracer telemetry for the service, the problem is in the cluster.
+- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no tracer telemetry for the service, the tracer was either never injected (cluster-side — confirm with the kubectl init-container check) or injected but unable to report yet (connectivity, DD_SITE, API key, or telemetry lag). Don't assume the cluster; cross-check kubectl.
 - **kubectl** — sees cluster state. Blind to whether data reached Datadog. If kubectl shows the init container but pup shows no traces, the problem is post-injection.
 
 **What healthy looks like:**
@@ -163,10 +163,10 @@ Before investigating, explicitly state your ranked hypotheses based on triage ou
 
 | Triage signal | Strong hypothesis |
 |---|---|
-| Traces arriving + service in tracers list | Not a real problem — likely a UI filter or time window. Tell the user and stop |
+| Traces arriving + service in tracers list | Both signals are service-scoped, so on a partial rollout they can be positive while the specific pod the user named is uninstrumented. First confirm **this** pod is instrumented (init container present in the triage kubectl check, or the `admission.datadoghq.com/status: injected` annotation). If it is, it's likely a UI filter or time window — tell the user and stop |
 | No traces + service NOT in tracers list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
-| No traces + service NOT in tracers list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
-| No traces + service in tracers list + init container present | Tracer reporting telemetry but traces not arriving — investigate: connectivity, DD_SITE, API key, trace sampling |
+| No traces + service NOT in tracers list + init container present | Tracer injected but not reporting — `tracers list` is telemetry-derived, so a correctly injected pod is absent when it can't report or hasn't yet. Investigate: Agent connectivity, DD_SITE mismatch, API key, blocked egress, or no traffic / telemetry lag. (A true injection failure shows up as an *absent* init container or as init-container errors — the CrashLoopBackOff row below — not here.) |
+| No traces + service in tracers list + init container present | Tracer is reporting telemetry (so Agent connectivity, API key, and DD_SITE are working) but spans aren't arriving — investigate trace-specific causes: sampling rules, an ingestion/retention filter, or the trace-agent receiver |
 | Pod events show CrashLoopBackOff or init container errors | Init container failure — check existing ddtrace, runtime version |
 | Traces arriving but wrong service/env | UST labels missing or misconfigured on the Deployment |
 
@@ -202,8 +202,15 @@ kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --t
 ### Claude runs
 
 ```bash
+# Primary — authoritative and immediate: confirm the restarted pod now carries the init container
+kubectl get pod <POD_NAME> -n <APP_NAMESPACE> \
+  -o jsonpath='{.spec.initContainers[*].name}'
+# Secondary — eventual: the service reappears here once the restarted pod reports telemetry
+# (subject to a propagation delay of a minute or more, and only if the pod serves traffic)
 pup fleet tracers list --filter "service:<SERVICE_NAME>"
 ```
+
+The kubectl init-container check is the authoritative post-restart signal — the pod is injected the moment that init container appears. `tracers list` is telemetry-derived and lags, so don't read an empty result immediately after a restart as "injection didn't happen."
 
 **Does the namespace carry the Admission Controller opt-in label?**
 When the Admission Controller runs with `mutateUnlabelled: false`, injection happens only in namespaces explicitly labeled `admission.datadoghq.com/mutate-pods=true`. A namespace missing this label silently has SSI skipped for every pod in it — a common cause when most cluster services are instrumented but one namespace's services aren't.

--- a/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md
@@ -98,12 +98,11 @@ Read this before investigating. It gives you the mental model to reason about no
 5. Application process loads the library automatically on startup via `LD_PRELOAD`
 
 **What each diagnostic layer can see:**
-- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no instrumented pods, the problem is in the cluster.
+- **pup** — sees what Datadog's backend received. Blind to cluster-side injection failures. If pup shows no tracer telemetry for the service, the problem is in the cluster.
 - **kubectl** — sees cluster state. Blind to whether data reached Datadog. If kubectl shows the init container but pup shows no traces, the problem is post-injection.
 
 **What healthy looks like:**
-- `pup fleet instrumented-pods list` shows the pod with correct language/version
-- `pup fleet tracers list` shows the service as active
+- `pup fleet tracers list` shows the service as active, with the expected language
 - `kubectl get pod -o jsonpath='{.spec.initContainers[*].name}'` includes `datadog-lib-<language>-init`
 
 **Known silent failures — SSI produces no error when these occur:**
@@ -127,7 +126,7 @@ Run all seven simultaneously and surface them back to the user as the diagnostic
 
 ```bash
 pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
-pup fleet instrumented-pods list <CLUSTER_NAME>
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
 pup apm troubleshooting list --hostname <NODE_HOSTNAME> --timeframe 1h
 pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>
 kubectl get pod <POD_NAME> -n <APP_NAMESPACE> \
@@ -151,7 +150,7 @@ Your final response is the deliverable — not your investigation transcript. It
   - `pup apm troubleshooting list --hostname <NODE_HOSTNAME>` — surfaces injection errors Datadog received from the node
   - `pup apm service-library-config get --service-name <SERVICE_NAME> --env <ENV>` — shows the tracer's runtime SDK config
 
-  Run them if `pup` is available; recommend them for the user to run if it isn't. Do **not** substitute `pup fleet instrumented-pods list` or `pup traces search` for these — those are different checks and do not satisfy the runbook. If you don't know `<ENV>`, state your assumed value and run the command anyway.
+  Run them if `pup` is available; recommend them for the user to run if it isn't. Do **not** substitute `pup traces search` for these — it is a different check and does not satisfy the runbook. If you don't know `<ENV>`, state your assumed value and run the command anyway.
 - **Stopping at the first root cause.** When multiple services are affected, investigate and report each one independently — they may have different causes — and give per-service remediation.
 
 ---
@@ -164,10 +163,10 @@ Before investigating, explicitly state your ranked hypotheses based on triage ou
 
 | Triage signal | Strong hypothesis |
 |---|---|
-| Traces arriving + pod in instrumented list | Not a real problem — likely a UI filter or time window. Tell the user and stop |
-| No traces + pod NOT in instrumented list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
-| No traces + pod NOT in instrumented list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
-| No traces + pod in instrumented list + init container present | Tracer injected but not reporting — investigate: connectivity, DD_SITE, API key |
+| Traces arriving + service in tracers list | Not a real problem — likely a UI filter or time window. Tell the user and stop |
+| No traces + service NOT in tracers list + no init container | Injection never happened — investigate: namespace targeting, webhook, pod-selector, opt-out annotation, pod not restarted |
+| No traces + service NOT in tracers list + init container present | Injection attempted but failed — check `pup apm troubleshooting list` for injection errors |
+| No traces + service in tracers list + init container present | Tracer reporting telemetry but traces not arriving — investigate: connectivity, DD_SITE, API key, trace sampling |
 | Pod events show CrashLoopBackOff or init container errors | Init container failure — check existing ddtrace, runtime version |
 | Traces arriving but wrong service/env | UST labels missing or misconfigured on the Deployment |
 
@@ -203,7 +202,7 @@ kubectl wait --for=condition=Ready pod -l app=<APP_LABEL> -n <APP_NAMESPACE> --t
 ### Claude runs
 
 ```bash
-pup fleet instrumented-pods list <CLUSTER_NAME>
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
 ```
 
 **Does the namespace carry the Admission Controller opt-in label?**
@@ -402,10 +401,10 @@ Re-run triage to confirm the fix worked:
 
 ```bash
 pup traces search --query "service:<SERVICE_NAME>" --from 1h --limit 5
-pup fleet instrumented-pods list <CLUSTER_NAME>
+pup fleet tracers list --filter "service:<SERVICE_NAME>"
 ```
 
-If traces are arriving and the pod is in the instrumented list — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
+If traces are arriving and the service appears in `pup fleet tracers list` — resolved. Automatically proceed to `onboarding-summary` now — do not ask the user for permission.
 
 ERROR: Still not resolved — return to Step 2 with the new triage data and form updated hypotheses.
 

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -144,7 +144,7 @@ ERROR: Config missing but `ddTraceConfigs` was configured — check it is presen
 
 Exit when ALL of the following are true:
 - [ ] Step 1: target pods have SSI init containers injected (`datadog-lib-<language>-init`)
-- [ ] Step 2: service appears in `tracers list` with active status
+- [ ] Step 2: service appears in `pup apm services list` with `isTraced: true`
 - [ ] Step 3: tracer config matches what was set in `DatadogAgent`
 
 If any check fails, go to `troubleshoot-ssi`.

--- a/dd-apm/k8s-ssi/verify-ssi/SKILL.md
+++ b/dd-apm/k8s-ssi/verify-ssi/SKILL.md
@@ -143,7 +143,7 @@ ERROR: Config missing but `ddTraceConfigs` was configured — check it is presen
 ## Done
 
 Exit when ALL of the following are true:
-- [ ] Step 1: target pods appear in `instrumented-pods list`
+- [ ] Step 1: target pods have SSI init containers injected (`datadog-lib-<language>-init`)
 - [ ] Step 2: service appears in `tracers list` with active status
 - [ ] Step 3: tracer config matches what was set in `DatadogAgent`
 


### PR DESCRIPTION
## What

The dd-apm Kubernetes SSI skills instruct the agent to run `pup fleet instrumented-pods list <CLUSTER_NAME>`, but that pup command **no longer exists**. `datadog-labs/pup` removed both `pup fleet instrumented-pods list` and `pup fleet clusters list` in [`656c2e2`](https://github.com/datadog-labs/pup/commit/656c2e2) (2026-06-18, "Bump SDK version."). The skills install pup via `releases/latest`, so the step fails at runtime once a release carries the removal.

**Verified against current pup `main` (fetched fresh):** `src/commands/fleet.rs` has no `instrumented_pods` / `clusters_list` handler — the present fleet subcommands are `agents (list/get/versions/tracers)`, `deployments`, `schedules`, and `tracers list`. (pup's own `docs/COMMANDS.md` / `docs/EXAMPLES.md` still advertise the removed commands — tracked separately, not in this PR.)

## Fix

Replace the removed command with the still-supported **`pup fleet tracers list --filter "service:<SERVICE_NAME>"`** — the backend/telemetry signal these skills already rely on (troubleshoot-ssi lines 106 & 326). This preserves the skill's **two-layer diagnostic model** (pup = what Datadog's backend received; kubectl = cluster state); the `kubectl` init-container checks stay as the cluster-side ground truth for "is this pod SSI-instrumented, with which language".

### Per-file changes
- **`troubleshoot-ssi/SKILL.md`** — swap the command at the three sites (Step 1 triage, Step 3 post-restart recheck, Step 6 verify); update the "what pup can see" and "what healthy looks like" prose; update the Step 2 triage hypothesis table so its signal is "in tracers list" instead of "in instrumented list". Triage still runs **seven** commands.
- **`onboarding-summary/SKILL.md`** — drop the now-unbacked "Pod instrumented" report row. The "Init container injected" (cluster) and "Tracer reporting" (backend, with version) rows already establish that the pod is instrumented and reporting.
- **`verify-ssi/SKILL.md`** — align the Step 1 "Done" checklist item to the init-container check Step 1 **actually runs** (it never used `pup`; it was a stale reference to the removed command's output).

## Reviewer note (please sanity-check)

The Step 2 hypothesis table previously used "pod **in instrumented list**" as a distinct backend signal from "init container present". `tracers list` is telemetry-derived (tracer reporting) rather than an injection registry, so the last row's diagnosis was reworded from *"tracer injected but not reporting"* to *"tracer reporting telemetry but traces not arriving"* to stay accurate to the new signal. The 4-row decision tree and its failure modes are otherwise unchanged. Happy to instead collapse the table to `traces + init-container` only if you prefer not to lean on `tracers list` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
