### PR TITLE
replay-trace: pup CLI fallback + auto local-setup for non-runnable apps

### DIFF
--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -17,273 +17,133 @@ description: >-
 # Replay a trace against local code
 
 A fast **iteration loop** on a single production trace: take a trace whose output a developer didn't like,
-optionally change the code to fix it, **re-run that trace against their LOCAL code**, and show a concise
-diff of old vs new output — repeating until they're happy. It assumes nothing about the project's layout.
+optionally change the code, **re-run it against their LOCAL code**, and show a concise diff of old vs new
+output — repeating until they're happy. Assumes nothing about the project's layout.
 
-Invoked from the developer's coding agent (they paste a CTA from the Agent Observability UI):
-`/agent-observability-replay-trace <trace-id> [<changes to test>]`.
+Invoked from the developer's coding agent: `/agent-observability-replay-trace <trace-id> [<changes to test>]`.
+With no modification, do the replay + diff only (a reproduce/regression check), then offer to enter the loop.
 
-## The loop (what you're building each run)
-
-1. Fetch the trace and read its output (the baseline).
-2. If a change was requested, edit the local code to address it — **show the changes and get an OK before replaying**.
-3. **Replay**: re-run the entrypoint locally so it emits a **new trace**.
-4. Wait for the new trace, then show a **concise diff** of old vs new output.
-5. Satisfied → done. Not satisfied → the developer says what's still wrong → back to step 2. Iterate.
-
-With **no** modification (`/agent-observability-replay-trace <trace-id>`): do the replay + diff only (a
-reproduce/regression check), then offer to enter the edit loop.
+**This file is the workflow spine — terse on purpose. The depth lives in `references/details.md` (trace
+backend + pup flags, the runner contract, export mode, polling, the trace-link scoping fix) and
+`references/local-setup.md` (making a deployed-only app locally runnable). Read `details.md` before you touch
+pup or generate the runner.**
 
 ## Interaction model — selector gates, never a hard stop
 
-This is a live loop. At every decision point, present the choices as an **interactive selector** (the
-`AskUserQuestion` tool — the same menu style as plan mode), **not** a plain question that ends your turn.
-There are two gates: (a) after you **propose code changes**, before replaying; and (b) after **each diff
-view**. Keep re-presenting the selector after every replay until the user explicitly chooses to finish —
-do not stop mid-loop. Only end when they pick "Looks good — stop here".
+This is a live loop. At every decision point present the choices as an **`AskUserQuestion` selector** (the
+plan-mode-style menu), not a plain question that ends your turn. Two gates: (a) after you propose code
+changes, before replaying; (b) after each diff. The selector's free-text option lets the user type detail
+(what to refine) inline — act on it directly, don't ask a follow-up. Keep re-presenting after every replay
+until they pick "stop here".
 
-The selector always offers a **free-text option**, so when a choice needs detail (what to refine, what to
-adjust), the user types it **right in the selector** — you get their description in the same view. Treat
-that free-text as the instruction and act on it directly; don't follow up with a separate question.
+## Scope — check first
 
-## Scope — check this first
-
-- **Traced with `ddtrace` / LLM Obs**, with an `ml_app` and a discoverable entrypoint. **Python is
-  first-class**; other languages work in principle (the loop is language-neutral) but you must learn that
-  language's build/run command and generate the runner in it.
-- **Entrypoint input JSON-serializable.** The runner invokes the entrypoint with a JSON input.
-- **A callable seam.** Not the binary "is the app locally runnable?" — ask **what is the innermost callable
-  seam corresponding to the trace's root span, and can it be called directly with a JSON input?** A
-  deployed-only HTTP/gRPC service often still exposes a plain callable underneath its handler (the common
-  ports-and-adapters / hexagonal case) — full local-setup would be overkill, but "already runnable" is also
-  wrong. Only when no seam can be called directly — truly deployed-only, or one needing live infra — does the
-  skill offer to **set up a local testing flow** first (see `references/local-setup.md`); it still needs you
-  for secrets and the stub-vs-real call.
-- **Needs a trace-access backend** — the `datadog-llmo` MCP (preferred) or the `pup` CLI (step 0).
-- **Credentials:** `DD_API_KEY` + `DD_SITE` + the agent's provider key(s). **Not** `DD_APP_KEY` — this
-  replays into a plain trace, not an Experiment.
-- **Side effects:** replaying re-runs real code (real model spend + any real writes the agent does). See
-  step 6 — warn before the first replay.
-
-## Why trace-only (not an Experiment)
-
-This is deliberately **not** the Experiments path (that's `agent-observability-replay-experiment`). Re-running
-the app just emits a normal new trace; the comparison is an LLM diff of the two traces' outputs. This keeps
-it lightweight, drops the `DD_APP_KEY` requirement, and isn't limited to Python's Experiments SDK. Details in
-`references/details.md` — read it before generating the runner.
+- **Traced with `ddtrace` / LLM Obs** (an `ml_app` + a discoverable entrypoint). **Python is first-class**;
+  other languages work but you write the runner to the contract in their SDK/build tooling.
+- **JSON-serializable entrypoint input**, and a **callable seam** for the root span (see step 3.5 — not a
+  binary "is it runnable?"; deployed-only apps often still expose a plain callable).
+- **A trace-access backend** — the `datadog-llmo` MCP (preferred) or `pup` (step 0).
+- **Credentials:** `DD_API_KEY` + `DD_SITE` + provider key(s). **Not `DD_APP_KEY`** — plain trace, not an
+  Experiment (that's `agent-observability-replay-experiment`).
+- **Side effects:** replaying re-runs real code (model spend + any real writes). Warn before the first replay.
 
 ## Workflow
 
-### 0. Ensure a trace-access backend (MCP preferred, pup fallback)
-The skill reads traces through a **trace-access backend** — the `datadog-llmo` MCP (preferred, richest) or
-the **pup CLI** as a fallback. Later steps say "fetch the trace / read span content / poll for spans"
-without caring which; the two backends map like this:
-
-| operation | MCP backend | pup backend |
-|---|---|---|
-| fetch a trace | `get_llmobs_trace` | `pup llm-obs spans get-trace --trace-id <id>` |
-| read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
-| poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |
-
-**pup response shape (parse this, not the top level):** pup nests results under **`data.spans[]`**, and when
-it detects an AI agent it wraps the whole payload in `{status, data, metadata}` (its own `metadata.note`
-suggests `--no-agent` for scripts). Parsing the top level yields **zero hits on a trace that is actually
-ingested** — the single most dangerous failure here, because a wrong "0 spans" reads as a normal "not found"
-(see step 7). Pass `--no-agent` to stabilize the parse path, and always look under `data.spans[]`.
-
-**pup exact usage** (the flags are non-obvious, but this copy has drifted before — treat `pup <cmd> --help`
-and pup's own error text as the source of truth, and keep only the genuinely non-obvious bits below):
-- `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a flag (not positional); the
-  default window is **1h**, so pass `--from` as a **bare duration** (`30d`, `7d`, `1h`) — `now-30d` is
-  rejected. Returns `total_duration_ms` and a ready `trace_url`. **Carry the `trace_id` forward — not the
-  `apm_trace_id`** that also appears in results; feeding `apm_trace_id` back into get-trace 404s.
-- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output --from 30d` —
-  span-id comes from get-trace; `--field` is required. **get-content has the same 1h default window**, so
-  pass `--from` for older traces — a 404 `"span not found: <id>"` there is usually the **window**, not a bad
-  span id.
-- `pup llm-obs spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"` — the
-  tag filter is a plain `key:value` in `--query` (the MCP-style `@replay_run_id:` matches nothing). Full
-  results include each span's `output`, `tags`, and `trace_url`.
-- Add `--org <name>` (or ensure `pup auth` picked the app's org) — a mismatched org returns a bare
-  `404 "no spans found"`, not an auth error.
-
-Pick a backend, in order:
-1. If `mcp__datadog-llmo-mcp__*` tools are present → use the **MCP**.
-2. Else if `pup` is installed and `pup auth` points at the app's org → use **pup**.
-3. Else **guide the user to install the MCP** — it's the one-command option (easier than pup's
-   brew-install + `pup auth login`):
-   `claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'`
-   (pup stays a "use it if already present" fallback — don't send users to install it.) Resume once a
-   backend is available; do not proceed without one.
+### 0. Ensure a trace-access backend
+Pick, in order: (1) MCP if `mcp__datadog-llmo-mcp__*` tools are present; (2) else `pup` if installed and
+`pup auth` targets the app's org; (3) else guide the **one-command MCP install** —
+`claude mcp add --scope user --transport http "datadog-llmo-mcp" '…?toolsets=llmobs'` (pup stays a
+use-if-present fallback, not something to install). Don't proceed without a backend.
+The backend↔operation mapping and **pup's exact flags/gotchas are in `details.md` — read that section before
+using pup.** The one pup thing you must not miss: parse results under **`data.spans[]`** with `--no-agent` —
+reading the top level returns **zero hits on an ingested trace**, a silent false negative (step 7).
 
 ### 1. Parse the command
-`<trace-id>` (required) and an optional free-text modification (everything after the id). No modification →
-reproduce/diff-only mode. Determine the `ml_app` from the project (`LLMObs.enable(ml_app=…)` /
-`DD_LLMOBS_ML_APP`) or the trace; confirm if ambiguous.
+`<trace-id>` + optional free-text modification (everything after the id); none → diff-only mode. Determine
+the `ml_app` from the project (`LLMObs.enable(ml_app=…)` / `DD_LLMOBS_ML_APP`) or the trace; confirm if
+ambiguous.
 
-### 2. Fetch the trace
-Fetch it via the backend (MCP `get_llmobs_trace` / pup `spans get-trace`), reading span content as needed
-(MCP `get_llmobs_span_content` / pup `spans get-content`). Read its `metadata.replay_input` /
-`metadata.replay_entrypoint` if present, note its `total_duration_ms` (drives the step 7 timeout) and its
-`trace_url` (both backends return one). (In pup mode the default window is 1h — pass `--from 30d` (bare
-duration, **not** `now-30d`) for older traces.)
+### 2. Fetch the trace + locate the baseline
+Fetch via the backend; note `total_duration_ms` (drives step 7), the `trace_url`, and
+`metadata.replay_input`/`replay_entrypoint` if present. **Locate the baseline field — it's not always the
+root output:** the value the developer dislikes may be a tool-call input or an intermediate output several
+levels deep, and the app may post-process it before the span records it. Pick the field the code change can
+actually move, or the delta drowns in noise.
 
-**Locate the baseline field — don't assume it's the root output.** The value the developer is dissatisfied
-with is often **not** the root span's output (which may be a summary/counter carrying nothing about the
-change) — it can be a tool-call **input** or an intermediate output several levels deep. Find the span
-field(s), at whatever depth, that actually express the complaint, and use those as the diff baseline. Also
-check whether the app **post-processes** that value between what the model produced and what the span
-records (e.g. appending deterministic boilerplate): if two plausible "before" values exist, pick the one the
-code change can actually move, or the delta drowns in noise.
-
-### 2.5. Check for fan-out before replaying the whole root
-If the root span **fans out into repeated sibling subtrees** (a batch/map that dispatches N parallel
-sub-runs), the change under test is usually visible in a **single** representative branch. Replaying the
-whole root then costs ~N× the model spend and wall-clock for no extra signal. Surface the fan-out and offer
-to replay one representative branch instead of the entire root; **log what you skipped** (consistent with
-the skill's "no silent caps" instinct). Only replay the full root if the change is inherently cross-branch.
+### 2.5. Check for fan-out
+If the root span **fans out into repeated sibling subtrees** (a batch/map over N parallel sub-runs), the
+change under test is usually visible in a **single** branch — replaying the whole root costs ~N× spend and
+time for no extra signal. Offer to replay one representative branch; **log what you skipped**. Full root only
+if the change is inherently cross-branch.
 
 ### 3. Resolve the entrypoint + input
-- **Entrypoint:** if `metadata.replay_entrypoint` is present, use it as the dispatch id. If absent, **infer**
-  the entrypoint from the root span (name/kind) + code and **ask the user to confirm** before proceeding.
-- **Input:** if `metadata.replay_input` is present, use it. If absent, derive a **suggested** input from the
-  trace (best-effort — the rendered prompt is lossy, so prefer the code signature) and have the user
-  **confirm or edit** it.
+- **Entrypoint:** `metadata.replay_entrypoint` if present; else infer from the root span (name/kind) + code
+  and **confirm with the user**.
+- **Input:** `metadata.replay_input` if present; else derive a **suggested** input (prefer the code
+  signature — the rendered prompt is lossy) and have the user **confirm/edit**.
 
 ### 3.5. Ensure a local run path (find the innermost callable seam)
-Replay re-runs the entrypoint **locally**. Resolve this by asking **"what is the innermost callable seam for
-this root span, and can I call it directly with JSON?"** — not the binary "is the app runnable?":
-- **Seam already directly callable** (an importable function you can call) → **skip this step**, continue.
-- **Seam buried under a handler/service** (deployed-only HTTP/gRPC, no local `__main__`/CLI, deps not
-  installed, live-infra coupling) → **read `references/local-setup.md` and follow it**: detect the gap,
-  **propose** a local testing flow, get one approval, then build it (pausing only for secrets and the
-  stub-vs-real decision).
+Ask **"what is the innermost callable seam for this root span, and can I call it directly with JSON?"** — not
+"is the app runnable?". Already directly callable → **skip, continue**. Buried under a handler/service
+(deployed-only, no local `__main__`, live-infra coupling) → follow **`references/local-setup.md`** (detect →
+propose → approve → build). The common middle case — a deployed service whose core logic is *already* a plain
+callable (ports-and-adapters) — just extract/call that seam; full local-setup is overkill.
 
-The middle case — a deployed service whose core logic is *already* a plain callable with local-dev seams —
-is the **normal** ports-and-adapters shape: extract/call that seam rather than running full local-setup.
-
-### 4. Ensure the two persistent artifacts (one-time setup, reused every iteration)
-- **a) In-entrypoint annotation** — so future traces self-describe. If the entrypoint doesn't already
-  annotate its root span, add it (best-effort, non-destructive):
+### 4. Ensure the two persistent artifacts (one-time setup)
+- **a) In-entrypoint annotation** on the app's **real** entrypoint, so all future traces (production too)
+  self-describe:
   ```python
-  LLMObs.annotate(span=span, metadata={
-      "replay_entrypoint": "<stable id for this type>",
-      "replay_input": <input extractor>,   # e.g. {"tickers": tickers}
-  })
+  LLMObs.annotate(span=span, metadata={"replay_entrypoint": "<stable id>", "replay_input": <extractor>})
   ```
-  (No `replay_output` — the original trace is the baseline; the diff reads outputs from the traces.)
-- **b) The runner** — a small CLI that satisfies the **language-independent runner contract** in
-  `references/details.md` (load env → derive `<ml_app>-local` → dispatch one entrypoint on JSON input →
-  **flush on every exit path, including errors** → print the `-local` ml_app). For **Python**, copy
-  `scripts/replay_runner_template.py` → `replay_runner.py` and fill its **`ENTRYPOINTS` dispatch table** (one
-  entry per type, keyed by `replay_entrypoint` → function + sync/async). For **other languages, write the
-  runner to the same contract** — do not assume the Python template's API shape carries over (e.g. Go uses
-  `tracer.Start(WithLLMObsEnabled/WithLLMObsMLApp/WithLLMObsAgentlessEnabled)`, not `LLMObs.enable(...)`, and
-  needs an explicit flush before exit **on the error path too**, or a failed replay leaves no diffable trace;
-  the `DD_TAGS` correlation marker does carry across languages). Extend the table/dispatch when new
-  entrypoints appear; keep the file.
-  - **Run command:** infer it (venv/interpreter/build) from the project and **confirm it** with the user.
-    Follow the host repo's **build-file conventions** for the new source file — repos with generated build
-    metadata (Bazel/Gazelle, Pants, Buck, or a lockfile/manifest to regenerate) need that step or the runner
-    won't build. On a **transient dependency-fetch failure**, retry the build **once** before reporting a
-    break. If the entrypoint needs non-serializable live infra, ask how to build it or skip it.
-  - **Export mode:** check how the app ships spans before replaying. The Python template defaults to
-    agentless (`agentless_enabled=True`), which is what you want locally, but a service may be wired to a
-    local Agent sidecar. Prefer **agentless** for the replay. Pre-empt a benign gotcha: with agentless LLM
-    Obs on, the APM tracer may still dial `localhost:8126` and log `ERROR: lost N traces … connection
-    refused` — **harmless** (LLM Obs spans ship independently and arrive fine); flag it so it isn't mistaken
-    for a failed replay (it compounds the false-negative in step 7).
+  No `replay_output` — the original trace is the baseline.
+- **b) The runner** — satisfies the **language-independent runner contract in `details.md`** (load env →
+  derive `<ml_app>-local` → dispatch one entrypoint on JSON → **flush on every exit path incl. errors** →
+  print the `-local` ml_app). **Python:** copy `scripts/replay_runner_template.py` and fill `ENTRYPOINTS`.
+  **Other languages:** write to the contract — don't assume the Python API carries over (see the Go notes +
+  export-mode gotchas in `details.md`). Infer + **confirm the run command**, and follow the host repo's
+  **build-file conventions** for the new file (Bazel/Gazelle, lockfiles, …).
 
-### 5. (If a change was requested) edit the code, then gate on a selector
-Analyze the trace + the request, make the code changes, show the developer the diff of your changes, then
-present an `AskUserQuestion` **selector** (not a plain question) — e.g.:
-- **Replay now** — proceed to step 6.
-- **Adjust the changes first** — the user says what to adjust; edit again and re-present this gate.
-- **Cancel** — stop without replaying.
-Only replay on the "Replay now" choice.
+### 5. (If a change was requested) edit, then gate
+Make the code changes, show the developer the diff of your changes, then an `AskUserQuestion` selector:
+**Replay now** / **Adjust the changes first** / **Cancel**. Only replay on "Replay now".
 
 ### 6. Replay
-**Before the first replay, run an ambient-environment check and surface it (don't silently correct).** An
-ambient var in the shell can quietly reroute the replay so it doesn't match production — a fidelity gap that
-is **invisible in the diff**. Check for: a provider API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) that
-could make the SDK **bypass the app's configured model gateway**, and ambient `DD_*` that could send the
-trace to a different org/site. The runner's `load_dotenv(override=True)` handles `DD_*`, but provider
-credentials change what the diff is *worth*, so **report what you found** and let the user decide.
-
-**Before the first replay, warn:** re-running executes the agent for real — model calls cost tokens and any
-external writes (DB/email/billing/queues) happen again. On confirmation, record the launch time `t0`, then
-invoke the runner with the entrypoint id + input (as a JSON file), passing a unique correlation marker as a
-span tag via the environment:
+Before the first replay: **warn** (re-running is real — model spend + real writes), and **check the ambient
+environment** and surface it — a provider key (`OPENAI_API_KEY`, …) or ambient `DD_*` in the shell can
+reroute the model gateway or telemetry so the replay doesn't match production, a fidelity gap **invisible in
+the diff**. Report what you found; let the user decide.
+On confirmation, record `t0` and run (marker in the env):
 ```
-DD_TAGS=replay_run_id:<unique-id> <python> replay_runner.py --entrypoint <id> --input-file <path>
+DD_TAGS=replay_run_id:<unique-id> <run cmd> --entrypoint <id> --input-file <path>
 ```
-The runner runs the entrypoint **directly — no wrapper span — so the replay trace looks identical to a
-normal run**, and the marker rides along as a tag on the emitted spans.
-
-**Local replays emit under `<ml_app>-local`** (the app's ml_app + `-local`) so they never pollute the
-production ml_app — the original trace stays under the real ml_app; the new one lands under `-local`. The
-runner does this automatically and prints the `-local` ml_app; poll for the new trace **under that name**.
+The runner emits **under `<ml_app>-local`** (idempotent, so replays never pollute production) and prints that
+name — poll for the new trace **under it**.
 
 ### 7. Wait for the new trace
-Two waits, keyed off the original trace's duration (`total_duration_ms`, read in step 2):
-- **Runner run:** give the runner subprocess a timeout of `max(120s, ~3 × total_duration_ms)` — the replay
-  runs the same code, so it takes roughly the original duration; 3× catches a hung/stuck run without
-  tripping on a normal one.
-- **Ingest:** once the runner returns, tell the user **"waiting for the new trace to appear in Datadog…"**
-  and poll the backend **every ~5s for up to ~2 min** for the `replay_run_id` tag (from ≈ `t0`), **under the
-  `<ml_app>-local` name** the runner printed (not the production ml_app): MCP `search_llmobs_spans`
-  (`ml_app: <ml_app>-local`, `tags: {replay_run_id: <id>}`) or pup `spans search --ml-app <ml_app>-local
-  --root-spans-only --from <t0> --query "replay_run_id:<id>"` (plain `key:value`, not `@`). If that tag
-  isn't queryable, fall back to the **newest root span** under `<ml_app>-local` for this entrypoint created
-  after `t0`. Ingest lag is seconds-to-~2 min and does **not** scale with duration.
-  **Sanity check before you ever report "not found":** re-query with **no tag filter** (just the
-  `<ml_app>-local` + time window) to distinguish "nothing ingested" from "my filter/parse is wrong." A
-  parse/scope mistake (e.g. reading pup's top level instead of `data.spans[]`, or polling the production
-  ml_app) produces a **confident false negative** — telling the user the replay never landed when it did,
-  which reads as normal and invites a wasteful re-run. If the unfiltered query returns spans, the problem is
-  your filter, not ingestion.
-  **Don't hard-fail** on timeout: say it hasn't appeared yet and offer to keep waiting.
+- **Runner subprocess timeout** = `max(120s, ~3 × total_duration_ms)`.
+- **Ingest poll:** after it returns, poll the backend **every ~5s up to ~2 min** for the `replay_run_id` tag
+  under `<ml_app>-local` (pup: `--query "replay_run_id:<id>"`, plain `key:value`). **Before ever reporting
+  "not found," re-query with no tag filter** (just `<ml_app>-local` + window): if that returns spans, your
+  filter/parse/scope is wrong — **not** ingestion. A false "no trace" is the worst outcome (reads as normal,
+  invites a wasteful re-run). Don't hard-fail; offer to keep waiting.
 
-### 8. Summarize the diff (with links to both traces)
-Fetch the new trace and give a **concise** summary of how the **new output differs from the old** — just the
-meaningful output differences, not the full span trees. Note that live-world drift (time, prices, search
-results) can differ even with unchanged code. **When the edit targeted model-facing text** (a prompt, system
-message, or tool schema) rather than deterministic code, add that **model sampling variance is a separate
-confound**: a single replay can't separate "my change worked" from "this sample differed." Say plainly that
-n=1 is *suggestive, not conclusive*, and offer to replay 2–3 units (or the same unit twice) to tell them
-apart.
+### 8. Diff (with links to both traces)
+Concise summary of how the **new output differs from the old** — meaningful differences only. Note live-world
+drift; and if the edit targeted **model-facing text** (prompt/system/tool-schema), sampling variance makes
+n=1 *suggestive, not conclusive* — offer 2–3 replays. Lead the diff with both trace links:
+- **Old:** `trace_url` **verbatim**.
+- **New (replay):** must carry `ml_app=<ml_app>-local` or it opens **empty** — and the `trace_url` is an
+  org-switch wrapper (`…/switch_to_user/<id>?next=<encoded /llm/traces …>&flow=org_switch`), so **inject
+  `ml_app=<ml_app>-local` into the decoded `next` query and re-encode; do NOT append to the outer URL**
+  (mechanics in `details.md`). Browser-unverifiable from here — confirm once it opens non-empty.
 
-**Every diff view must start with clickable links to BOTH traces** so the developer can open either in the
-UI. Both backends return a ready `trace_url`, but there's one scoping trap:
-- **Old trace:** use its `trace_url` **verbatim** — do NOT hand-construct a `/llm/traces` URL.
-- **New (replay) trace:** the `trace_url` carries **no `ml_app`**, so opened as-is it scopes to whatever app
-  the user's picker last had (usually production) and renders **empty** — it must carry
-  `ml_app=<ml_app>-local`. **But the returned URL is an org-switch wrapper**
-  (`…/switch_to_user/<id>?next=<URL-encoded /llm/traces …>&flow=org_switch`) with the real `/llm/traces` path
-  encoded inside `next`. So **do NOT append `&ml_app=…` to the outer URL** — that lands after
-  `&flow=org_switch` on the `switch_to_user` endpoint, which ignores it and redirects to the decoded `next`
-  path (no ml_app). Instead: URL-**decode** the `next` value, add `ml_app=<ml_app>-local` to its
-  `/llm/traces` query, then re-encode `next` (keeping `&flow=org_switch`). If a backend ever returns a
-  **bare** `/llm/traces?…` URL (no wrapper), just add `&ml_app=<ml_app>-local` directly. *(This scoping can't
-  be verified from a coding agent — confirm the replay link opens non-empty in a browser once.)*
-```
-- [Old trace](<old trace_url — verbatim>)
-- [New trace](<new trace_url with ml_app=<ml_app>-local injected into the `next` path>)
-```
-The link text is just "Old trace" / "New trace". Then the diff summary.
-
-### 9. Iterate — gate on a selector (never a hard stop)
-After the diff, present an `AskUserQuestion` **selector** with two options (the tool also offers a free-text
-"Other"):
-- **Looks good — stop here** — finish; leave the code changes in the working tree for the user to review.
-- **Make more changes** — the user describes what to change **inline in the selector** (free-text); use
-  that description and go to step 5 (edit → gate → replay → diff). In diff-only mode, this is where the
-  first change is made.
-Re-present this gate after every replay until the user picks "stop here". Do not end your turn between iterations.
+### 9. Iterate — gate on a selector
+After the diff, an `AskUserQuestion` selector: **Looks good — stop here** (finish; leave the edits in the
+working tree) / **Make more changes** (free-text inline → back to step 5). Re-present after every replay;
+end only on "stop here".
 
 ## Reference
-- `scripts/replay_runner_template.py` — the runner to copy + fill. Read it first.
-- `references/details.md` — the trace-access backend (MCP or pup), the annotation + runner contract,
-  correlation-marker/polling, concise-diff guidance, and scope/limitations. Read before generating the runner.
-- `references/local-setup.md` — how to set up a local testing flow when the app isn't locally runnable
-  (step 3.5). Read only when that gap is detected.
+- `references/details.md` — trace backend + **pup exact flags**, the **runner contract** (+ Go, export mode),
+  polling + the false-negative sanity check, the **trace-link scoping fix**, limitations. Read before pup / the runner.
+- `references/local-setup.md` — making a deployed-only app locally runnable (step 3.5). Read when that gap shows.
+- `scripts/replay_runner_template.py` — the Python runner to copy + fill.

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -7,8 +7,8 @@ description: >-
   /agent-observability-replay-trace <trace-id> [changes to test]. Signals: "replay this trace"; "iterate on
   a trace"; "this trace's output is wrong, fix it and re-run"; "re-run trace <id> with <change>"; pasting a
   trace id from the Agent Observability UI with a description of what to fix. It fetches the trace via the
-  datadog-llmo MCP, edits code, re-runs the app to emit a NEW trace, and diffs the two — no local server,
-  no browser. For agents traced with ddtrace / LLM Obs (Python first-class), with JSON-serializable entry
+  datadog-llmo MCP (or the pup CLI as a fallback), edits code, re-runs the app to emit a NEW trace, and
+  diffs the two — no local server, no browser. For agents traced with ddtrace / LLM Obs (Python first-class), with JSON-serializable entry
   input. Do NOT use for: scored Experiments or the browser "Replay" button (that's
   agent-observability-replay-experiment), building an experiment from a dataset/CSV, writing evaluators,
   root-causing failed traces, or RUM/HTTP session replay.
@@ -51,10 +51,11 @@ that free-text as the instruction and act on it directly; don't follow up with a
 - **Traced with `ddtrace` / LLM Obs**, with an `ml_app` and a discoverable entrypoint. **Python is
   first-class**; other languages work in principle (the loop is language-neutral) but you must learn that
   language's build/run command and generate the runner in it.
-- **Entrypoint input JSON-serializable.** If the entrypoint needs non-serializable live infra rebuilt at
-  replay (DB/API clients, a `deps`/context object), the runner can't manufacture it — ask the user how, or
-  declare that entrypoint out of scope.
-- **Requires the `datadog-llmo` MCP** (step 0).
+- **Entrypoint input JSON-serializable.** The runner invokes the entrypoint with a JSON input.
+- **Locally runnable.** If the app can't be invoked locally with a JSON input — a deployed-only service, an
+  HTTP/gRPC handler entrypoint, or one needing live infra — the skill offers to **set up a local testing
+  flow** first (see `references/local-setup.md`); it still needs you for secrets and the stub-vs-real call.
+- **Needs a trace-access backend** — the `datadog-llmo` MCP (preferred) or the `pup` CLI (step 0).
 - **Credentials:** `DD_API_KEY` + `DD_SITE` + the agent's provider key(s). **Not** `DD_APP_KEY` — this
   replays into a plain trace, not an Experiment.
 - **Side effects:** replaying re-runs real code (real model spend + any real writes the agent does). See
@@ -69,10 +70,37 @@ it lightweight, drops the `DD_APP_KEY` requirement, and isn't limited to Python'
 
 ## Workflow
 
-### 0. Ensure the `datadog-llmo` MCP is available
-Discovery + diffing read traces via this MCP. Check for `mcp__datadog-llmo-mcp__*` (e.g.
-`get_llmobs_trace`, `search_llmobs_spans`). **If absent, stop and walk the user through installing it**
-(https://docs.datadoghq.com/bits_ai/mcp_server/setup/) and resume only once the tools appear.
+### 0. Ensure a trace-access backend (MCP preferred, pup fallback)
+The skill reads traces through a **trace-access backend** — the `datadog-llmo` MCP (preferred, richest) or
+the **pup CLI** as a fallback. Later steps say "fetch the trace / read span content / poll for spans"
+without caring which; the two backends map like this:
+
+| operation | MCP backend | pup backend |
+|---|---|---|
+| fetch a trace | `get_llmobs_trace` | `pup llm-obs spans get-trace --trace-id <id>` |
+| read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
+| poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |
+
+**pup exact usage** (verified against pup 1.8.0 — the flags are non-obvious):
+- `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a flag (not positional); the
+  default window is **1h**, so pass `--from` as a **bare duration** (`30d`, `7d`, `1h`) — `now-30d` is
+  rejected. Returns `total_duration_ms` and a ready `trace_url`.
+- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output` — span-id comes
+  from get-trace.
+- `pup llm-obs spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"` — the
+  tag filter is a plain `key:value` in `--query` (the MCP-style `@replay_run_id:` matches nothing). Full
+  results include each span's `output`, `tags`, and `trace_url`.
+- Add `--org <name>` (or ensure `pup auth` picked the app's org) — a mismatched org returns a bare
+  `404 "no spans found"`, not an auth error.
+
+Pick a backend, in order:
+1. If `mcp__datadog-llmo-mcp__*` tools are present → use the **MCP**.
+2. Else if `pup` is installed and `pup auth` points at the app's org → use **pup**.
+3. Else **guide the user to install the MCP** — it's the one-command option (easier than pup's
+   brew-install + `pup auth login`):
+   `claude mcp add --scope user --transport http "datadog-llmo-mcp" 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs'`
+   (pup stays a "use it if already present" fallback — don't send users to install it.) Resume once a
+   backend is available; do not proceed without one.
 
 ### 1. Parse the command
 `<trace-id>` (required) and an optional free-text modification (everything after the id). No modification →
@@ -80,8 +108,11 @@ reproduce/diff-only mode. Determine the `ml_app` from the project (`LLMObs.enabl
 `DD_LLMOBS_ML_APP`) or the trace; confirm if ambiguous.
 
 ### 2. Fetch the trace
-`get_llmobs_trace` (and span content as needed). Read the **root span's output** — this is the baseline for
-the diff — and its `metadata.replay_input` / `metadata.replay_entrypoint` if present.
+Fetch it via the backend (MCP `get_llmobs_trace` / pup `spans get-trace`), reading span content as needed
+(MCP `get_llmobs_span_content` / pup `spans get-content`). Read the **root span's output** — this is the
+baseline for the diff — and its `metadata.replay_input` / `metadata.replay_entrypoint` if present. Also note
+its `total_duration_ms` (drives the step 7 timeout) and its `trace_url` (both backends return one). (In pup
+mode the default window is 1h — pass `--from 30d` (bare duration, **not** `now-30d`) for older traces.)
 
 ### 3. Resolve the entrypoint + input
 - **Entrypoint:** if `metadata.replay_entrypoint` is present, use it as the dispatch id. If absent, **infer**
@@ -89,6 +120,14 @@ the diff — and its `metadata.replay_input` / `metadata.replay_entrypoint` if p
 - **Input:** if `metadata.replay_input` is present, use it. If absent, derive a **suggested** input from the
   trace (best-effort — the rendered prompt is lossy, so prefer the code signature) and have the user
   **confirm or edit** it.
+
+### 3.5. Ensure a local run path (only if the app isn't locally runnable)
+Replay re-runs the entrypoint **locally**. If the app can't be invoked locally with a JSON input — a
+deployed-only service, an HTTP/gRPC handler entrypoint, no local `__main__`/CLI, deps not installed, or it
+needs live infra — **read `references/local-setup.md` and follow it**: detect the gap, **propose** a local
+testing flow, get one approval, then build it (pausing only for secrets and the stub-vs-real decision).
+**Skip this step entirely** when a local run path already exists (e.g. the entrypoint is an importable
+function you can call). Only then continue.
 
 ### 4. Ensure the two persistent artifacts (one-time setup, reused every iteration)
 - **a) In-entrypoint annotation** — so future traces self-describe. If the entrypoint doesn't already
@@ -131,8 +170,10 @@ Two waits, keyed off the original trace's duration (`total_duration_ms`, read in
   runs the same code, so it takes roughly the original duration; 3× catches a hung/stuck run without
   tripping on a normal one.
 - **Ingest:** once the runner returns, tell the user **"waiting for the new trace to appear in Datadog…"**
-  and poll the MCP **every ~5s for up to ~2 min**: `search_llmobs_spans` for the `replay_run_id` tag (from
-  ≈ `t0`). If that tag isn't queryable, fall back to the **newest root span** for this `ml_app` +
+  and poll the backend **every ~5s for up to ~2 min** for the `replay_run_id` tag (from ≈ `t0`): MCP
+  `search_llmobs_spans` (`tags: {replay_run_id: <id>}`) or pup `spans search --ml-app <app>
+  --root-spans-only --from <t0> --query "replay_run_id:<id>"` (plain `key:value`, not `@`). If that tag
+  isn't queryable, fall back to the **newest root span** for this `ml_app` +
   entrypoint created after `t0`. Ingest lag is seconds-to-~2 min and does **not** scale with duration.
   **Don't hard-fail** on timeout: say it hasn't appeared yet and offer to keep waiting.
 
@@ -142,9 +183,8 @@ meaningful output differences, not the full span trees. Note that live-world dri
 results) can differ even with unchanged code.
 
 **Every diff view must start with clickable links to BOTH traces** so the developer can open either in the
-UI. Use the **`trace_url` the MCP returns** for each trace (from `get_llmobs_trace`) **verbatim** — do NOT
-hand-construct the URL (the correct query is `?query=trace_id:<id>`, not `@trace_id:` or the APM `?traceID=`
-convention, so building it yourself gets it wrong):
+UI. **Both backends return a ready `trace_url`** for each trace (MCP `get_llmobs_trace`; pup
+`spans get-trace`/`search`) — use it **verbatim**, do NOT hand-construct a `/llm/traces` URL:
 ```
 - [Old trace](<old trace_url from get_llmobs_trace>)
 - [New trace](<new trace_url from get_llmobs_trace>)
@@ -162,5 +202,7 @@ Re-present this gate after every replay until the user picks "stop here". Do not
 
 ## Reference
 - `scripts/replay_runner_template.py` — the runner to copy + fill. Read it first.
-- `references/details.md` — the annotation + runner contract, correlation-marker/polling, concise-diff
-  guidance, and scope/limitations. Read before generating the runner.
+- `references/details.md` — the trace-access backend (MCP or pup), the annotation + runner contract,
+  correlation-marker/polling, concise-diff guidance, and scope/limitations. Read before generating the runner.
+- `references/local-setup.md` — how to set up a local testing flow when the app isn't locally runnable
+  (step 3.5). Read only when that gap is detected.

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -59,9 +59,14 @@ until they pick "stop here".
 
 ### 0. Ensure a trace-access backend
 Pick, in order: (1) MCP if `mcp__datadog-llmo-mcp__*` tools are present; (2) else `pup` if installed and
-`pup auth` targets the app's org; (3) else guide the **one-command MCP install** —
-`claude mcp add --scope user --transport http "datadog-llmo-mcp" '…?toolsets=llmobs'` (pup stays a
-use-if-present fallback, not something to install). Don't proceed without a backend.
+`pup auth` targets the app's org; (3) else guide the **one-command MCP install** (pup stays a
+use-if-present fallback, not something to install):
+```
+claude mcp add --scope user --transport http "datadog-llmo-mcp" \
+  "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs"
+```
+(Confirm the current server URL at https://docs.datadoghq.com/bits_ai/mcp_server/setup/.) Don't proceed
+without a backend.
 The backend↔operation mapping and **pup's exact flags/gotchas are in `details.md` — read that section before
 using pup.** Two pup musts: (1) results come back at **`data.spans[]`** *or* top-level **`spans[]`**
 (varies by version/`--no-agent`) — parse **whichever is present**, or you get zero hits on an ingested

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   /agent-observability-replay-trace <trace-id> [changes to test]. Signals: "replay this trace"; "iterate on
   a trace"; "this trace's output is wrong, fix it and re-run"; "re-run trace <id> with <change>"; pasting a
   trace id from the Agent Observability UI with a description of what to fix. It fetches the trace via the
-  datadog-llmo MCP (or the pup CLI as a fallback), edits code, re-runs the app to emit a NEW trace, and
+  datadog-llmo MCP or the pup CLI, edits code, re-runs the app to emit a NEW trace, and
   diffs the two — no local server, no browser. For agents traced with ddtrace / LLM Obs (Python first-class), with JSON-serializable entry
   input. Do NOT use for: scored Experiments or the browser "Replay" button (that's
   agent-observability-replay-experiment), building an experiment from a dataset/CSV, writing evaluators,
@@ -47,7 +47,8 @@ until they pick "stop here".
   other languages work but you write the runner to the contract in their SDK/build tooling.
 - **JSON-serializable entrypoint input**, and a **callable seam** for the root span (see step 3.5 — not a
   binary "is it runnable?"; deployed-only apps often still expose a plain callable).
-- **A trace-access backend** — the `datadog-llmo` MCP (preferred) or `pup` (step 0).
+- **A trace-access backend** — the `datadog-llmo` MCP (used when present) or the `pup` CLI (fallback, and
+  the easier install if you have neither) (step 0).
 - **Credentials:** `DD_API_KEY` + `DD_SITE` + provider key(s). **Not `DD_APP_KEY`** — plain trace, not an
   Experiment (that's `agent-observability-replay-experiment`).
 - **Side effects, irreversible:** replaying re-runs real code (model spend + real writes), and **LLM Obs
@@ -58,15 +59,15 @@ until they pick "stop here".
 ## Workflow
 
 ### 0. Ensure a trace-access backend
-Pick, in order: (1) MCP if `mcp__datadog-llmo-mcp__*` tools are present; (2) else `pup` if installed and
-`pup auth` targets the app's org; (3) else guide the **one-command MCP install** (pup stays a
-use-if-present fallback, not something to install):
+Pick, in order: (1) the **MCP** if `mcp__datadog-llmo-mcp__*` tools are present — the default (slightly
+richer for reads: structured tree + `content_info`); (2) else **`pup`** if installed and `pup auth` targets
+the app's org; (3) else the user has neither → guide the **pup install** (it's easier to set up than the
+MCP, so recommend pup here):
 ```
-claude mcp add --scope user --transport http "datadog-llmo-mcp" \
-  "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs"
+brew tap datadog-labs/pack && brew install datadog-labs/pack/pup
+pup auth login
 ```
-(Confirm the current server URL at https://docs.datadoghq.com/bits_ai/mcp_server/setup/.) Don't proceed
-without a backend.
+(MCP alternative: `claude mcp add --scope user --transport http "datadog-llmo-mcp" "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs"`; see https://docs.datadoghq.com/bits_ai/mcp_server/setup/.) Don't proceed without a backend.
 The backend↔operation mapping and **pup's exact flags/gotchas are in `details.md` — read that section before
 using pup.** Two pup musts: (1) results come back at **`data.spans[]`** *or* top-level **`spans[]`**
 (varies by version/`--no-agent`) — parse **whichever is present**, or you get zero hits on an ingested

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -28,6 +28,11 @@ backend + pup flags, the runner contract, export mode, polling, the trace-link s
 `references/local-setup.md` (making a deployed-only app locally runnable). Read `details.md` before you touch
 pup or generate the runner.**
 
+**Writing code — keep comments minimal to none.** Everything you generate or edit (the annotation, the
+runner's `ENTRYPOINTS` entries, a local harness, iteration edits) should match the surrounding code and
+carry **no unnecessary comments** — don't narrate what the code plainly does; add a comment only for a
+genuinely non-obvious *why*.
+
 ## Interaction model — selector gates, never a hard stop
 
 This is a live loop. At every decision point present the choices as an **`AskUserQuestion` selector** (the

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -50,7 +50,10 @@ until they pick "stop here".
 - **A trace-access backend** — the `datadog-llmo` MCP (preferred) or `pup` (step 0).
 - **Credentials:** `DD_API_KEY` + `DD_SITE` + provider key(s). **Not `DD_APP_KEY`** — plain trace, not an
   Experiment (that's `agent-observability-replay-experiment`).
-- **Side effects:** replaying re-runs real code (model spend + any real writes). Warn before the first replay.
+- **Side effects, irreversible:** replaying re-runs real code (model spend + real writes), and **LLM Obs
+  traces cannot be deleted** — a mis-scoped replay (wrong ml_app) *permanently* pollutes the production app's
+  dashboards/eval sets. That's why the `<ml_app>-local` isolation (steps 4/6/7) is load-bearing, not tidy.
+  Warn before the first replay.
 
 ## Workflow
 
@@ -60,8 +63,10 @@ Pick, in order: (1) MCP if `mcp__datadog-llmo-mcp__*` tools are present; (2) els
 `claude mcp add --scope user --transport http "datadog-llmo-mcp" '…?toolsets=llmobs'` (pup stays a
 use-if-present fallback, not something to install). Don't proceed without a backend.
 The backend↔operation mapping and **pup's exact flags/gotchas are in `details.md` — read that section before
-using pup.** The one pup thing you must not miss: parse results under **`data.spans[]`** with `--no-agent` —
-reading the top level returns **zero hits on an ingested trace**, a silent false negative (step 7).
+using pup.** Two pup musts: (1) results come back at **`data.spans[]`** *or* top-level **`spans[]`**
+(varies by version/`--no-agent`) — parse **whichever is present**, or you get zero hits on an ingested
+trace (a silent false negative, step 7); (2) check **token expiry** (`pup auth status`), not just that auth
+exists — expiry mid-loop looks like "trace not found."
 
 ### 1. Parse the command
 `<trace-id>` + optional free-text modification (everything after the id); none → diff-only mode. Determine
@@ -78,8 +83,10 @@ actually move, or the delta drowns in noise.
 ### 2.5. Check for fan-out
 If the root span **fans out into repeated sibling subtrees** (a batch/map over N parallel sub-runs), the
 change under test is usually visible in a **single** branch — replaying the whole root costs ~N× spend and
-time for no extra signal. Offer to replay one representative branch; **log what you skipped**. Full root only
-if the change is inherently cross-branch.
+time for no extra signal. Offer to replay one representative branch; **log what you skipped**. **Pick deliberately: the cheapest
+branch that reached the terminal / side-effecting tool** (most branches are no-ops that prove nothing), and
+reconstruct its input from the **child** span's input, not the root's. Full root only if the change is
+inherently cross-branch.
 
 ### 3. Resolve the entrypoint + input
 - **Entrypoint:** `metadata.replay_entrypoint` if present; else infer from the root span (name/kind) + code
@@ -96,30 +103,43 @@ callable (ports-and-adapters) — just extract/call that seam; full local-setup 
 
 ### 4. Ensure the two persistent artifacts (one-time setup)
 - **a) In-entrypoint annotation** on the app's **real** entrypoint, so all future traces (production too)
-  self-describe:
+  self-describe. Stamp it at **span start, not the success/deferred-finish path** — a failed run must still
+  carry `replay_input` (those are the ones you most want to replay):
   ```python
   LLMObs.annotate(span=span, metadata={"replay_entrypoint": "<stable id>", "replay_input": <extractor>})
   ```
-  No `replay_output` — the original trace is the baseline.
+  No `replay_output` — the original trace is the baseline. (Non-Python annotate APIs differ — e.g. Go
+  `span.Annotate(llmobs.WithAnnotatedMetadata(...))`; see `details.md`.)
+- **Isolation pre-flight (before writing the runner):** grep the entrypoint's call path for **per-span/
+  per-call ml_app overrides** (Go `llmobs.WithMLApp`; Python `ml_app=` on a decorator or in
+  `LLMObs.annotate`). Those **beat** the init-level `-local`, so the app's spans can still land in
+  production — tracer-level config is **not** proof of isolation. If any exist, the app's ml_app must
+  resolve from env so `-local` wins.
 - **b) The runner** — satisfies the **language-independent runner contract in `details.md`** (load env →
   derive `<ml_app>-local` → dispatch one entrypoint on JSON → **flush on every exit path incl. errors** →
-  print the `-local` ml_app). **Python:** copy `scripts/replay_runner_template.py` and fill `ENTRYPOINTS`.
-  **Other languages:** write to the contract — don't assume the Python API carries over (see the Go notes +
-  export-mode gotchas in `details.md`). Infer + **confirm the run command**, and follow the host repo's
-  **build-file conventions** for the new file (Bazel/Gazelle, lockfiles, …).
+  **refuse to start unless ml_app ends in `-local`** → print the `-local` ml_app). **Python:** copy
+  `scripts/replay_runner_template.py` and fill `ENTRYPOINTS`. **Other languages:** write to the contract —
+  don't assume the Python API carries over (Go APIs + export-mode gotchas in `details.md`), and where the
+  language has no in-process dotenv add a **run wrapper (artifact c)** that sources the project env, unsets
+  ambient provider vars, and exports the `-local` override. Infer + **confirm the run command**; follow the
+  host repo's **build-file conventions** (Bazel/Gazelle → `cmd/<name>/`, run Gazelle, build before replay).
 
 ### 5. (If a change was requested) edit, then gate
 Make the code changes, show the developer the diff of your changes, then an `AskUserQuestion` selector:
 **Replay now** / **Adjust the changes first** / **Cancel**. Only replay on "Replay now".
 
 ### 6. Replay
-Before the first replay: **warn** (re-running is real — model spend + real writes), and **check the ambient
-environment** and surface it — a provider key (`OPENAI_API_KEY`, …) or ambient `DD_*` in the shell can
-reroute the model gateway or telemetry so the replay doesn't match production, a fidelity gap **invisible in
-the diff**. Report what you found; let the user decide.
-On confirmation, record `t0` and run (marker in the env):
+Before the first replay: **warn** (re-running is real — model spend + real writes), and **sanitize the
+environment**. The **coding agent's own env** (`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` set by Claude
+Code, and other provider keys) can make the app's SDK **bypass its configured model gateway** — a fidelity
+gap **invisible in the diff**. **Unset ambient provider vars by default and report that you did** (don't
+just ask); grep the app for its own ambient-key guards. Also **verify the credential's org matches the
+trace's org** — a mismatch ships the replay somewhere you can't query (looks like ingest lag).
+On confirmation, record `t0` and run — **source the project's env file, never inline secrets** (the marker
+tag is fine on the command; `DD_API_KEY=<value>` inline is blocked by the permission classifier and leaks to
+history/transcript — use the wrapper/env-file):
 ```
-DD_TAGS=replay_run_id:<unique-id> <run cmd> --entrypoint <id> --input-file <path>
+DD_TAGS=replay_run_id:<unique-id> <run cmd or wrapper> --entrypoint <id> --input-file <path>
 ```
 The runner emits **under `<ml_app>-local`** (idempotent, so replays never pollute production) and prints that
 name — poll for the new trace **under it**.
@@ -129,23 +149,37 @@ name — poll for the new trace **under it**.
 - **Ingest poll:** after it returns, poll the backend **every ~5s up to ~2 min** for the `replay_run_id` tag
   under `<ml_app>-local` (pup: `--query "replay_run_id:<id>"`, plain `key:value`). **Before ever reporting
   "not found," re-query with no tag filter** (just `<ml_app>-local` + window): if that returns spans, your
-  filter/parse/scope is wrong — **not** ingestion. A false "no trace" is the worst outcome (reads as normal,
-  invites a wasteful re-run). Don't hard-fail; offer to keep waiting.
+  filter/parse/scope is wrong — **not** ingestion. A false "no trace" reads as normal and invites a wasteful
+  re-run.
+- **Verify isolation on each hit — a tag match is NOT proof.** `--query`/tag matching can return a span
+  whose real `ml_app` is a *different* app (the `--ml-app` filter gets ignored). Read `ml_app` off every
+  returned span and **assert it ends in `-local`** before reporting a clean replay — otherwise you report
+  "clean replay under `-local`" while the trace is actually in production (which you can't undo). This false
+  *confidence* is worse than the false negative. Don't hard-fail on timeout; offer to keep waiting.
 
 ### 8. Diff (with links to both traces)
 Concise summary of how the **new output differs from the old** — meaningful differences only. Note live-world
-drift; and if the edit targeted **model-facing text** (prompt/system/tool-schema), sampling variance makes
-n=1 *suggestive, not conclusive* — offer 2–3 replays. Lead the diff with both trace links:
-- **Old:** `trace_url` **verbatim**.
+drift; and because any nondeterministic agent varies run-to-run, **default to two replays** (diff-only mode
+too, not just model-facing edits) and use **replay-to-replay comparison** — if the two local runs differ
+from each other about as much as from production, the delta is sampling variance, not your change. If the
+replay **disables a side-effecting integration** (dry-run), that integration's subtree is absent — **exclude
+it from both sides** before comparing span counts, or the structural diff is junk. Lead the diff with both
+trace links:
+- **Old:** `trace_url` **verbatim** — but **under fan-out** (you replayed one branch) link the **branch
+  span**, not the whole-root url.
 - **New (replay):** must carry `ml_app=<ml_app>-local` or it opens **empty** — and the `trace_url` is an
   org-switch wrapper (`…/switch_to_user/<id>?next=<encoded /llm/traces …>&flow=org_switch`), so **inject
   `ml_app=<ml_app>-local` into the decoded `next` query and re-encode; do NOT append to the outer URL**
   (mechanics in `details.md`). Browser-unverifiable from here — confirm once it opens non-empty.
 
-### 9. Iterate — gate on a selector
-After the diff, an `AskUserQuestion` selector: **Looks good — stop here** (finish; leave the edits in the
-working tree) / **Make more changes** (free-text inline → back to step 5). Re-present after every replay;
-end only on "stop here".
+### 9. Gate — iterate, or stop on a broken harness
+**Harness-failure gate (before the diff):** if a replay reveals the harness is wrong — trace landed under
+the wrong ml_app, no trace after the step-7 sanity checks, missing flush, or auth/org misrouted — **do NOT
+proceed to a diff on bad data.** Stop and present a selector to fix the harness (re-scope ml_app / add flush
+/ fix env) and re-replay.
+Otherwise, after the diff, an `AskUserQuestion` selector: **Looks good — stop here** (finish; leave the edits
+in the working tree) / **Make more changes** (free-text inline → back to step 5). Re-present after every
+replay; end only on "stop here".
 
 ## Reference
 - `references/details.md` — trace backend + **pup exact flags**, the **runner contract** (+ Go, export mode),

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -52,9 +52,13 @@ that free-text as the instruction and act on it directly; don't follow up with a
   first-class**; other languages work in principle (the loop is language-neutral) but you must learn that
   language's build/run command and generate the runner in it.
 - **Entrypoint input JSON-serializable.** The runner invokes the entrypoint with a JSON input.
-- **Locally runnable.** If the app can't be invoked locally with a JSON input — a deployed-only service, an
-  HTTP/gRPC handler entrypoint, or one needing live infra — the skill offers to **set up a local testing
-  flow** first (see `references/local-setup.md`); it still needs you for secrets and the stub-vs-real call.
+- **A callable seam.** Not the binary "is the app locally runnable?" — ask **what is the innermost callable
+  seam corresponding to the trace's root span, and can it be called directly with a JSON input?** A
+  deployed-only HTTP/gRPC service often still exposes a plain callable underneath its handler (the common
+  ports-and-adapters / hexagonal case) — full local-setup would be overkill, but "already runnable" is also
+  wrong. Only when no seam can be called directly — truly deployed-only, or one needing live infra — does the
+  skill offer to **set up a local testing flow** first (see `references/local-setup.md`); it still needs you
+  for secrets and the stub-vs-real call.
 - **Needs a trace-access backend** — the `datadog-llmo` MCP (preferred) or the `pup` CLI (step 0).
 - **Credentials:** `DD_API_KEY` + `DD_SITE` + the agent's provider key(s). **Not** `DD_APP_KEY` — this
   replays into a plain trace, not an Experiment.
@@ -81,12 +85,22 @@ without caring which; the two backends map like this:
 | read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
 | poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |
 
-**pup exact usage** (verified against pup 1.8.0 — the flags are non-obvious):
+**pup response shape (parse this, not the top level):** pup nests results under **`data.spans[]`**, and when
+it detects an AI agent it wraps the whole payload in `{status, data, metadata}` (its own `metadata.note`
+suggests `--no-agent` for scripts). Parsing the top level yields **zero hits on a trace that is actually
+ingested** — the single most dangerous failure here, because a wrong "0 spans" reads as a normal "not found"
+(see step 7). Pass `--no-agent` to stabilize the parse path, and always look under `data.spans[]`.
+
+**pup exact usage** (the flags are non-obvious, but this copy has drifted before — treat `pup <cmd> --help`
+and pup's own error text as the source of truth, and keep only the genuinely non-obvious bits below):
 - `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a flag (not positional); the
   default window is **1h**, so pass `--from` as a **bare duration** (`30d`, `7d`, `1h`) — `now-30d` is
-  rejected. Returns `total_duration_ms` and a ready `trace_url`.
-- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output` — span-id comes
-  from get-trace.
+  rejected. Returns `total_duration_ms` and a ready `trace_url`. **Carry the `trace_id` forward — not the
+  `apm_trace_id`** that also appears in results; feeding `apm_trace_id` back into get-trace 404s.
+- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output --from 30d` —
+  span-id comes from get-trace; `--field` is required. **get-content has the same 1h default window**, so
+  pass `--from` for older traces — a 404 `"span not found: <id>"` there is usually the **window**, not a bad
+  span id.
 - `pup llm-obs spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"` — the
   tag filter is a plain `key:value` in `--query` (the MCP-style `@replay_run_id:` matches nothing). Full
   results include each span's `output`, `tags`, and `trace_url`.
@@ -109,10 +123,25 @@ reproduce/diff-only mode. Determine the `ml_app` from the project (`LLMObs.enabl
 
 ### 2. Fetch the trace
 Fetch it via the backend (MCP `get_llmobs_trace` / pup `spans get-trace`), reading span content as needed
-(MCP `get_llmobs_span_content` / pup `spans get-content`). Read the **root span's output** — this is the
-baseline for the diff — and its `metadata.replay_input` / `metadata.replay_entrypoint` if present. Also note
-its `total_duration_ms` (drives the step 7 timeout) and its `trace_url` (both backends return one). (In pup
-mode the default window is 1h — pass `--from 30d` (bare duration, **not** `now-30d`) for older traces.)
+(MCP `get_llmobs_span_content` / pup `spans get-content`). Read its `metadata.replay_input` /
+`metadata.replay_entrypoint` if present, note its `total_duration_ms` (drives the step 7 timeout) and its
+`trace_url` (both backends return one). (In pup mode the default window is 1h — pass `--from 30d` (bare
+duration, **not** `now-30d`) for older traces.)
+
+**Locate the baseline field — don't assume it's the root output.** The value the developer is dissatisfied
+with is often **not** the root span's output (which may be a summary/counter carrying nothing about the
+change) — it can be a tool-call **input** or an intermediate output several levels deep. Find the span
+field(s), at whatever depth, that actually express the complaint, and use those as the diff baseline. Also
+check whether the app **post-processes** that value between what the model produced and what the span
+records (e.g. appending deterministic boilerplate): if two plausible "before" values exist, pick the one the
+code change can actually move, or the delta drowns in noise.
+
+### 2.5. Check for fan-out before replaying the whole root
+If the root span **fans out into repeated sibling subtrees** (a batch/map that dispatches N parallel
+sub-runs), the change under test is usually visible in a **single** representative branch. Replaying the
+whole root then costs ~N× the model spend and wall-clock for no extra signal. Surface the fan-out and offer
+to replay one representative branch instead of the entire root; **log what you skipped** (consistent with
+the skill's "no silent caps" instinct). Only replay the full root if the change is inherently cross-branch.
 
 ### 3. Resolve the entrypoint + input
 - **Entrypoint:** if `metadata.replay_entrypoint` is present, use it as the dispatch id. If absent, **infer**
@@ -121,13 +150,17 @@ mode the default window is 1h — pass `--from 30d` (bare duration, **not** `now
   trace (best-effort — the rendered prompt is lossy, so prefer the code signature) and have the user
   **confirm or edit** it.
 
-### 3.5. Ensure a local run path (only if the app isn't locally runnable)
-Replay re-runs the entrypoint **locally**. If the app can't be invoked locally with a JSON input — a
-deployed-only service, an HTTP/gRPC handler entrypoint, no local `__main__`/CLI, deps not installed, or it
-needs live infra — **read `references/local-setup.md` and follow it**: detect the gap, **propose** a local
-testing flow, get one approval, then build it (pausing only for secrets and the stub-vs-real decision).
-**Skip this step entirely** when a local run path already exists (e.g. the entrypoint is an importable
-function you can call). Only then continue.
+### 3.5. Ensure a local run path (find the innermost callable seam)
+Replay re-runs the entrypoint **locally**. Resolve this by asking **"what is the innermost callable seam for
+this root span, and can I call it directly with JSON?"** — not the binary "is the app runnable?":
+- **Seam already directly callable** (an importable function you can call) → **skip this step**, continue.
+- **Seam buried under a handler/service** (deployed-only HTTP/gRPC, no local `__main__`/CLI, deps not
+  installed, live-infra coupling) → **read `references/local-setup.md` and follow it**: detect the gap,
+  **propose** a local testing flow, get one approval, then build it (pausing only for secrets and the
+  stub-vs-real decision).
+
+The middle case — a deployed service whose core logic is *already* a plain callable with local-dev seams —
+is the **normal** ports-and-adapters shape: extract/call that seam rather than running full local-setup.
 
 ### 4. Ensure the two persistent artifacts (one-time setup, reused every iteration)
 - **a) In-entrypoint annotation** — so future traces self-describe. If the entrypoint doesn't already
@@ -139,11 +172,27 @@ function you can call). Only then continue.
   })
   ```
   (No `replay_output` — the original trace is the baseline; the diff reads outputs from the traces.)
-- **b) The runner** — copy `scripts/replay_runner_template.py` → `replay_runner.py` and fill its
-  **`ENTRYPOINTS` dispatch table** (one entry per type, keyed by `replay_entrypoint` → its function +
-  sync/async). Extend the table when new entrypoints appear; keep the file. **Infer the run command**
-  (venv/interpreter/build) from the project and **confirm it** with the user. If the entrypoint needs
-  non-serializable live infra, ask how to build it or skip it.
+- **b) The runner** — a small CLI that satisfies the **language-independent runner contract** in
+  `references/details.md` (load env → derive `<ml_app>-local` → dispatch one entrypoint on JSON input →
+  **flush on every exit path, including errors** → print the `-local` ml_app). For **Python**, copy
+  `scripts/replay_runner_template.py` → `replay_runner.py` and fill its **`ENTRYPOINTS` dispatch table** (one
+  entry per type, keyed by `replay_entrypoint` → function + sync/async). For **other languages, write the
+  runner to the same contract** — do not assume the Python template's API shape carries over (e.g. Go uses
+  `tracer.Start(WithLLMObsEnabled/WithLLMObsMLApp/WithLLMObsAgentlessEnabled)`, not `LLMObs.enable(...)`, and
+  needs an explicit flush before exit **on the error path too**, or a failed replay leaves no diffable trace;
+  the `DD_TAGS` correlation marker does carry across languages). Extend the table/dispatch when new
+  entrypoints appear; keep the file.
+  - **Run command:** infer it (venv/interpreter/build) from the project and **confirm it** with the user.
+    Follow the host repo's **build-file conventions** for the new source file — repos with generated build
+    metadata (Bazel/Gazelle, Pants, Buck, or a lockfile/manifest to regenerate) need that step or the runner
+    won't build. On a **transient dependency-fetch failure**, retry the build **once** before reporting a
+    break. If the entrypoint needs non-serializable live infra, ask how to build it or skip it.
+  - **Export mode:** check how the app ships spans before replaying. The Python template defaults to
+    agentless (`agentless_enabled=True`), which is what you want locally, but a service may be wired to a
+    local Agent sidecar. Prefer **agentless** for the replay. Pre-empt a benign gotcha: with agentless LLM
+    Obs on, the APM tracer may still dial `localhost:8126` and log `ERROR: lost N traces … connection
+    refused` — **harmless** (LLM Obs spans ship independently and arrive fine); flag it so it isn't mistaken
+    for a failed replay (it compounds the false-negative in step 7).
 
 ### 5. (If a change was requested) edit the code, then gate on a selector
 Analyze the trace + the request, make the code changes, show the developer the diff of your changes, then
@@ -154,6 +203,13 @@ present an `AskUserQuestion` **selector** (not a plain question) — e.g.:
 Only replay on the "Replay now" choice.
 
 ### 6. Replay
+**Before the first replay, run an ambient-environment check and surface it (don't silently correct).** An
+ambient var in the shell can quietly reroute the replay so it doesn't match production — a fidelity gap that
+is **invisible in the diff**. Check for: a provider API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) that
+could make the SDK **bypass the app's configured model gateway**, and ambient `DD_*` that could send the
+trace to a different org/site. The runner's `load_dotenv(override=True)` handles `DD_*`, but provider
+credentials change what the diff is *worth*, so **report what you found** and let the user decide.
+
 **Before the first replay, warn:** re-running executes the agent for real — model calls cost tokens and any
 external writes (DB/email/billing/queues) happen again. On confirmation, record the launch time `t0`, then
 invoke the runner with the entrypoint id + input (as a JSON file), passing a unique correlation marker as a
@@ -180,19 +236,39 @@ Two waits, keyed off the original trace's duration (`total_duration_ms`, read in
   --root-spans-only --from <t0> --query "replay_run_id:<id>"` (plain `key:value`, not `@`). If that tag
   isn't queryable, fall back to the **newest root span** under `<ml_app>-local` for this entrypoint created
   after `t0`. Ingest lag is seconds-to-~2 min and does **not** scale with duration.
+  **Sanity check before you ever report "not found":** re-query with **no tag filter** (just the
+  `<ml_app>-local` + time window) to distinguish "nothing ingested" from "my filter/parse is wrong." A
+  parse/scope mistake (e.g. reading pup's top level instead of `data.spans[]`, or polling the production
+  ml_app) produces a **confident false negative** — telling the user the replay never landed when it did,
+  which reads as normal and invites a wasteful re-run. If the unfiltered query returns spans, the problem is
+  your filter, not ingestion.
   **Don't hard-fail** on timeout: say it hasn't appeared yet and offer to keep waiting.
 
 ### 8. Summarize the diff (with links to both traces)
 Fetch the new trace and give a **concise** summary of how the **new output differs from the old** — just the
 meaningful output differences, not the full span trees. Note that live-world drift (time, prices, search
-results) can differ even with unchanged code.
+results) can differ even with unchanged code. **When the edit targeted model-facing text** (a prompt, system
+message, or tool schema) rather than deterministic code, add that **model sampling variance is a separate
+confound**: a single replay can't separate "my change worked" from "this sample differed." Say plainly that
+n=1 is *suggestive, not conclusive*, and offer to replay 2–3 units (or the same unit twice) to tell them
+apart.
 
 **Every diff view must start with clickable links to BOTH traces** so the developer can open either in the
-UI. **Both backends return a ready `trace_url`** for each trace (MCP `get_llmobs_trace`; pup
-`spans get-trace`/`search`) — use it **verbatim**, do NOT hand-construct a `/llm/traces` URL:
+UI. Both backends return a ready `trace_url`, but there's one scoping trap:
+- **Old trace:** use its `trace_url` **verbatim** — do NOT hand-construct a `/llm/traces` URL.
+- **New (replay) trace:** the `trace_url` carries **no `ml_app`**, so opened as-is it scopes to whatever app
+  the user's picker last had (usually production) and renders **empty** — it must carry
+  `ml_app=<ml_app>-local`. **But the returned URL is an org-switch wrapper**
+  (`…/switch_to_user/<id>?next=<URL-encoded /llm/traces …>&flow=org_switch`) with the real `/llm/traces` path
+  encoded inside `next`. So **do NOT append `&ml_app=…` to the outer URL** — that lands after
+  `&flow=org_switch` on the `switch_to_user` endpoint, which ignores it and redirects to the decoded `next`
+  path (no ml_app). Instead: URL-**decode** the `next` value, add `ml_app=<ml_app>-local` to its
+  `/llm/traces` query, then re-encode `next` (keeping `&flow=org_switch`). If a backend ever returns a
+  **bare** `/llm/traces?…` URL (no wrapper), just add `&ml_app=<ml_app>-local` directly. *(This scoping can't
+  be verified from a coding agent — confirm the replay link opens non-empty in a browser once.)*
 ```
-- [Old trace](<old trace_url from get_llmobs_trace>)
-- [New trace](<new trace_url from get_llmobs_trace>)
+- [Old trace](<old trace_url — verbatim>)
+- [New trace](<new trace_url with ml_app=<ml_app>-local injected into the `next` path>)
 ```
 The link text is just "Old trace" / "New trace". Then the diff summary.
 

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -164,17 +164,22 @@ DD_TAGS=replay_run_id:<unique-id> <python> replay_runner.py --entrypoint <id> --
 The runner runs the entrypoint **directly — no wrapper span — so the replay trace looks identical to a
 normal run**, and the marker rides along as a tag on the emitted spans.
 
+**Local replays emit under `<ml_app>-local`** (the app's ml_app + `-local`) so they never pollute the
+production ml_app — the original trace stays under the real ml_app; the new one lands under `-local`. The
+runner does this automatically and prints the `-local` ml_app; poll for the new trace **under that name**.
+
 ### 7. Wait for the new trace
 Two waits, keyed off the original trace's duration (`total_duration_ms`, read in step 2):
 - **Runner run:** give the runner subprocess a timeout of `max(120s, ~3 × total_duration_ms)` — the replay
   runs the same code, so it takes roughly the original duration; 3× catches a hung/stuck run without
   tripping on a normal one.
 - **Ingest:** once the runner returns, tell the user **"waiting for the new trace to appear in Datadog…"**
-  and poll the backend **every ~5s for up to ~2 min** for the `replay_run_id` tag (from ≈ `t0`): MCP
-  `search_llmobs_spans` (`tags: {replay_run_id: <id>}`) or pup `spans search --ml-app <app>
+  and poll the backend **every ~5s for up to ~2 min** for the `replay_run_id` tag (from ≈ `t0`), **under the
+  `<ml_app>-local` name** the runner printed (not the production ml_app): MCP `search_llmobs_spans`
+  (`ml_app: <ml_app>-local`, `tags: {replay_run_id: <id>}`) or pup `spans search --ml-app <ml_app>-local
   --root-spans-only --from <t0> --query "replay_run_id:<id>"` (plain `key:value`, not `@`). If that tag
-  isn't queryable, fall back to the **newest root span** for this `ml_app` +
-  entrypoint created after `t0`. Ingest lag is seconds-to-~2 min and does **not** scale with duration.
+  isn't queryable, fall back to the **newest root span** under `<ml_app>-local` for this entrypoint created
+  after `t0`. Ingest lag is seconds-to-~2 min and does **not** scale with duration.
   **Don't hard-fail** on timeout: say it hasn't appeared yet and offer to keep waiting.
 
 ### 8. Summarize the diff (with links to both traces)

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -20,9 +20,11 @@ user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — ea
 
 **pup exact usage** (flags are non-obvious, and this copy has drifted from reality before — treat
 `pup <cmd> --help` and pup's own error text as the source of truth; keep only the non-obvious bits here):
-- **Response shape:** pup nests results under **`data.spans[]`**, and in AI-agent mode wraps the payload in
-  `{status, data, metadata}` (its `metadata.note` suggests `--no-agent` for scripts). Parsing the top level
-  returns **zero hits on an already-ingested trace** — pass `--no-agent` and read `data.spans[]`.
+- **Response shape (parse defensively — it has drifted between versions):** in AI-agent mode pup wraps the
+  payload in `{status, data, metadata}` with spans under **`data.spans[]`**; with `--no-agent` (pup 1.8.0)
+  they have come back at **top-level `spans[]`**. **Read whichever of `data.spans[]` / `spans[]` is
+  present.** Parsing the wrong level returns **zero hits on an already-ingested trace** — a silent false
+  negative (see polling). Prefer `--no-agent` for a stable script path.
 - `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a **flag**, not positional;
   the default window is **1h**, so pass `--from` as a **bare duration** (`30d`/`7d`/`1h`) — `now-30d` is
   rejected. Returns `total_duration_ms` and `trace_url`. **Carry `trace_id` forward, not `apm_trace_id`**
@@ -37,6 +39,9 @@ user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — ea
   trace's output straight from the hit (no separate get-content needed).
 - Multi-org: add `--org <name>`, or make sure `pup auth` selected the app's org — a mismatched org returns a
   bare `404 "no spans found"`, not an auth error.
+- **Check token expiry, not just presence.** Read `pup auth status` for the remaining token time before a
+  loop; expiry **mid-loop** surfaces as `404 "no spans found"` and feeds the false-negative trap. Re-auth if
+  it's short.
 
 ## Two persistent artifacts (one-time setup, reused every iteration)
 
@@ -49,12 +54,21 @@ user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — ea
    ```
    Only `replay_input` + `replay_entrypoint` — **no `replay_output`**. The original trace already holds its
    output; the diff reads outputs from the two traces via the backend, so storing it would be redundant.
+   **Stamp it at span START, not on the success/deferred-finish path** — otherwise a run that errors carries
+   no `replay_input`, and failed runs are exactly the ones you most want to replay.
 
-2. **The runner** (`replay_runner.py`) — a small CLI (not a server) with an `ENTRYPOINTS` dispatch table
-   keyed by `replay_entrypoint`. The skill invokes it to re-run one entrypoint on a given input. Keep the
-   file; extend the table when new entrypoints appear.
+2. **The runner** — a small CLI (not a server) with an `ENTRYPOINTS` dispatch table keyed by
+   `replay_entrypoint`. The skill invokes it to re-run one entrypoint on a given input. Satisfies the runner
+   contract below. Keep the file; extend the table when new entrypoints appear.
 
-Both are set up once per app. The per-iteration cost is just: edit code → run the runner → poll → diff.
+3. **A run wrapper (only where the language has no in-process dotenv)** — e.g. a shell script for Go. It is
+   the natural home for the env work the Python template does inline: **source the project's env file**
+   (never inline `DD_API_KEY=<value>` on the command — the permission classifier blocks it and it leaks into
+   shell history + the transcript; see contract point 2), **unset ambient provider vars**, and **export the
+   `<ml_app>-local` override** before invoking the runner. Where in-process dotenv exists (Python), the
+   runner covers this and no wrapper is needed.
+
+The annotation + runner are set up once per app. The per-iteration cost is just: edit → run → poll → diff.
 
 ## `replay_entrypoint` is the dispatch key (not a hint)
 
@@ -73,21 +87,36 @@ shape carries over:
 
 1. **Inputs:** a `--entrypoint <id>` + `--input-file <path.json>` (JSON kwargs) CLI, invoked with the marker
    in the environment: `DD_TAGS=replay_run_id:<marker> <run cmd> --entrypoint <id> --input-file <path>`.
-2. **Env:** make the project's `.env` authoritative over ambient vars (Python: `load_dotenv(override=True)`)
-   — a shell configured for the MCP often exports `DD_*` for a **different org**.
+2. **Env:** make the project's env authoritative over ambient vars (Python: `load_dotenv(override=True)`;
+   languages without in-process dotenv → do it in the run wrapper, artifact 3). A shell configured for the
+   MCP often exports `DD_*` for a **different org**, and the coding agent itself exports provider vars.
+   **Never inline secret values on the command** — source the env file (the permission classifier blocks
+   `DD_API_KEY=<value> …`, and it leaks into history + the transcript).
 3. **ml_app derivation:** enable LLM Obs under **`<ml_app>-local`** (idempotent `+ "-local"`) so replay/test
-   traces never pollute the production ml_app.
+   traces never pollute production. **Tracer/init-level ml_app is NOT proof of isolation:** a
+   **per-span/per-call override** (Go `llmobs.WithMLApp(...)`; Python `ml_app=` on a decorator or in
+   `LLMObs.annotate`) beats the init setting, so the app's spans can still land in production even with the
+   runner set to `-local`. Before writing the runner, **grep the entrypoint's call path for such overrides**;
+   if any exist, the app's ml_app constant must resolve from env so the `-local` override wins — configuring
+   the runner alone won't do it.
 4. **Dispatch:** route `<id>` → the entrypoint function and call it **directly — no wrapper span** — so the
    replay trace is structurally identical to a normal run.
 5. **Flush on EVERY exit path, including errors** (`try/finally`). A failed replay that exits without
    flushing leaves **no diffable partial trace** — the worst case, because the developer sees nothing.
 6. **On exit, print the `-local` ml_app** the caller should poll under.
+7. **Fail-fast interlock:** refuse to start unless the resolved ml_app ends in `-local` (one line). Cheaper
+   to trip here than to discover a permanently-polluted production ml_app afterward — LLM Obs traces **cannot
+   be deleted** (see limitations).
 
 **Per-language notes (this is where the template does *not* transfer):**
-- **Go** (`ddtrace-go`): init is `tracer.Start(WithLLMObsEnabled / WithLLMObsMLApp /
-  WithLLMObsAgentlessEnabled)`, **not** `LLMObs.enable(...)`; the explicit flush-before-exit (incl. error
-  path) is mandatory. The `DD_TAGS` correlation marker **does** work in Go — the mechanism is portable.
-- Other stacks: learn the SDK's enable/flush API and build/run command; keep the six contract points.
+- **Go** (`dd-trace-go`) — the Python `LLMObs.*` shape does not carry over; the actual APIs:
+  - init: `tracer.Start(WithLLMObsEnabled(true), WithLLMObsMLApp("<ml_app>-local"), WithLLMObsAgentlessEnabled(true))`.
+  - flush/stop: `defer tracer.Stop()` (calls `llmobs.Stop()`) **and** `tracer.Flush()` (flushes APM + LLM
+    Obs) on **every** exit incl. the error path — in a `defer`.
+  - annotate: `span.Annotate(llmobs.WithAnnotatedMetadata(map[string]any{...}))` (or the option to
+    `AnnotateTextIO`) — **not** `LLMObs.annotate(span=…, metadata=…)`.
+  - common first failure: `WithLLMObsAgentlessEnabled(true)` **errors hard without `DD_API_KEY`** — name it.
+- Other stacks: learn the SDK's enable/flush/annotate API and build/run command; keep the seven contract points.
 
 **Export mode (agentless vs Agent sidecar).** The template enables **agentless** (`agentless_enabled=True`),
 which is correct for local replay, but a service may be wired to a local Agent sidecar — check before
@@ -114,10 +143,17 @@ Two separate waits, keyed off the original trace's `total_duration_ms` (read via
   + entrypoint created after launch. Treat "not found yet" as normal for the first attempts; on timeout
   **don't hard-fail** — tell the user it hasn't appeared yet and offer to keep waiting.
 - **Before ever reporting "not found," re-query with no tag filter** (just `<ml_app>-local` + window). This
-  distinguishes "nothing ingested" from "my filter/parse/scope is wrong" (e.g. reading pup's top level
-  instead of `data.spans[]`, or polling the production ml_app). A parse/scope bug produces a **confident
-  false negative** — the worst outcome the skill can produce, because it looks like a normal "no trace" and
-  invites a wasteful re-run. If the unfiltered query returns spans, the problem is the filter, not ingest.
+  distinguishes "nothing ingested" from "my filter/parse/scope is wrong" (e.g. reading the wrong spans array,
+  or polling the production ml_app). A parse/scope bug produces a **confident false negative** — the worst
+  outcome the skill can produce, because it looks like a normal "no trace" and invites a wasteful re-run. If
+  the unfiltered query returns spans, the problem is the filter, not ingest.
+- **False-positive twin — verify the ml_app on each hit, don't trust the query.** `pup … search --ml-app
+  <app> --query "<tag>:<val>"` has returned a span whose **actual `ml_app` was a different app** — the
+  `--query` tag did the matching and `--ml-app` was effectively ignored. So a hit is **not** proof of
+  isolation. Read `ml_app` (or the `ml_app:` tag) off every returned span and **assert it ends in `-local`**
+  before reporting a clean replay. This is worse than the false negative because it produces false
+  *confidence*: "clean replay under `-local`" while the trace is actually sitting in production (which you
+  can't undo — traces don't delete).
 
 ## The diff
 
@@ -126,14 +162,24 @@ the old output** — the meaningful differences only, not the full span trees or
 short; the developer is iterating fast. Call out that live-world drift (time, prices, live search results)
 can change the output even when the code didn't — so not every diff is attributable to the code change.
 
-**Sampling variance is a separate confound from drift.** When the edit targets **model-facing text** (a
-prompt, system message, or tool schema) rather than deterministic code, one replay can't separate "my change
-worked" from "this sample differed." Say n=1 is *suggestive, not conclusive*, and offer to replay 2–3 units
-(or the same unit twice). For deterministic-code edits this doesn't apply.
+**Sampling variance is a separate confound from drift — n=1 can't isolate it.** Any nondeterministic agent
+needs a control, not just prompt edits: **default to two replays** (in diff-only mode too, not only when the
+edit targets model-facing text). The technique that makes a run conclusive is **replay-to-replay
+comparison** — if two local runs differ from each other about as much as either differs from production, the
+wording delta is sampling variance while the decision layer is stable. One replay can't produce that signal.
+Deterministic-code edits are the only case where a single replay suffices.
+
+**Exclude disabled-integration subtrees before comparing structure.** If the replay disables a downstream
+side-effecting integration (dry-run/stub/nil-adapter), that integration's whole subtree is absent from the
+new trace — so raw span-count / tool-count comparisons against production are **junk** (they mostly measure
+the skipped subtree, not your change). Identify the subtree the dry-run skips and exclude it from **both**
+sides before any structural diff.
 
 **Always lead the diff with clickable links to both traces**, so the developer can open either run in the
 UI. Both backends return a ready `trace_url`, with one scoping trap on the replay link:
-- **Old trace** → use its `trace_url` **verbatim**; do NOT hand-construct a `/llm/traces` URL.
+- **Old trace** → use its `trace_url` **verbatim**; do NOT hand-construct a `/llm/traces` URL. **Under
+  fan-out** (you replayed one branch — step 2.5 / below), the old `trace_url` opens the *whole root*; instead
+  link the **specific old branch span** (or tell the user which child to open) so old and new line up.
 - **New (replay) trace** → the `trace_url` has **no `ml_app`**, so as-is it opens scoped to whatever app the
   user's picker last had (usually production) and renders **empty**; it needs `ml_app=<ml_app>-local`.
   **The trap:** the returned URL is an org-switch wrapper —
@@ -167,7 +213,14 @@ This keeps the loop live the way plan mode stays open until you approve.
 
 Infer it from the project (Python venv/interpreter, `package.json`, a build step for compiled languages) and
 **confirm with the user** before using it — don't silently assume. Ask the user only when detection fails or
-the entrypoint can't be called with just JSON input (needs live infra built first).
+the entrypoint can't be called with just JSON input (needs live infra built first). On a **transient
+dependency-fetch failure**, retry the build **once** before reporting a break.
+
+**Monorepo / generated build systems.** Follow the host repo's build-file conventions for the new runner
+(and wrapper): repos with generated metadata (Bazel/Gazelle, Pants, Buck, lockfiles) need the regeneration
+step or the file won't build. For **Bazel**: put the runner at `cmd/<name>/` under the app, run **Gazelle**
+on the touched dirs, **build before replaying**, and prefer executing the built binary from `bazel-bin/…`
+directly over `bazel run` (cleaner env control — matters for the `-local` override and unset provider vars).
 
 ## Baseline field & fan-out (get these right or the diff means less than it looks)
 
@@ -178,25 +231,39 @@ the entrypoint can't be called with just JSON input (needs live infra built firs
   change can move, not the boilerplate-appended one.
 - **Fan-out roots.** If the root dispatches N repeated sibling subtrees (a batch/map), the change is usually
   visible in one representative branch; replaying the whole root costs ~N× spend/time for no extra signal.
-  Offer a single-branch replay and log what was skipped.
+  Offer a single-branch replay and log what was skipped. **Pick the branch deliberately:** prefer the
+  **cheapest branch that reached the terminal / side-effecting tool** — most branches are no-ops that would
+  reproduce trivially and prove nothing. **Reconstruct that branch's input from the child span's input, not
+  the root's.**
 
 ## Known limitations
 
-- **Side effects.** Replaying re-runs real code: real model spend every iteration, and any real writes the
-  agent performs (DB, email, billing, queues) happen again. Warn before the first replay; the safe pattern
-  (test doubles / dry-run mode / read-only creds in the replay path) is the user's responsibility.
-- **Ambient environment can silently lower fidelity.** A provider key in the ambient shell can make the SDK
-  bypass the app's model gateway; ambient `DD_*` can retarget the org/site. The runner's `override=True`
-  handles `DD_*`, but check for provider keys before replaying and **surface** findings — this changes how
-  much the diff is worth and is invisible in the diff itself.
+- **Side effects, and traces are permanent.** Replaying re-runs real code: real model spend every iteration,
+  and any real writes the agent performs (DB, email, billing, queues) happen again — warn before the first
+  replay (safe pattern: test doubles / dry-run / read-only creds). **And LLM Obs traces cannot be deleted** —
+  a mis-scoped replay (wrong ml_app) **permanently** contaminates the production app's dashboards and eval
+  sets. That irreversibility is what makes the `-local` isolation load-bearing, not tidy: contract points
+  3 + 7, the per-span-override pre-flight, and the poll ml_app-verification all exist to prevent it.
+- **Dry-run changes what the model sees.** The "safe pattern" isn't free: a stubbed/dry-run tool returns
+  *different* text to the model mid-loop, so every turn after the first side-effecting call diverges from
+  production. Treat post-stub turns as lower fidelity, and prefer the app's **own** dry-run affordance over a
+  hand-written stub (closer to the real return).
+- **Ambient environment — the coding agent is the likely contaminant; unset by default.** The agent's own
+  env (e.g. `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` set by Claude Code) can make the app's SDK **bypass
+  its configured model gateway** — invisible in the diff — and many SDKs log a warning about exactly this.
+  So **unset ambient provider vars by default and report that you did** (not just "surface and let the user
+  decide"), and grep the app for its own guards against ambient keys. Also **verify the credential's org
+  matches the trace's org before replaying** — a mismatch ships the replay somewhere you can't query, which
+  again looks like ingest lag. (`override=True` / the wrapper handles ambient `DD_*`.)
 - **Ingest lag.** The "wait for the new trace" step is the loop's main latency, not the skill logic.
 - **Not locally runnable → local setup.** If the app can't be invoked locally with a JSON input
   (deployed-only service, HTTP/gRPC handler, live-infra deps), the skill sets up a local testing flow first
   — see `references/local-setup.md` (detect → propose → build; hands back for secrets + the stub-vs-real
   decision). Input still has to be JSON-serializable once the local path exists.
-- **Language.** The loop (fetch/edit/diff/MCP) is language-neutral, but the runner is generated in the app's
-  language and the skill must know its build/run command. Python is first-class; compiled languages need a
-  build step and more setup.
+- **Language — Python is the only templated path.** The loop (fetch/edit/diff/backend) is language-neutral,
+  but only Python ships a runner template (`scripts/replay_runner_template.py`); other languages are **not**
+  at parity — write the runner (+ wrapper) to the contract from scratch using their SDK/build tooling (Go
+  APIs named above). Treat non-Python as "supported via the contract," not "templated."
 - **Credentials.** `DD_API_KEY` + `DD_SITE` + provider key(s). No `DD_APP_KEY` (no Experiments API here).
 - **Revert.** Code edits accumulate in the working tree across iterations; the skill does not auto-revert
   (deferred) — the user reviews/keeps/restores at the end.

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -18,12 +18,19 @@ when the MCP isn't installed (`pup auth` must point at the app's org). If neithe
 user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — easier than pup's brew-install +
 `pup auth login`). Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
 
-**pup exact usage** (verified against pup 1.8.0 — flags are non-obvious, got several wrong on first pass):
+**pup exact usage** (flags are non-obvious, and this copy has drifted from reality before — treat
+`pup <cmd> --help` and pup's own error text as the source of truth; keep only the non-obvious bits here):
+- **Response shape:** pup nests results under **`data.spans[]`**, and in AI-agent mode wraps the payload in
+  `{status, data, metadata}` (its `metadata.note` suggests `--no-agent` for scripts). Parsing the top level
+  returns **zero hits on an already-ingested trace** — pass `--no-agent` and read `data.spans[]`.
 - `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a **flag**, not positional;
   the default window is **1h**, so pass `--from` as a **bare duration** (`30d`/`7d`/`1h`) — `now-30d` is
-  rejected. Returns `total_duration_ms` and `trace_url`.
-- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output` — span-id from
-  get-trace; `--field` is required (`input`/`output`/`messages`/…).
+  rejected. Returns `total_duration_ms` and `trace_url`. **Carry `trace_id` forward, not `apm_trace_id`**
+  (also present in results) — feeding `apm_trace_id` into get-trace 404s.
+- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output --from 30d` —
+  span-id from get-trace; `--field` is required (`input`/`output`/`messages`/…). **Same 1h default window as
+  get-trace**, so pass `--from` for older traces — a 404 `"span not found: <id>"` here is usually the
+  **window**, not a bad span id.
 - `pup llm-obs spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"` — the
   tag filter is a plain `key:value` in `--query`; the MCP-style `@replay_run_id:` matches **nothing**. Full
   results already include each span's `output`, `tags`, and `trace_url`, so the poll can read the new
@@ -58,20 +65,36 @@ span + code, **confirm with the user**, then add the annotation so future traces
 `replay_input` is the same story: present on the trace → use it; absent → derive a **suggested** input
 (prefer the code signature; the rendered prompt on the span is lossy) and have the user confirm/edit.
 
-## How the runner works
+## The runner contract (language-independent)
 
-The skill calls it with the marker set as a span tag via the environment:
-```
-DD_TAGS=replay_run_id:<marker> <python> replay_runner.py --entrypoint <id> --input-file <path.json>
-```
-The runner:
-- loads `.env` with `override=True` (org-safety: ambient `DD_*` from a shell configured for the MCP can
-  point at a different org),
-- enables `LLMObs` under **`<ml_app>-local`** (idempotent `+ "-local"`) so replay/test traces never pollute
-  the production ml_app,
-- runs the entrypoint **directly — no wrapper span** — so the replay trace is structurally identical to a
-  normal run,
-- flushes and exits, printing the `-local` ml_app the caller should poll under.
+The runner is generated in the **app's language**; the Python template is the reference implementation, not
+the definition. Any runner — Python, Go, TS, … — must satisfy this contract; don't assume the Python API
+shape carries over:
+
+1. **Inputs:** a `--entrypoint <id>` + `--input-file <path.json>` (JSON kwargs) CLI, invoked with the marker
+   in the environment: `DD_TAGS=replay_run_id:<marker> <run cmd> --entrypoint <id> --input-file <path>`.
+2. **Env:** make the project's `.env` authoritative over ambient vars (Python: `load_dotenv(override=True)`)
+   — a shell configured for the MCP often exports `DD_*` for a **different org**.
+3. **ml_app derivation:** enable LLM Obs under **`<ml_app>-local`** (idempotent `+ "-local"`) so replay/test
+   traces never pollute the production ml_app.
+4. **Dispatch:** route `<id>` → the entrypoint function and call it **directly — no wrapper span** — so the
+   replay trace is structurally identical to a normal run.
+5. **Flush on EVERY exit path, including errors** (`try/finally`). A failed replay that exits without
+   flushing leaves **no diffable partial trace** — the worst case, because the developer sees nothing.
+6. **On exit, print the `-local` ml_app** the caller should poll under.
+
+**Per-language notes (this is where the template does *not* transfer):**
+- **Go** (`ddtrace-go`): init is `tracer.Start(WithLLMObsEnabled / WithLLMObsMLApp /
+  WithLLMObsAgentlessEnabled)`, **not** `LLMObs.enable(...)`; the explicit flush-before-exit (incl. error
+  path) is mandatory. The `DD_TAGS` correlation marker **does** work in Go — the mechanism is portable.
+- Other stacks: learn the SDK's enable/flush API and build/run command; keep the six contract points.
+
+**Export mode (agentless vs Agent sidecar).** The template enables **agentless** (`agentless_enabled=True`),
+which is correct for local replay, but a service may be wired to a local Agent sidecar — check before
+replaying and prefer agentless locally. Known benign gotcha: with agentless LLM Obs on, the APM tracer may
+still dial `localhost:8126` and log `ERROR: lost N traces … connection refused`. **Harmless** — LLM Obs
+spans ship independently and arrive fine — but it looks like a failed replay, so flag it pre-emptively (it
+compounds the false-negative failure mode in the polling step).
 
 `DD_TAGS=replay_run_id:<marker>` makes ddtrace stamp the marker on every span of the run (the same channel
 that carries `git_commit_sha`, `env`, etc.), so the caller can locate the new trace by that tag **without
@@ -90,6 +113,11 @@ Two separate waits, keyed off the original trace's `total_duration_ms` (read via
   Fallback: the **newest root span** for this `ml_app`
   + entrypoint created after launch. Treat "not found yet" as normal for the first attempts; on timeout
   **don't hard-fail** — tell the user it hasn't appeared yet and offer to keep waiting.
+- **Before ever reporting "not found," re-query with no tag filter** (just `<ml_app>-local` + window). This
+  distinguishes "nothing ingested" from "my filter/parse/scope is wrong" (e.g. reading pup's top level
+  instead of `data.spans[]`, or polling the production ml_app). A parse/scope bug produces a **confident
+  false negative** — the worst outcome the skill can produce, because it looks like a normal "no trace" and
+  invites a wasteful re-run. If the unfiltered query returns spans, the problem is the filter, not ingest.
 
 ## The diff
 
@@ -98,12 +126,26 @@ the old output** — the meaningful differences only, not the full span trees or
 short; the developer is iterating fast. Call out that live-world drift (time, prices, live search results)
 can change the output even when the code didn't — so not every diff is attributable to the code change.
 
+**Sampling variance is a separate confound from drift.** When the edit targets **model-facing text** (a
+prompt, system message, or tool schema) rather than deterministic code, one replay can't separate "my change
+worked" from "this sample differed." Say n=1 is *suggestive, not conclusive*, and offer to replay 2–3 units
+(or the same unit twice). For deterministic-code edits this doesn't apply.
+
 **Always lead the diff with clickable links to both traces**, so the developer can open either run in the
-UI. **Both backends return a ready `trace_url`** (MCP `get_llmobs_trace`; pup `spans get-trace`/`search`) —
-use it **verbatim**; do NOT hand-construct a `/llm/traces` URL:
+UI. Both backends return a ready `trace_url`, with one scoping trap on the replay link:
+- **Old trace** → use its `trace_url` **verbatim**; do NOT hand-construct a `/llm/traces` URL.
+- **New (replay) trace** → the `trace_url` has **no `ml_app`**, so as-is it opens scoped to whatever app the
+  user's picker last had (usually production) and renders **empty**; it needs `ml_app=<ml_app>-local`.
+  **The trap:** the returned URL is an org-switch wrapper —
+  `…/switch_to_user/<id>?next=<URL-encoded /llm/traces …>&flow=org_switch` — with the real `/llm/traces`
+  query encoded inside `next`. Appending `&ml_app=…` to the outer URL is a **no-op** (it sits after
+  `&flow=org_switch`; the `switch_to_user` endpoint drops it and redirects to the decoded `next` without
+  ml_app). Correct fix: URL-**decode** `next`, add `ml_app=<ml_app>-local` to its `/llm/traces` query,
+  re-encode `next` (keep `&flow=org_switch`). Bare `/llm/traces?…` URLs (no wrapper) → append directly.
+  Browser-unverifiable from here — confirm once that the replay link opens non-empty.
 ```
-- [Old trace](<old trace_url from get_llmobs_trace>)
-- [New trace](<new trace_url from get_llmobs_trace>)
+- [Old trace](<old trace_url — verbatim>)
+- [New trace](<new trace_url with ml_app=<ml_app>-local injected into `next`>)
 ```
 The link text is just "Old trace" / "New trace".
 
@@ -127,11 +169,26 @@ Infer it from the project (Python venv/interpreter, `package.json`, a build step
 **confirm with the user** before using it — don't silently assume. Ask the user only when detection fails or
 the entrypoint can't be called with just JSON input (needs live infra built first).
 
+## Baseline field & fan-out (get these right or the diff means less than it looks)
+
+- **The baseline is not necessarily the root output.** The value the developer is dissatisfied with can be a
+  tool-call input or an intermediate output several levels deep; the root output may be a summary that
+  carries nothing about the change. Locate the field(s) that actually express the complaint. Also check for
+  **post-processing** between what the model produced and what the span records — diff the value the code
+  change can move, not the boilerplate-appended one.
+- **Fan-out roots.** If the root dispatches N repeated sibling subtrees (a batch/map), the change is usually
+  visible in one representative branch; replaying the whole root costs ~N× spend/time for no extra signal.
+  Offer a single-branch replay and log what was skipped.
+
 ## Known limitations
 
 - **Side effects.** Replaying re-runs real code: real model spend every iteration, and any real writes the
   agent performs (DB, email, billing, queues) happen again. Warn before the first replay; the safe pattern
   (test doubles / dry-run mode / read-only creds in the replay path) is the user's responsibility.
+- **Ambient environment can silently lower fidelity.** A provider key in the ambient shell can make the SDK
+  bypass the app's model gateway; ambient `DD_*` can retarget the org/site. The runner's `override=True`
+  handles `DD_*`, but check for provider keys before replaying and **surface** findings — this changes how
+  much the diff is worth and is invisible in the diff itself.
 - **Ingest lag.** The "wait for the new trace" step is the loop's main latency, not the skill logic.
 - **Not locally runnable → local setup.** If the app can't be invoked locally with a JSON input
   (deployed-only service, HTTP/gRPC handler, live-infra deps), the skill sets up a local testing flow first

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -15,8 +15,10 @@ The skill reads traces through one of two backends; every other step is backend-
 
 Prefer the **MCP** (richest — structured tree, `content_info`, a ready `trace_url`). Fall back to **pup**
 when the MCP isn't installed (`pup auth` must point at the app's org). If neither is available, guide the
-user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — easier than pup's brew-install +
-`pup auth login`). Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
+user to install the MCP — one command,
+`claude mcp add --scope user --transport http "datadog-llmo-mcp" "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs"`
+(confirm the current URL at https://docs.datadoghq.com/bits_ai/mcp_server/setup/), easier than pup's
+brew-install + `pup auth login`. Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
 
 **pup exact usage** (flags are non-obvious, and this copy has drifted from reality before — treat
 `pup <cmd> --help` and pup's own error text as the source of truth; keep only the non-obvious bits here):

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -13,12 +13,14 @@ The skill reads traces through one of two backends; every other step is backend-
 | read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
 | poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |
 
-Prefer the **MCP** (richest — structured tree, `content_info`, a ready `trace_url`). Fall back to **pup**
-when the MCP isn't installed (`pup auth` must point at the app's org). If neither is available, guide the
-user to install the MCP — one command,
+Use the **MCP** when it's present — the default; slightly richer for reads (structured tree + `content_info`,
+plus a ready `trace_url`). Fall back to **pup** when the MCP isn't installed (`pup auth` must point at the
+app's org); pup returns everything this skill needs too — `trace_url`, span `output`, and a tree via
+`--include-tree`. If neither is available, guide the **pup install** — it's easier to set up than the MCP
+(and the other Agent Observability skills fall back to pup): `brew tap datadog-labs/pack && brew install
+datadog-labs/pack/pup`, then `pup auth login`. MCP alternative:
 `claude mcp add --scope user --transport http "datadog-llmo-mcp" "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs"`
-(confirm the current URL at https://docs.datadoghq.com/bits_ai/mcp_server/setup/), easier than pup's
-brew-install + `pup auth login`. Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
+(see https://docs.datadoghq.com/bits_ai/mcp_server/setup/). Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
 
 **pup exact usage** (flags are non-obvious, and this copy has drifted from reality before — treat
 `pup <cmd> --help` and pup's own error text as the source of truth; keep only the non-obvious bits here):

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -1,7 +1,35 @@
 # Replay a trace against local code — details & rationale
 
-Read this before generating the runner. It covers the artifacts, the correlation/polling mechanism, the
-diff, and the known limitations.
+Read this before generating the runner. It covers the trace-access backend, the artifacts, the
+correlation/polling mechanism, the diff, and the known limitations.
+
+## Trace-access backend (MCP or pup)
+
+The skill reads traces through one of two backends; every other step is backend-agnostic:
+
+| operation | MCP backend | pup backend |
+|---|---|---|
+| fetch a trace | `get_llmobs_trace` | `pup llm-obs spans get-trace --trace-id <id>` |
+| read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
+| poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |
+
+Prefer the **MCP** (richest — structured tree, `content_info`, a ready `trace_url`). Fall back to **pup**
+when the MCP isn't installed (`pup auth` must point at the app's org). If neither is available, guide the
+user to install the MCP (one `claude mcp add …?toolsets=llmobs` command — easier than pup's brew-install +
+`pup auth login`). Both the MCP and pup return a ready **`trace_url`** — use it verbatim (no construction).
+
+**pup exact usage** (verified against pup 1.8.0 — flags are non-obvious, got several wrong on first pass):
+- `pup llm-obs spans get-trace --trace-id <id> --from 30d` — `--trace-id` is a **flag**, not positional;
+  the default window is **1h**, so pass `--from` as a **bare duration** (`30d`/`7d`/`1h`) — `now-30d` is
+  rejected. Returns `total_duration_ms` and `trace_url`.
+- `pup llm-obs spans get-content --trace-id <id> --span-id <root-span-id> --field output` — span-id from
+  get-trace; `--field` is required (`input`/`output`/`messages`/…).
+- `pup llm-obs spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"` — the
+  tag filter is a plain `key:value` in `--query`; the MCP-style `@replay_run_id:` matches **nothing**. Full
+  results already include each span's `output`, `tags`, and `trace_url`, so the poll can read the new
+  trace's output straight from the hit (no separate get-content needed).
+- Multi-org: add `--org <name>`, or make sure `pup auth` selected the app's org — a mismatched org returns a
+  bare `404 "no spans found"`, not an auth error.
 
 ## Two persistent artifacts (one-time setup, reused every iteration)
 
@@ -13,7 +41,7 @@ diff, and the known limitations.
    })
    ```
    Only `replay_input` + `replay_entrypoint` — **no `replay_output`**. The original trace already holds its
-   output; the diff reads outputs from the two traces via the MCP, so storing it would be redundant.
+   output; the diff reads outputs from the two traces via the backend, so storing it would be redundant.
 
 2. **The runner** (`replay_runner.py`) — a small CLI (not a server) with an `ENTRYPOINTS` dispatch table
    keyed by `replay_entrypoint`. The skill invokes it to re-run one entrypoint on a given input. Keep the
@@ -54,8 +82,10 @@ Two separate waits, keyed off the original trace's `total_duration_ms` (read via
 - **Runner subprocess timeout** = `max(120s, ~3 × total_duration_ms)`. The replay runs the same code, so it
   takes roughly the original duration; 3× catches a hung/stuck run without tripping on a normal one.
 - **Ingest poll** (after the runner returns): ingest lag is seconds-to-~2 min and does **not** scale with
-  duration, so poll **every ~5s up to a flat ~2 min**. Preferred: `search_llmobs_spans` for the
-  `replay_run_id` tag (from ≈ the replay launch time). Fallback: the **newest root span** for this `ml_app`
+  duration, so poll **every ~5s up to a flat ~2 min**. Preferred: search the backend for the `replay_run_id`
+  tag (from ≈ the replay launch time) — MCP `search_llmobs_spans` (`tags: {replay_run_id: <id>}`) or pup
+  `spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"`.
+  Fallback: the **newest root span** for this `ml_app`
   + entrypoint created after launch. Treat "not found yet" as normal for the first attempts; on timeout
   **don't hard-fail** — tell the user it hasn't appeared yet and offer to keep waiting.
 
@@ -67,9 +97,8 @@ short; the developer is iterating fast. Call out that live-world drift (time, pr
 can change the output even when the code didn't — so not every diff is attributable to the code change.
 
 **Always lead the diff with clickable links to both traces**, so the developer can open either run in the
-UI. Use the **`trace_url` field the MCP returns** (`get_llmobs_trace`) **verbatim** — it's a ready-made
-deep link; do NOT hand-construct a `/llm/traces` URL (the correct query is `?query=trace_id:<id>`, not
-`@trace_id:` or the APM `?traceID=` convention):
+UI. **Both backends return a ready `trace_url`** (MCP `get_llmobs_trace`; pup `spans get-trace`/`search`) —
+use it **verbatim**; do NOT hand-construct a `/llm/traces` URL:
 ```
 - [Old trace](<old trace_url from get_llmobs_trace>)
 - [New trace](<new trace_url from get_llmobs_trace>)
@@ -102,8 +131,10 @@ the entrypoint can't be called with just JSON input (needs live infra built firs
   agent performs (DB, email, billing, queues) happen again. Warn before the first replay; the safe pattern
   (test doubles / dry-run mode / read-only creds in the replay path) is the user's responsibility.
 - **Ingest lag.** The "wait for the new trace" step is the loop's main latency, not the skill logic.
-- **Serializable input only.** Entrypoints needing non-serializable live infra rebuilt at replay are out of
-  scope — detect and ask, or skip that entrypoint.
+- **Not locally runnable → local setup.** If the app can't be invoked locally with a JSON input
+  (deployed-only service, HTTP/gRPC handler, live-infra deps), the skill sets up a local testing flow first
+  — see `references/local-setup.md` (detect → propose → build; hands back for secrets + the stub-vs-real
+  decision). Input still has to be JSON-serializable once the local path exists.
 - **Language.** The loop (fetch/edit/diff/MCP) is language-neutral, but the runner is generated in the app's
   language and the skill must know its build/run command. Python is first-class; compiled languages need a
   build step and more setup.

--- a/agent-observability/agent-observability-replay-trace/references/details.md
+++ b/agent-observability/agent-observability-replay-trace/references/details.md
@@ -67,9 +67,11 @@ DD_TAGS=replay_run_id:<marker> <python> replay_runner.py --entrypoint <id> --inp
 The runner:
 - loads `.env` with `override=True` (org-safety: ambient `DD_*` from a shell configured for the MCP can
   point at a different org),
+- enables `LLMObs` under **`<ml_app>-local`** (idempotent `+ "-local"`) so replay/test traces never pollute
+  the production ml_app,
 - runs the entrypoint **directly — no wrapper span** — so the replay trace is structurally identical to a
   normal run,
-- flushes and exits.
+- flushes and exits, printing the `-local` ml_app the caller should poll under.
 
 `DD_TAGS=replay_run_id:<marker>` makes ddtrace stamp the marker on every span of the run (the same channel
 that carries `git_commit_sha`, `env`, etc.), so the caller can locate the new trace by that tag **without
@@ -84,7 +86,7 @@ Two separate waits, keyed off the original trace's `total_duration_ms` (read via
 - **Ingest poll** (after the runner returns): ingest lag is seconds-to-~2 min and does **not** scale with
   duration, so poll **every ~5s up to a flat ~2 min**. Preferred: search the backend for the `replay_run_id`
   tag (from ≈ the replay launch time) — MCP `search_llmobs_spans` (`tags: {replay_run_id: <id>}`) or pup
-  `spans search --ml-app <app> --root-spans-only --from <t0> --query "replay_run_id:<id>"`.
+  `spans search --ml-app <ml_app>-local --root-spans-only --from <t0> --query "replay_run_id:<id>"`.
   Fallback: the **newest root span** for this `ml_app`
   + entrypoint created after launch. Treat "not found yet" as normal for the first attempts; on timeout
   **don't hard-fail** — tell the user it hasn't appeared yet and offer to keep waiting.

--- a/agent-observability/agent-observability-replay-trace/references/local-setup.md
+++ b/agent-observability/agent-observability-replay-trace/references/local-setup.md
@@ -1,0 +1,69 @@
+# Setting up a local testing flow (step 3.5)
+
+Read this only when the app **can't be invoked locally with a JSON input** — a deployed-only service, an
+HTTP/gRPC handler entrypoint, no local `__main__`/CLI, deps not installed, or logic coupled to live infra.
+Replay re-runs the entrypoint locally, so without a local run path there's nothing to replay. This procedure
+makes the app locally runnable, then hands back to the normal instrument + runner steps.
+
+**Shape:** detect → **propose (one approval)** → build automatically. You do as much as possible on your own,
+but two things are **mandatory handbacks** to the user; see below.
+
+## 1. Detect the gap
+
+Signals the app isn't locally runnable as-is:
+- The entrypoint is a request handler (FastAPI/Flask/gRPC/Lambda), not a plain callable.
+- No `if __name__ == "__main__"` / CLI, or no way to import + call the core logic directly.
+- Config/secrets read from a deployed environment (env injected by the platform, a secrets manager).
+- Imports of cloud/service clients constructed at service startup (DB, queues, downstream services).
+- No local virtualenv / dependencies not installed.
+
+If none of these apply (the entrypoint is already an importable function you can call with JSON), **skip this
+whole procedure** and return to step 4.
+
+## 2. Analyze + propose (get ONE approval before touching anything)
+
+Read the code around the entrypoint and produce a concrete, reviewable plan covering:
+- **The local entry point** you'll scaffold — a thin module that invokes the core agent logic with a JSON
+  input (extracting a callable seam if the logic is buried inside a handler).
+- **Deps + venv** to create/install, and the **run command**.
+- **Env/config** to load locally (e.g. a `.env`), and **tracing** (`LLMObs.enable(ml_app=…)`).
+- **Per external dependency**, your proposed handling: **stub / no-op**, **point at a local or test
+  instance**, or **use real read-only creds** — one line each.
+- **Any structural edits** to the app (e.g. extracting the core function out of a handler), called out
+  explicitly.
+
+Present this as a single plan and get the user's approval (accept / adjust / "just scaffold, I'll do X").
+This is their one control point — don't build before it.
+
+## 3. Build (automatic after approval)
+
+Do everything you can without further prompting:
+- Scaffold the local entry point that calls the core logic with the JSON input.
+- Extract the callable seam if needed (apply the structural edits you flagged).
+- Create the venv, install deps, write the local `.env` skeleton, enable `LLMObs`.
+- Wire external deps per the approved plan (stubs / local instances).
+
+Then hand off to **step 4** (instrument + runner) as normal — the runner's entrypoint becomes this local
+entry point.
+
+## 4. Two mandatory handbacks
+
+These you cannot (and must not silently) do for the user:
+- **Secrets.** You can't fabricate API keys, DB credentials, or service tokens. Scaffold the `.env` with the
+  required keys **empty** and ask the user to fill them; never invent or guess values.
+- **Stub-vs-real per external dependency.** Never silently auto-mock — a wrong mock makes the replay's output
+  diverge for reasons unrelated to the code change, so the **diff becomes misleading**. Surface each external
+  dependency and let the user choose stub / local / real. Only then implement it.
+
+Everything outside these two is automatic.
+
+## 5. Safety
+
+- **Default external writes to stubbed / no-op** unless the user explicitly opts into real dependencies —
+  replaying against real infra re-triggers real writes (DB/email/billing/queues) on **every** iteration of
+  the loop.
+- **Warn before structural refactors.** Extracting a seam edits the app's real code; show the change and keep
+  it minimal and non-destructive.
+- Don't make it run "at any cost" — hardcoding config, disabling auth, or skipping validation just to get a
+  trace out produces a local flow that runs but doesn't represent production. Flag such shortcuts instead of
+  taking them silently.

--- a/agent-observability/agent-observability-replay-trace/references/local-setup.md
+++ b/agent-observability/agent-observability-replay-trace/references/local-setup.md
@@ -33,7 +33,9 @@ edit (see §2) — still lighter than treating the whole app as non-runnable.
 dry-run / no-op / sandbox mode or a nil-adapter branch built for exactly this situation. Using the app's own
 affordance is **safer and higher fidelity** than a mock — it exercises the real code path right up to the
 side effect, and it's code the owners already trust. Check for it (flags, env vars, a `--dry-run`, a
-nil/fake adapter) and prefer it; only fall back to stubs (§4) where no such affordance exists.
+nil/fake adapter) and prefer it. Only fall back to a **stub** — a fake/no-op stand-in for a dependency
+that either isn't reachable locally or whose real call would re-trigger a side-effecting write — where no
+such affordance exists; the per-dependency **stub-vs-real** decision is §4's second handback.
 
 Read the code around the entrypoint and produce a concrete, reviewable plan covering:
 - **The local entry point** you'll scaffold — a thin module that invokes the core agent logic with a JSON

--- a/agent-observability/agent-observability-replay-trace/references/local-setup.md
+++ b/agent-observability/agent-observability-replay-trace/references/local-setup.md
@@ -10,21 +10,35 @@ but two things are **mandatory handbacks** to the user; see below.
 
 ## 1. Detect the gap
 
-Signals the app isn't locally runnable as-is:
-- The entrypoint is a request handler (FastAPI/Flask/gRPC/Lambda), not a plain callable.
+The real question isn't the binary "is the app runnable?" — it's **what is the innermost callable seam
+corresponding to the trace's root span, and can it be called directly with a JSON input?** A deployed-only
+HTTP/gRPC service frequently still exposes a plain callable underneath its handler (the ports-and-adapters /
+hexagonal case); when it does, extract/call that seam — full local-setup would be overkill. Only run this
+procedure when **no seam is directly callable**.
+
+Signals the seam isn't directly callable as-is:
+- The entrypoint is a request handler (FastAPI/Flask/gRPC/Lambda) with no plain callable beneath it.
 - No `if __name__ == "__main__"` / CLI, or no way to import + call the core logic directly.
 - Config/secrets read from a deployed environment (env injected by the platform, a secrets manager).
 - Imports of cloud/service clients constructed at service startup (DB, queues, downstream services).
 - No local virtualenv / dependencies not installed.
 
-If none of these apply (the entrypoint is already an importable function you can call with JSON), **skip this
-whole procedure** and return to step 4.
+If the seam is already an importable function you can call with JSON, **skip this whole procedure** and
+return to step 4. If the logic is a plain callable buried inside a handler, extracting that seam is a small
+edit (see §2) — still lighter than treating the whole app as non-runnable.
 
 ## 2. Analyze + propose (get ONE approval before touching anything)
+
+**First, look for an existing dry-run affordance before proposing any stubs.** Many apps already ship a
+dry-run / no-op / sandbox mode or a nil-adapter branch built for exactly this situation. Using the app's own
+affordance is **safer and higher fidelity** than a mock — it exercises the real code path right up to the
+side effect, and it's code the owners already trust. Check for it (flags, env vars, a `--dry-run`, a
+nil/fake adapter) and prefer it; only fall back to stubs (§4) where no such affordance exists.
 
 Read the code around the entrypoint and produce a concrete, reviewable plan covering:
 - **The local entry point** you'll scaffold — a thin module that invokes the core agent logic with a JSON
   input (extracting a callable seam if the logic is buried inside a handler).
+- **Any existing dry-run / no-op / sandbox mode** you found, and where you'll use it instead of a stub.
 - **Deps + venv** to create/install, and the **run command**.
 - **Env/config** to load locally (e.g. a `.env`), and **tracing** enabled under **`<ml_app>-local`**
   (`LLMObs.enable(ml_app="<ml_app>-local")`) — local test traces must **not** pollute the production ml_app.
@@ -54,7 +68,8 @@ These you cannot (and must not silently) do for the user:
   required keys **empty** and ask the user to fill them; never invent or guess values.
 - **Stub-vs-real per external dependency.** Never silently auto-mock — a wrong mock makes the replay's output
   diverge for reasons unrelated to the code change, so the **diff becomes misleading**. Surface each external
-  dependency and let the user choose stub / local / real. Only then implement it.
+  dependency and let the user choose stub / local / real (**prefer the app's own dry-run / no-op affordance
+  from §2 over a hand-written stub** — it's higher fidelity). Only then implement it.
 
 Everything outside these two is automatic.
 

--- a/agent-observability/agent-observability-replay-trace/references/local-setup.md
+++ b/agent-observability/agent-observability-replay-trace/references/local-setup.md
@@ -26,7 +26,8 @@ Read the code around the entrypoint and produce a concrete, reviewable plan cove
 - **The local entry point** you'll scaffold — a thin module that invokes the core agent logic with a JSON
   input (extracting a callable seam if the logic is buried inside a handler).
 - **Deps + venv** to create/install, and the **run command**.
-- **Env/config** to load locally (e.g. a `.env`), and **tracing** (`LLMObs.enable(ml_app=…)`).
+- **Env/config** to load locally (e.g. a `.env`), and **tracing** enabled under **`<ml_app>-local`**
+  (`LLMObs.enable(ml_app="<ml_app>-local")`) — local test traces must **not** pollute the production ml_app.
 - **Per external dependency**, your proposed handling: **stub / no-op**, **point at a local or test
   instance**, or **use real read-only creds** — one line each.
 - **Any structural edits** to the app (e.g. extracting the core function out of a handler), called out
@@ -40,7 +41,7 @@ This is their one control point — don't build before it.
 Do everything you can without further prompting:
 - Scaffold the local entry point that calls the core logic with the JSON input.
 - Extract the callable seam if needed (apply the structural edits you flagged).
-- Create the venv, install deps, write the local `.env` skeleton, enable `LLMObs`.
+- Create the venv, install deps, write the local `.env` skeleton, enable `LLMObs` under `<ml_app>-local`.
 - Wire external deps per the approved plan (stubs / local instances).
 
 Then hand off to **step 4** (instrument + runner) as normal — the runner's entrypoint becomes this local

--- a/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
+++ b/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
@@ -30,6 +30,10 @@ from ddtrace.llmobs import LLMObs
 from {{MODULE}} import {{ENTRYPOINT_FN}}   # , {{ANOTHER_ENTRYPOINT_FN}}, ...
 
 ML_APP = os.environ.get("DD_LLMOBS_ML_APP", "{{ML_APP}}")
+# Local replays emit under "<ml_app>-local" (idempotent) so they never pollute the production ml_app's
+# traces — the original trace stays under the real ml_app; every replay lands under "-local".
+if not ML_APP.endswith("-local"):
+    ML_APP = ML_APP + "-local"
 LLMObs.enable(ml_app=ML_APP, agentless_enabled=True)
 
 
@@ -63,7 +67,8 @@ def main():
     _run_entrypoint(ENTRYPOINTS[args.entrypoint], input_data)
 
     LLMObs.flush()  # agentless: make sure the trace is sent before we exit
-    print(json.dumps({"status": "done", "entrypoint": args.entrypoint}))
+    # ml_app is the "-local" name the caller should poll under for the new trace.
+    print(json.dumps({"status": "done", "entrypoint": args.entrypoint, "ml_app": ML_APP}))
 
 
 if __name__ == "__main__":

--- a/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
+++ b/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
@@ -30,10 +30,13 @@ from ddtrace.llmobs import LLMObs
 from {{MODULE}} import {{ENTRYPOINT_FN}}   # , {{ANOTHER_ENTRYPOINT_FN}}, ...
 
 ML_APP = os.environ.get("DD_LLMOBS_ML_APP", "{{ML_APP}}")
-# Local replays emit under "<ml_app>-local" (idempotent) so they never pollute the production ml_app's
-# traces — the original trace stays under the real ml_app; every replay lands under "-local".
+# Local replays emit under "<ml_app>-local" (idempotent) so they never pollute the production ml_app.
 if not ML_APP.endswith("-local"):
     ML_APP = ML_APP + "-local"
+# Interlock: refuse to emit under a non-isolated ml_app. NOTE this only guards the init-level setting — if
+# the app sets ml_app per span/call it overrides this (see the pre-flight in references/details.md).
+if not ML_APP.endswith("-local"):
+    raise SystemExit(f"[replay] refusing to run: ml_app {ML_APP!r} is not isolated (must end in -local)")
 
 # Export mode: agentless is the right default for a LOCAL replay (ships LLM Obs spans straight to Datadog,
 # no Agent needed). If this app is instead wired to a local Agent sidecar, set DD_LLMOBS_AGENTLESS_ENABLED=0.

--- a/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
+++ b/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
@@ -79,13 +79,13 @@ def main():
     status, error = "done", None
     try:
         _run_entrypoint(ENTRYPOINTS[args.entrypoint], input_data)
-    except Exception as exc:  # noqa: BLE001 — surface any failure, but flush first
+    except Exception as exc:  # noqa: BLE001 — normal failures → report + exit 1
         status, error = "error", repr(exc)
     finally:
-        LLMObs.flush()  # make sure the trace (even a partial one) is sent before we exit
-
-    # ml_app is the "-local" name the caller should poll under for the new trace.
-    print(json.dumps({"status": status, "entrypoint": args.entrypoint, "ml_app": ML_APP, "error": error}))
+        LLMObs.flush()  # send the trace (even a partial one) before we exit
+        # Print in `finally` so the caller always gets ml_app to poll — even if the entrypoint raised
+        # SystemExit/KeyboardInterrupt (which skip `except Exception` but still run `finally`, then propagate).
+        print(json.dumps({"status": status, "entrypoint": args.entrypoint, "ml_app": ML_APP, "error": error}))
     if status == "error":
         sys.exit(1)
 

--- a/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
+++ b/agent-observability/agent-observability-replay-trace/scripts/replay_runner_template.py
@@ -34,7 +34,14 @@ ML_APP = os.environ.get("DD_LLMOBS_ML_APP", "{{ML_APP}}")
 # traces — the original trace stays under the real ml_app; every replay lands under "-local".
 if not ML_APP.endswith("-local"):
     ML_APP = ML_APP + "-local"
-LLMObs.enable(ml_app=ML_APP, agentless_enabled=True)
+
+# Export mode: agentless is the right default for a LOCAL replay (ships LLM Obs spans straight to Datadog,
+# no Agent needed). If this app is instead wired to a local Agent sidecar, set DD_LLMOBS_AGENTLESS_ENABLED=0.
+# Benign gotcha: with agentless on, the APM tracer may still dial localhost:8126 and log
+# "ERROR: lost N traces ... connection refused". That is HARMLESS — the LLM Obs spans ship independently and
+# arrive fine — so don't mistake it for a failed replay.
+_agentless = os.environ.get("DD_LLMOBS_AGENTLESS_ENABLED", "1").lower() not in ("0", "false", "no")
+LLMObs.enable(ml_app=ML_APP, agentless_enabled=_agentless)
 
 
 # Dispatch table — ONE entry per execution type, keyed by the replay_entrypoint id the app annotates.
@@ -64,11 +71,20 @@ def main():
 
     # Run the entrypoint DIRECTLY — no wrapper span — so the replay trace is structurally identical to a
     # normal run. The correlation marker rides along as a span tag via DD_TAGS (set by the caller).
-    _run_entrypoint(ENTRYPOINTS[args.entrypoint], input_data)
+    # Flush in `finally` so a FAILED replay still emits its partial trace — otherwise the error path leaves
+    # nothing to diff, which is worse than a visible failure.
+    status, error = "done", None
+    try:
+        _run_entrypoint(ENTRYPOINTS[args.entrypoint], input_data)
+    except Exception as exc:  # noqa: BLE001 — surface any failure, but flush first
+        status, error = "error", repr(exc)
+    finally:
+        LLMObs.flush()  # make sure the trace (even a partial one) is sent before we exit
 
-    LLMObs.flush()  # agentless: make sure the trace is sent before we exit
     # ml_app is the "-local" name the caller should poll under for the new trace.
-    print(json.dumps({"status": "done", "entrypoint": args.entrypoint, "ml_app": ML_APP}))
+    print(json.dumps({"status": status, "entrypoint": args.entrypoint, "ml_app": ML_APP, "error": error}))
+    if status == "error":
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two additions to `agent-observability-replay-trace`, both contained in the skill folder (no new registered skill, no `lib.rs`/README changes).

## 1. pup CLI fallback for the MCP

Trace reads now go through a **trace-access backend** so the MCP is preferred but not mandatory:

| operation | MCP backend | pup fallback |
|---|---|---|
| fetch a trace | `get_llmobs_trace` | `pup llm-obs spans get-trace` |
| read span output | `get_llmobs_span_content` | `pup llm-obs spans get-content` |
| poll for the replay | `search_llmobs_spans` | `pup llm-obs spans search` |

Step 0 becomes: prefer MCP → else pup (if installed and `pup auth` points at the app's org) → else guide the **one-command MCP install** (pup stays a "use-it-if-present" fallback, not something users are told to install). All later steps use backend-agnostic wording. In pup mode, the trace link is constructed as `<base>/llm/traces?query=trace_id:<id>` since pup doesn't return a `trace_url`.

## 2. Auto local-setup when the app isn't locally runnable

Replay re-runs the entrypoint locally, so a **deployed-only** app (HTTP/gRPC handler, no local `__main__`, live-infra deps) couldn't be replayed — previously a hard "out of scope" bail. New `references/local-setup.md` + step 3.5 fix that: the skill **detects the gap**, **proposes** a local testing flow, and on **one approval** builds it automatically (thin local entry point, venv/deps, `.env`, tracing), handing back only for the two things it shouldn't do silently:

- **secrets** it can't fabricate (scaffolds an empty `.env`, asks the user to fill it), and
- the **stub-vs-real decision** per external dependency (a wrong auto-mock makes the diff misleading).

External writes default to stubbed/no-op, and structural refactors are shown before applying.

## 3. Isolated `ml_app` for local runs

Local replays/tests now emit under **`<ml_app>-local`** (the app's ml_app + `-local`, applied idempotently by the runner), so replay traces never pollute the production ml_app. The runner prints the `-local` ml_app and the skill polls for the new trace under that name. The in-code `replay_input`/`replay_entrypoint` annotation stays on the **real** app, so all production traces remain replayable.

## Files
- `agent-observability/agent-observability-replay-trace/SKILL.md` — backend abstraction (step 0), backend-agnostic steps 2/7/8, new step 3.5, softened scope, pup `trace_url` construction.
- `agent-observability/agent-observability-replay-trace/references/local-setup.md` — **new** localize procedure.
- `agent-observability/agent-observability-replay-trace/references/details.md` — backend section + local-setup pointer.

## Verified End to End with LLM Obs Docs Agent
Reviewer runbook (same setup as PR #80): install the skill (`cp -r agent-observability/agent-observability-replay-trace ~/.claude/skills/`) and run it from inside the [stock-watchlist-agent](https://github.com/DataDog/llm-observability/tree/main/test-apps/stock-watchlist-agent) app.

1. **pup fallback:** with the MCP disabled, confirm step 0 detects pup and a read (`pup llm-obs spans get-trace <trace-id>`) returns the trace; confirm the constructed `trace_url` resolves.
<img width="683" height="236" alt="image" src="https://github.com/user-attachments/assets/47824bbd-2642-453e-9767-e18a1f3e7179" />

2. **local setup:** Against a clean checkout, the replay skill finds no local-testing artifacts and rebuilds the run purely from the deploy service's existing seams and the fetched trace's own metadata .
<img width="714" height="155" alt="image" src="https://github.com/user-attachments/assets/3152dfe9-4a9b-468f-9dc7-86efcacb116d" />
<img width="698" height="433" alt="image" src="https://github.com/user-attachments/assets/9490044a-539c-4809-869d-d81023ea6326" />

3. Traces ran on <ml_app>-local:
<img width="626" height="515" alt="• Traces" src="https://github.com/user-attachments/assets/cc7fc0c4-e1f4-44a2-995f-e9c5dea915eb" />

