### PR TITLE
replay-trace: tag MCP tool calls with skill name in telemetry.intent

### DIFF
--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -33,6 +33,12 @@ runner's `ENTRYPOINTS` entries, a local harness, iteration edits) should match t
 carry **no unnecessary comments** — don't narrate what the code plainly does; add a comment only for a
 genuinely non-obvious *why*.
 
+**Intent tagging (skill capture).** On every `datadog-llmo` MCP tool call, prefix `telemetry.intent` with
+`skill:agent-observability-replay-trace — ` and then the reason for the call (e.g.
+`"skill:agent-observability-replay-trace — fetch the original trace's baseline output"`). The server
+attributes MCP tool calls to this skill by that exact prefix, so it's how the skill's invocations get
+captured. (pup-CLI calls carry no `telemetry.intent`, so this applies only on the MCP path.)
+
 ## Interaction model — selector gates, never a hard stop
 
 This is a live loop. At every decision point present the choices as an **`AskUserQuestion` selector** (the

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -33,15 +33,7 @@ runner's `ENTRYPOINTS` entries, a local harness, iteration edits) should match t
 carry **no unnecessary comments** — don't narrate what the code plainly does; add a comment only for a
 genuinely non-obvious *why*.
 
-**Intent tagging (skill capture).** On every `datadog-llmo` MCP tool call, prefix `telemetry.intent` with
-`skill:agent-observability-replay-trace[<inv_id>] — ` followed by a description of why the tool is being
-called — where `<inv_id>` is a short id you generate once at the start of the run and reuse for every call
-(it groups this invocation's calls). On the **first MCP tool call only**, use
-`skill:agent-observability-replay-trace:start[<inv_id>] — ` instead (note the `:start` suffix, which marks
-the invocation start). Example first call:
-`skill:agent-observability-replay-trace:start[3a9f1c2b] — fetch the original trace's baseline output`. The
-server attributes calls to this skill by that prefix (how invocations get captured). pup-CLI calls carry no
-`telemetry.intent`, so this applies only on the MCP path.
+**Intent tagging:** On every `datadog-llmo` MCP tool call, prefix `telemetry.intent` with `skill:agent-observability-replay-trace[<inv_id>] — ` (a short per-run id, generated once and reused for every call) followed by a description of why the tool is being called. On the **first MCP tool call only**, use `skill:agent-observability-replay-trace:start[<inv_id>] — ` instead (note the `:start` suffix). Example first call: `skill:agent-observability-replay-trace:start[3a9f1c2b] — fetch the original trace's baseline output`. pup-CLI calls carry no `telemetry.intent`, so this applies only on the MCP path.
 
 ## Interaction model — selector gates, never a hard stop
 

--- a/agent-observability/agent-observability-replay-trace/SKILL.md
+++ b/agent-observability/agent-observability-replay-trace/SKILL.md
@@ -34,10 +34,14 @@ carry **no unnecessary comments** — don't narrate what the code plainly does; 
 genuinely non-obvious *why*.
 
 **Intent tagging (skill capture).** On every `datadog-llmo` MCP tool call, prefix `telemetry.intent` with
-`skill:agent-observability-replay-trace — ` and then the reason for the call (e.g.
-`"skill:agent-observability-replay-trace — fetch the original trace's baseline output"`). The server
-attributes MCP tool calls to this skill by that exact prefix, so it's how the skill's invocations get
-captured. (pup-CLI calls carry no `telemetry.intent`, so this applies only on the MCP path.)
+`skill:agent-observability-replay-trace[<inv_id>] — ` followed by a description of why the tool is being
+called — where `<inv_id>` is a short id you generate once at the start of the run and reuse for every call
+(it groups this invocation's calls). On the **first MCP tool call only**, use
+`skill:agent-observability-replay-trace:start[<inv_id>] — ` instead (note the `:start` suffix, which marks
+the invocation start). Example first call:
+`skill:agent-observability-replay-trace:start[3a9f1c2b] — fetch the original trace's baseline output`. The
+server attributes calls to this skill by that prefix (how invocations get captured). pup-CLI calls carry no
+`telemetry.intent`, so this applies only on the MCP path.
 
 ## Interaction model — selector gates, never a hard stop
 


### PR DESCRIPTION
Adds one operating rule: on every `datadog-llmo` MCP tool call, prefix `telemetry.intent` with `skill:agent-observability-replay-trace — ` then the reason for the call. The server attributes MCP tool calls (→ skill invocations) to this skill by exact-prefix match.

**Scope:** one-line addition to `SKILL.md`. Applies on the MCP path only — pup-CLI calls carry no `telemetry.intent`, same limitation as the other pup-using skills.

## Verification
Verified the skill invocation appears on this [dashboard](https://app.datadoghq.com/dashboard/9xc-wwj-n8g/agent-observability---coding-agent-usage?fromUser=false&refresh_mode=sliding&tab_id=1b48038e-8333-4899-a96a-04b85be4edda&from_ts=1783359758352&to_ts=1785951758352&live=true).

<img width="451" height="132" alt="image" src="https://github.com/user-attachments/assets/963a6443-15fd-428f-ae9a-a5cfa1398331" />
