### PR TITLE
Add dd-account-setup skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ Essential Datadog skills for AI agents.
 
 | Skill | Description |
 |-------|-------------|
+| **dd-account-setup** | Ensure an authenticated Datadog account with a valid API key on the right region; validates keys, fixes wrong-region 403s, signs in or creates an account |
 | **dd-pup** | Primary CLI - all pup commands, auth, PATH setup |
 | **dd-monitors** | Create, manage, mute monitors and alerts |
 | **dd-logs** | Search logs, pipelines, archives |

--- a/dd-account-setup/SKILL.md
+++ b/dd-account-setup/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: dd-account-setup
+description: Ensure the user has an authenticated Datadog account with a valid DD_API_KEY on the right region before any Datadog setup or instrumentation. Detects existing DD_API_KEY / DD_APP_KEY / DD_SITE, validates them against the Datadog API, and fixes the common wrong-region 403. If no usable key exists, signs the user in (OAuth) or creates a new account, then obtains and validates a key. Use this whenever a user needs a Datadog account or API key, hits a 403 / wrong-region error, or is about to run any Datadog *-setup or instrumentation skill.
+---
+
+# Create / connect a Datadog account
+
+This skill gets the user to a known-good state: **a valid API key + application key, on the right region, validated against the Datadog API.** It is the "step 0" that setup/instrumentation skills depend on — run it first, then hand off.
+
+It is a standalone guided flow: detect what already exists, and when nothing usable is found, sign in with **OAuth** (browser, PKCE + state) or create a new account (in-terminal, with a **generated** password saved to `.env`), then turn that session into an API key. Everything runs as small **inline `bash` + `curl`** commands (OAuth also uses `openssl`) — **no bundled scripts, no node**; cross-platform (macOS, Linux, Windows via WSL/Git Bash).
+
+This SKILL.md is the spine — it carries the short steps inline and routes to `references/` for the heavy per-step machinery. Read a reference only when you reach the step that names it.
+
+## The flow at a glance
+
+```
+headless requested?  ──yes──▶  Step H: env keys only (OAuth needs a browser), validate, done
+   │no (default — interactive)
+   ▼
+Step 1  Detect existing credentials (env)
+   │
+   ▼
+Step 2  Determine region / site  (DD_SITE → validate; else IP-detect → confirm)
+   │
+   ▼
+Step 3  Authenticate  — ask first (even if env keys were detected)   → references/authenticate.md
+   │        └─ ASK: how to connect? ↴
+   │            ├─ A. Use the detected env key (only if one exists) → validate → Step 5
+   │            ├─ B. Sign in (I have an account) → OAuth (browser, PKCE + state) ──▶ Bearer token
+   │            └─ C. Create a new account → Path C: auto in-terminal signup, generated password ──▶ then OAuth
+   ▼
+Step 4  Turn the OAuth session into an API key   → references/get-api-key.md
+   │        (identity + region via /current_user; OAuth→retrieve most-recent key, app-key→create → write straight to .env; else guide to UI key page)
+   ▼
+Step 5  Load creds from .env, validate, hand off
+```
+
+**Golden rule: never guess or fabricate an API key, app key, token, or site.** Read what's in the environment, validate it, and if it isn't there, authenticate — do not proceed on assumptions.
+
+## Display & wording conventions — read once before Step 1
+
+**Every step** obeys the same rules for how it talks to the user and renders progress: the clean-status-line presentation contract, asking with the host's native selector (never letter-entry), and the live progress checklist with its marker discipline. These live in **`references/conventions.md`** — read it before Step 1 and apply it throughout. Each step below ends with a `↳ Checklist:` cue telling you what to flip.
+
+---
+
+## Step 0 — Preflight (readiness board)
+
+Run this once, first, so the user sees the whole path before anything happens — which tools are
+present, what's already detected, and what the flow will do (including that it opens the browser
+once). It writes nothing and reveals no secret. Every invocation runs the full flow from Step 1 —
+there is no resume/skip-ahead; a prior run is not reused.
+
+```bash
+DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"; : >"$DDLOG"   # fresh log for this run
+mark(){ command -v "$1" >/dev/null 2>&1 && echo "✓" || echo "$2"; }
+# python3 gates the auto browser-callback; fall back to python only if it's a real py3.
+have_py3(){ command -v python3 >/dev/null 2>&1 && return 0; command -v python >/dev/null 2>&1 && python -c 'import sys;exit(0 if sys.version_info[0]==3 else 1)' 2>/dev/null; }
+py3msg(){ have_py3 && echo '✓ (auto browser-callback)' || echo '⊘ (will paste the redirect URL)'; }
+echo   "Datadog account setup — preflight"
+echo   "  deps (required):  bash ✓   curl $(mark curl ✗)   openssl $(mark openssl ✗)"
+echo   "  deps (optional):  python3 $(py3msg)   browser-open $( { command -v open >/dev/null 2>&1 || command -v xdg-open >/dev/null 2>&1; } && echo ✓ || echo '⊘ (open URL manually)')"
+# Canonical DD_* loader — this same block is repeated verbatim in later steps because each ```bash runs a fresh shell (not drift).
+# Load DD_* with precedence: shell env > .env.local > .env. A real env var is never overwritten; surrounding quotes are stripped. *_SRC records where each came from (unset ⇒ from the shell env).
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && { export "$k=$v"; eval "${k}_SRC=$f"; }; done; done
+echo   "  detected creds:   DD_SITE=${DD_SITE:-<unset>}${DD_SITE_SRC:+ [$DD_SITE_SRC]}   DD_API_KEY=$([ -n "$DD_API_KEY" ] && echo "set …${DD_API_KEY: -4}${DD_API_KEY_SRC:+ [$DD_API_KEY_SRC]}" || echo '<unset>')   DD_APP_KEY=$([ -n "$DD_APP_KEY" ] && echo "set${DD_APP_KEY_SRC:+ [$DD_APP_KEY_SRC]}" || echo '<unset>')"
+echo   "  what happens:     confirm region → authenticate (opens your browser once) → get an API key → write it to .env → validate. ~2 min, one browser approval."
+[ "$(mark curl ✗)" = ✗ ] || [ "$(mark openssl ✗)" = ✗ ] && echo "  ✗ missing a required dep above — install it before continuing."
+```
+
+Read the board to the user as-is (it's already clean). If a **required** dep is missing, stop and
+say so. Then tick the checklist's step 1 and move on — always continue into Step 1; never skip
+ahead to a later step.
+
+> ↳ **Checklist:** post the board, then the checklist; mark **1. Detect credentials** ◔.
+
+---
+
+## Step H — Headless / non-interactive (no browser, no prompts)
+
+Decide this first, because the browser + signup paths are impossible without a human. **Infer
+headless from the skill's invocation, not from the environment** — the trigger is the user's
+request itself: they explicitly ask to run without a browser or without interactive prompts
+(e.g. "set up Datadog non-interactively", "I'm in CI, no browser").
+
+Do **not** infer headless merely from a missing TTY — an ordinary terminal run always gets the
+interactive flow. Only an explicit request switches it off.
+
+When you've inferred a headless request, run the block below — and only then. There's no browser
+for OAuth and no human to answer the signup prompts, so the one way to a valid state is with keys
+already provided. Require `DD_API_KEY`, `DD_APP_KEY`, and `DD_SITE`, and fail fast otherwise:
+
+```bash
+# Run this block ONLY when you inferred a non-interactive request. It enforces the one thing
+# headless needs — keys already present — and fails fast when any are missing.
+missing=""
+[ -z "$DD_API_KEY" ] && missing="$missing DD_API_KEY"
+[ -z "$DD_APP_KEY" ] && missing="$missing DD_APP_KEY"
+[ -z "$DD_SITE" ]    && missing="$missing DD_SITE"
+[ -n "$missing" ] && { echo "Non-interactive mode requires:$missing — set them and re-run. Sign-in and trial signup need a browser."; exit 1; }
+```
+
+If all three are set, hand off to **Step 5**, which validates the key via `/api/v1/validate` (works with the `DD-API-KEY` header). Note: `/api/v1/validate` checks `DD_API_KEY` only — `DD_APP_KEY` is required but not independently verified here; a wrong/expired app key surfaces later at the first app-key-scoped call. There is **no OAuth or signup fallback when headless** — both need a browser — so fail with the message above and keep logs actionable.
+
+> ↳ **Checklist (headless):** two items only — once validate passes, tick both and jump to Step 5.
+
+---
+
+## Step 1 — Detect existing credentials
+
+Read the environment **and** the project's `.env` / `.env.local` files. Do not read the values back to the user in full; mask them.
+
+```bash
+# Load DD_* with precedence: shell env > .env.local > .env (real env var wins; quotes stripped). *_SRC = file it came from (unset ⇒ shell env).
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && { export "$k=$v"; eval "${k}_SRC=$f"; }; done; done
+echo "DD_SITE   = ${DD_SITE:-<unset>}${DD_SITE_SRC:+ (from $DD_SITE_SRC)}"
+echo "DD_API_KEY= $( [ -n "$DD_API_KEY" ] && echo "set (…${DD_API_KEY: -4})${DD_API_KEY_SRC:+ (from $DD_API_KEY_SRC)}" || echo "<unset>" )"
+echo "DD_APP_KEY= $( [ -n "$DD_APP_KEY" ] && echo "set (…${DD_APP_KEY: -4})${DD_APP_KEY_SRC:+ (from $DD_APP_KEY_SRC)}" || echo "<unset>" )"
+```
+
+- A `DD_API_KEY` is present (env **or** `.env`/`.env.local`) → go to **Step 2** (pin the site), then **Step 3** and **ask** (choice **A** = use the detected key, or **B**/**C** to authenticate / create a different account). The detected key is an option the user confirms in Step 3, not a default to use silently — they may want a different org or account.
+- No `DD_API_KEY` anywhere → the user has nothing usable yet. Still do **Step 2** (so signup lands them on the right region), then go to **Step 3**, where you'll ask how to connect.
+
+An app key without an api key is not enough; treat it as "no key." Because the shell doesn't persist between blocks, every later block that consumes `$DD_API_KEY` re-runs this same loader at its top — that's why it reappears in Path A, Step 4, and Step 5.
+
+> ↳ **Checklist:** post the list now — tick **1. Detect credentials**, mark **2. Confirm region** ◔.
+
+---
+
+## Step 2 — Determine region / site
+
+The site drives *every* URL downstream (signup, API host, key pages), so pin it before validating.
+The region table and the country→region IP mapping live in **`references/regions.md`**.
+
+1. **If `DD_SITE` is set** (env or `.env`): validate it against the allowed-site list in
+   `references/regions.md`. If it is **not** in that list, stop and show a clear error:
+   > `DD_SITE="<value>"` isn't a recognized Datadog site. Pick one of the regions in `references/regions.md` and set `DD_SITE` accordingly.
+
+2. **If `DD_SITE` is unset:** auto-detect the region from the user's location, then **confirm** — never silently commit a region.
+
+   ```bash
+   country=$(curl -s --max-time 2 https://ipinfo.io/json \
+     | grep -o '"country"[^,]*' | grep -o '"[A-Z][A-Z]"' | tr -d '"')
+   echo "Detected country: ${country:-unknown}"
+   ```
+
+   Map the country to a region using the **Country → region mapping** table in `references/regions.md`. On timeout, error, or no match, **default to US1** (`datadoghq.com`) — and say so. Then tell the user, e.g.:
+   > You look like you're in **DE** → suggesting **EU1 (Frankfurt), `datadoghq.eu`**. Use this, or pick another region below?
+
+   Wait for confirmation. Region cannot be changed after an account is created, so this choice matters.
+
+The API host is uniformly `https://api.${DD_SITE}`.
+
+> ↳ **Checklist:** after the user confirms the region, tick **2. Confirm region**, mark **3. Authenticate** ◔.
+
+---
+
+## Step 3 — Authenticate
+
+**Ask how to connect first — even when Step 1 detected env credentials** — then run the path the user picks. Present "The choice" before touching any credential: an ambient `DD_API_KEY` may belong to a different org or account than the user intends, and region/IP can't reveal which, so let the user decide rather than inferring it. (Headless/**Step H** is exempt — no TTY to ask, env keys only.)
+
+The full detail — "The choice" native-selector wording plus all three paths — lives in **`references/authenticate.md`**:
+
+| The user picks | Path | What it does |
+|----------------|------|--------------|
+| Use my existing credentials *(only offered if Step 1 detected a key)* | **A** | Validate the detected key (also catches a wrong-region key → back to Step 2). |
+| Sign in — I already have an account | **B** | OAuth in the browser (PKCE + state), Bearer token to a `0600` file. |
+| Create a new account *(default)* | **C** | Automated in-terminal signup with a generated password → then Path B. |
+
+Read `references/authenticate.md`, present the choice via the host's native selector, and run the matching path. Re-offer the choice whenever a path dead-ends (OAuth finds no account → **C**; a wrong-region key sent the user back to Step 2 first).
+
+> ↳ **Checklist:** keep **3. Authenticate** ◔ until a token or key is actually in hand (see the per-path cues in `references/authenticate.md`).
+
+---
+
+## Step 4 — Turn the OAuth session into an API key
+
+The OAuth token authenticates the user, but downstream instrumentation needs a **`DD_API_KEY`**. Use the Bearer token to confirm identity, then obtain a key — **retrieve** the org's most-recent key on an OAuth session (OAuth tokens cannot create keys), or **create** one when authenticating with an app key; else guide the user to the UI key page.
+
+The full branch (identity check, retrieve-vs-create, the HTTP-code-tagged block, and the outcome table for `EMPTY_ORG` / `LIST_DENIED` / `SECRET_DENIED` / `CREATE_DENIED` / `TRANSPORT_ERROR`) lives in **`references/get-api-key.md`** — follow it. The secret is written straight to `.env`, never echoed.
+
+> ↳ **Checklist:** once a validated key is in hand, tick **4. Get & validate an API key**, mark **5** ◔.
+
+---
+
+## Step 5 — Confirm and hand off
+
+The key is already in `.env`. Load it and validate (a fresh shell each call — always source `.env` first; never inline the literal key):
+
+```bash
+DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"; tf="${TMPDIR:-/tmp}/dd-oauth-$(id -u).token"
+# Load DD_* (env > .env.local > .env) — parse, don't source, so a crafted .env can't execute. Covers a Path-A key that lives only in the shell env or .env.local.
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && export "$k=$v"; done; done
+vcode=$(curl -sg -o "$DDLOG" -w '%{http_code}' -H "DD-API-KEY: $DD_API_KEY" "https://api.${DD_SITE}/api/v1/validate")
+# re-derive org/email for the card (fresh shell — Step 4 vars don't persist); only if a token is still around
+who=""; [ -s "$tf" ] && who=$(curl -sg -H "Authorization: Bearer $(cat "$tf")" "https://api.${DD_SITE}/api/v2/current_user" 2>>"$DDLOG" | grep -oE '"email"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+# consistent 🔑 credential card — the one place credential state is summarized; secret shown only as last4
+echo "🔑 Datadog credential"
+[ -n "$who" ] && echo "   org:     $who"
+echo "   region:  ${DD_SITE}"
+echo "   api key: …${DD_API_KEY: -4}  (in .env — never printed in full)"
+echo "   status:  $([ "$vcode" = 200 ] && echo '✓ validated (HTTP 200)' || echo "✗ validate HTTP $vcode — see: tail -n 30 \"$DDLOG\"")"
+```
+
+- The card above is the canonical summary — don't also dump the raw validate response. On a non-200, surface `tail -n 30 "$DDLOG"` and treat it per the outcome table (a `403` here is usually wrong region → Step 2).
+- Report the authenticated org/email from the identity call.
+- Credentials all live in **`.env`** (`DD_SITE`, `DD_API_KEY`, and `DD_SIGNUP_PASSWORD` if the account was created via Path C) — written there directly, never echoed. Clean up the signup temp files and the OAuth *state* + *callback* files: `rm -f "${TMPDIR:-/tmp}"/dd-signup-$(id -u).* "${TMPDIR:-/tmp}"/dd-oauth-$(id -u).state "${TMPDIR:-/tmp}"/dd-oauth-$(id -u).cb`.
+- **Downstream handoff — keep the OAuth token.** Leave `${TMPDIR:-/tmp}/dd-oauth-$(id -u).token` (`0600`) in place. Downstream instrumentation reuses this Bearer token to provision resources a plain API key can't create — notably a RUM application. It is short-lived and scoped; the onboarding caller (e.g. the orchestrator) removes it once setup finishes (`rm -f "${TMPDIR:-/tmp}"/dd-oauth-$(id -u).token`). Running instrumentation standalone? Delete it yourself when done.
+- Hand back: "Account is ready. You can now run the setup / instrumentation step." (e.g. `studio-setup`, `browser-rum-setup`, `llm-observability-setup`, or any other `*-setup` skill).
+
+> ↳ **Checklist:** tick **5. Ready — hand off** — show the fully completed list so the user sees the flow is done.
+
+---
+
+## Troubleshooting & reference
+
+When a step fails, see **`references/troubleshooting.md`** — the symptom→fix table (wrong region, OAuth state mismatch, headless exit, Path-C signup errors, …) plus the design-decision and temp-state notes.

--- a/dd-account-setup/SKILL.md
+++ b/dd-account-setup/SKILL.md
@@ -92,6 +92,8 @@ already provided. Require `DD_API_KEY`, `DD_APP_KEY`, and `DD_SITE`, and fail fa
 ```bash
 # Run this block ONLY when you inferred a non-interactive request. It enforces the one thing
 # headless needs — keys already present — and fails fast when any are missing.
+# Load DD_* (env > .env.local > .env), same precedence as Step 1 — CI keys often live in .env, not exported.
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && export "$k=$v"; done; done
 missing=""
 [ -z "$DD_API_KEY" ] && missing="$missing DD_API_KEY"
 [ -z "$DD_APP_KEY" ] && missing="$missing DD_APP_KEY"
@@ -184,7 +186,7 @@ The full branch (identity check, retrieve-vs-create, the HTTP-code-tagged block,
 
 ## Step 5 — Confirm and hand off
 
-The key is already in `.env`. Load it and validate (a fresh shell each call — always source `.env` first; never inline the literal key):
+The key is already in `.env`. Load it and validate (a fresh shell each call — always load `.env` first by *parsing* it, never `source` it, so a crafted `.env` can't execute; never inline the literal key):
 
 ```bash
 DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"; tf="${TMPDIR:-/tmp}/dd-oauth-$(id -u).token"

--- a/dd-account-setup/references/authenticate.md
+++ b/dd-account-setup/references/authenticate.md
@@ -62,7 +62,8 @@ url="https://dd.$site/oauth2/v1/authorize?client_id=$cid&redirect_uri=http%3A%2F
 PYBIN=$(command -v python3 2>/dev/null || true)
 [ -z "$PYBIN" ] && command -v python >/dev/null 2>&1 && python -c 'import sys;sys.exit(0 if sys.version_info[0]==3 else 1)' 2>/dev/null && PYBIN=$(command -v python)
 if [ -n "$PYBIN" ]; then
-  echo "callback listener: using $("$PYBIN" -V 2>&1) at $PYBIN"
+  echo "callback listener: using $("$PYBIN" -V 2>&1) at $PYBIN" >> "${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"  # interpreter detail → log, not screen (conventions.md)
+  echo "▸ waiting for the browser sign-in to complete…"
   CBFILE="$cb" "$PYBIN" - <<'PY'
 import http.server,urllib.parse,os
 os.umask(0o077)   # callback file (code/state) is 0600, like the sibling .state/.token files

--- a/dd-account-setup/references/authenticate.md
+++ b/dd-account-setup/references/authenticate.md
@@ -1,0 +1,177 @@
+# Step 3 — Authenticate (detail)
+
+Backs **Step 3** in `SKILL.md`. Assumes Step 2 has pinned `DD_SITE`. Presents "The
+choice", then runs the path the user picks: **Path A** (use a detected key), **Path B**
+(OAuth sign-in), or **Path C** (create a new account, then Path B). Display/wording
+rules are in `conventions.md`.
+
+**Ask how to connect before using any credential — even when Step 1 detected env keys.** Present **The choice** below, then run the path the user picks: an ambient `DD_API_KEY` may belong to a different org or account than the user intends, and region/IP can't reveal which, so let them decide. (Headless/**Step H** is exempt — no TTY to ask, env keys only.)
+
+## The choice — how to connect
+
+Ask via the host's **native selector** (`AskUserQuestion`) — an up/down-navigable list, **not** a
+letter/number the user types. Header: "Connect to Datadog". Options (A/B/C are your internal
+path labels, not shown as keys to press):
+
+> **How do you want to connect to Datadog?**
+> - **Use my existing credentials** — `DD_API_KEY …<last4>` (from your shell env or `.env`/`.env.local`) → validate & use (**Path A**)  · _include this option only when Step 1 detected a key_
+> - **Sign in** — I already have a Datadog account → browser OAuth (**Path B**)
+> - **Create a new account** — automated in-terminal signup (default; browser signup is the fallback) → **Path C**
+>
+> _(Include the "existing credentials" option only if a key was detected. Not sure between Sign in / Create? Pick **Sign in** — it fails cleanly if there's no account, then offer Create.)_
+
+Wait for the answer, then run the matching path. Re-offer the choice whenever a path dead-ends — OAuth finds no account (→ **C**), or a wrong-region key sent the user back to Step 2 first.
+
+> ↳ **Checklist:** this choice is part of **3. Authenticate** — keep that item ◔ until a token or key is actually in hand.
+
+## Path A — use the API key already detected (env or `.env`/`.env.local`)
+
+Only when the user picked **A** at The choice. Validate the detected key — this also catches a **wrong region** (a key valid on US1 returns `403` on EU1):
+
+```bash
+# Fresh shell — reload DD_* (env > .env.local > .env) so a file-only key is available here too.
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && export "$k=$v"; done; done
+site="${DD_SITE:?set DD_SITE first}"; DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"
+vcode=$(curl -sg -o "$DDLOG" -w '%{http_code}' -H "DD-API-KEY: $DD_API_KEY" "https://api.${site}/api/v1/validate")
+[ "$vcode" = 200 ] && echo "✓ key valid on $site (HTTP 200)" || echo "✗ key not valid on $site (HTTP $vcode) — likely wrong region; see: tail -n 30 \"$DDLOG\""
+```
+
+- `200` + `{"valid":true}` → the key is good for this region. If `DD_APP_KEY` is also set, sanity-check it **directly** — Path A has no OAuth token, so do **not** use Step 4's Bearer identity call. Use the app-key headers instead: `curl -s -o /dev/null -w '%{http_code}' -H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY" "https://api.$site/api/v2/current_user"` — `200` means the app key is valid (a `403` means it's wrong or from another region). Then go to **Step 5**.
+- `403` → the key is invalid, malformed, **or belongs to a different region** (Datadog returns `403` for all three). If the user believes it's valid, it's almost certainly the **wrong region** — show the error below and return to **Step 2**; otherwise re-offer **The choice** (sign in or create instead).
+
+  > Your `DD_API_KEY` isn't valid for **`<DD_SITE>`**. Datadog API keys are region-specific — this one most likely belongs to a different region. Set `DD_SITE` to that region, or authenticate to create a key here.
+
+> ↳ **Checklist (Path A):** on `200`, collapse 3–4 to a single **Validate existing key** ● and go to Step 5.
+
+## Path B — Sign in with OAuth (browser, PKCE + state)
+
+The user chose **B. Sign in** (this also runs after Path C creates an account). OAuth handles **no password from us** — the user authenticates on Datadog's own page. Done **inline, no bundled script**: PKCE via `openssl`, the redirect caught by a **one-shot local listener** (stdlib `python3` `http.server` on `localhost:8080` — the port the `redirect_uri` already targets), the token saved to a `0600` file. A **pasted-URL fallback** covers no-`python3`/timeout. Needs `bash`, `curl`, `openssl`, a browser (Windows: WSL/Git Bash); `python3` for the auto-callback (else paste).
+
+**Step 1 — start sign-in + auto-catch the callback** (opens the browser, then a one-shot listener writes the `code`/`state` to a file and shows the browser a real "close this tab" page — no paste):
+```bash
+site="$DD_SITE"; sf="${TMPDIR:-/tmp}/dd-oauth-$(id -u).state"; cb="${TMPDIR:-/tmp}/dd-oauth-$(id -u).cb"; rm -f "$cb"
+cid=32e4e079-11ce-49d6-ae37-6cd2c8937354   # Datadog OAuth public client (PKCE; travels in the authorize URL)
+b64u(){ openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+ver=$(openssl rand 32 | b64u); chal=$(printf %s "$ver" | openssl dgst -sha256 -binary | b64u)
+st=$(uuidgen 2>/dev/null || openssl rand -hex 16)
+( umask 077; printf 'ver=%s\nst=%s\n' "$ver" "$st" > "$sf" )
+url="https://dd.$site/oauth2/v1/authorize?client_id=$cid&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&response_type=code&code_challenge=$chal&code_challenge_method=S256&state=$st"
+{ command -v open >/dev/null && open "$url"; } 2>/dev/null || { command -v xdg-open >/dev/null && xdg-open "$url"; } 2>/dev/null || printf 'Open this URL:\n%s\n' "$url"
+# Resolve any Python 3 interpreter: prefer `python3`, else a `python` that is v3 (conda/some Windows/Linux).
+# The listener uses only http.server/urllib.parse/os — stdlib since 3.0 — so ANY 3.x works; no version pin.
+PYBIN=$(command -v python3 2>/dev/null || true)
+[ -z "$PYBIN" ] && command -v python >/dev/null 2>&1 && python -c 'import sys;sys.exit(0 if sys.version_info[0]==3 else 1)' 2>/dev/null && PYBIN=$(command -v python)
+if [ -n "$PYBIN" ]; then
+  echo "callback listener: using $("$PYBIN" -V 2>&1) at $PYBIN"
+  CBFILE="$cb" "$PYBIN" - <<'PY'
+import http.server,urllib.parse,os
+os.umask(0o077)   # callback file (code/state) is 0600, like the sibling .state/.token files
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        open(os.environ["CBFILE"],"w").write(urllib.parse.urlparse(self.path).query)
+        self.send_response(200);self.send_header("Content-Type","text/html");self.end_headers()
+        self.wfile.write(b"<h1>Signed in \xe2\x80\x94 close this tab and return to the terminal.</h1>")
+    def log_message(self,*a):pass
+s=http.server.HTTPServer(("127.0.0.1",8080),H);s.timeout=180;s.handle_request()  # one request, then exit
+PY
+  [ -s "$cb" ] && echo "callback captured ✓ — run Step 2" || echo "no callback in 180s (or port 8080 busy) — use the paste fallback in Step 2"
+else
+  echo "no Python 3 found — after approving, copy the localhost:8080 URL your browser shows (it will NOT load) and use the paste fallback in Step 2"
+fi
+```
+With `python3`, the listener captures the redirect automatically — nothing to paste. **Fallback:** if it printed "no callback" / "python3 not found", the browser's `localhost:8080/callback?...` won't load (expected) — copy that **full address-bar URL** for Step 2.
+
+**Step 2 — finish sign-in** (auto: reads the captured file; fallback: put the pasted URL in `PASTE_REDIRECT_URL`):
+```bash
+site="$DD_SITE"; sf="${TMPDIR:-/tmp}/dd-oauth-$(id -u).state"; cb="${TMPDIR:-/tmp}/dd-oauth-$(id -u).cb"; tf="${TMPDIR:-/tmp}/dd-oauth-$(id -u).token"
+cid=32e4e079-11ce-49d6-ae37-6cd2c8937354   # Datadog OAuth public client (PKCE; travels in the authorize URL)
+paste='PASTE_REDIRECT_URL'                                    # only used if the auto-capture file is absent
+if [ -s "$cb" ]; then q=$(cat "$cb"); else q=${paste#*\?}; fi
+code=$(printf %s "$q" | tr '&' '\n' | sed -n 's/^code=//p'  | head -1)
+st=$(printf   %s "$q" | tr '&' '\n' | sed -n 's/^state=//p' | head -1)
+ver=$(sed -n 's/^ver=//p' "$sf"); exp=$(sed -n 's/^st=//p' "$sf")
+[ -n "$code" ] && [ "$st" = "$exp" ] || { echo 'bad code or state mismatch — re-run Step 1'; exit 1; }
+scopes='api_keys_write rum_apps_write incident_read rum_apps_read logs_read_data apm_read metrics_read hosts_read'  # write scopes (api_keys_write, rum_apps_write) are for downstream provisioning the Bearer token performs later (e.g. a RUM app); reading keys here is role-based, not scope-gated (no api_keys_read needed)
+resp=$(curl -s -X POST "https://api.$site/oauth2/v1/token" \
+  --data-urlencode "client_id=$cid" --data-urlencode 'redirect_uri=http://localhost:8080/callback' \
+  --data-urlencode 'grant_type=authorization_code' --data-urlencode "code=$code" \
+  --data-urlencode "scope=$scopes" --data-urlencode "code_verifier=$ver")
+tok=$(printf %s "$resp" | grep -oE '"access_token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+granted=$(printf %s "$resp" | grep -oE '"scope"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"
+[ -n "$tok" ] \
+  && { ( umask 077; printf %s "$tok" > "$tf" ); rm -f "$sf" "$cb"; echo "Authenticated ✓ (token …${tok: -4}) → $tf"; \
+       echo "granted scopes: ${granted:-<none returned>}" >>"$DDLOG"; echo "✓ scopes granted (see \$DDLOG for the full list)"; } \
+  || { rm -f "$cb"; echo 'token exchange failed (the code is single-use — re-run Step 1 for a fresh one):'; printf %s "$resp" | grep -oE '"error[a-z_]*"[[:space:]]*:[[:space:]]*"[^"]*"'; }
+```
+
+Notes:
+- **One-shot local listener (no `nc`), paste fallback.** `python3`'s stdlib `http.server` handles exactly one request on `localhost:8080` then exits — so the redirect is captured with no copy-paste and the browser sees a real page. Without `python3` (or on timeout / port 8080 busy) it falls back to the pasted URL. Either way the `code` is one-time and PKCE-bound (useless without the verifier in the `0600` statefile), so it's safe in chat; the token is written to a `0600` file and **never printed**. Step 4 reads it from `${TMPDIR:-/tmp}/dd-oauth-$(id -u).token`.
+- If sign-in shows **no account yet**, go to **Path C** to create one, then sign in (log in with the email + generated password from `.env`).
+
+> ↳ **Checklist:** tick **3. Authenticate** only after `Authenticated ✓` (token in the file), then mark **4** ◔.
+
+## Path C — Create a new account (automated, in the terminal)
+
+**Default.** The skill creates the org over HTTP with a **generated** password (no masked prompt, no typed secret). Steps run as inline commands — no bundled script. **Browser trial signup is the fallback** (`<base-url>/signup`) if these endpoints are unavailable or the shell lacks `curl`/`openssl`.
+
+**C1 — collect + confirm.** Read git defaults, then show Name / Email / Company and let the user edit any field before submitting (email defaults from git, but it's just a default):
+```bash
+echo "Name:    $(git config --get user.name 2>/dev/null || echo '<none>')"
+echo "Email:   $(git config --get user.email 2>/dev/null || echo '<none>')"
+echo "Company: <ask the user>"
+```
+**Ask for these as a single plain free-text reply — do NOT use `AskUserQuestion` / a native selector here.** These are free-text values, not an enumerable choice; a selector can't edit an email, and forcing one makes the user "decline" the whole question just to change one field. Show the three defaults and say, e.g.: *"Reply to change any of these, or say 'ok' to accept — Name: … / Email: … / Company: …"*. (Native selectors are for the connect-method and region choices only.) Wait for the user to confirm or correct all three. There is **no password field** — it's generated next.
+
+If the git email looks like a corporate/work address (e.g. `@datadoghq.com`) and this is a trial, you may suggest a `+alias` (`name+test@…`) so it stays distinct — but let the user decide.
+
+**C2 — generate the password → `.env`** (off-context: the value is written straight to the file, never echoed; rule: ≥8 chars, ≥1 number, ≥1 lowercase — this makes a strong 26-char one):
+```bash
+envf=".env"
+git ls-files --error-unmatch "$envf" >/dev/null 2>&1 && { echo "✗ $envf is git-tracked — use .env.local or untrack it first"; exit 1; }
+git check-ignore -q "$envf" 2>/dev/null || printf '\n# Datadog local credentials\n.env\n' >> .gitignore
+pw="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24)"
+pw="${pw}$(LC_ALL=C tr -dc 'a-z' </dev/urandom | head -c 1)$(LC_ALL=C tr -dc '0-9' </dev/urandom | head -c 1)"
+( umask 077; printf 'DD_SIGNUP_PASSWORD=%s\n' "$pw" >> "$envf" ); chmod 600 "$envf" 2>/dev/null   # umask only guards NEW files; force 0600 in case .env pre-existed 0644
+echo "Generated password saved to $envf (DD_SIGNUP_PASSWORD, …${pw: -4}) — read it there; it's never shown in chat."
+```
+
+**C3 — create the account** (reads the password back from `.env`; it's piped to `curl` via the `printf` builtin so it never lands on argv/stdout; put the confirmed values in `EMAIL`/`NAME`/`COMPANY`):
+```bash
+site="$DD_SITE"; envf=".env"; jar="${TMPDIR:-/tmp}/dd-signup-$(id -u).jar"; jf="${TMPDIR:-/tmp}/dd-signup-$(id -u).jwt"
+case "$site" in datadoghq.com|datadoghq.eu) base="https://app.$site";; *) base="https://$site";; esac
+EMAIL='<confirmed email>'; NAME='<confirmed name>'; COMPANY='<confirmed company>'
+esc(){ local s=$1; s=${s//\\/\\\\}; s=${s//\"/\\\"}; printf %s "$s"; }        # escape name/company for JSON
+pw=$(grep '^DD_SIGNUP_PASSWORD=' "$envf" | head -1 | cut -d= -f2-)             # generated -> alnum, no escaping
+csrf=$(curl -s -c "$jar" -H 'Accept: application/vnd.api+json' "$base/api/ui/signup?csrf=true" | grep -oE '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+chmod 600 "$jar" 2>/dev/null   # jar holds the signup session cookie/JWT — curl -c honors ambient umask, so force 0600
+[ -n "$csrf" ] || { echo "signup unavailable (no CSRF token) — retry, or use $base/signup"; exit 1; }
+body='{"data":{"type":"password_signup","attributes":{"email":"'"$(esc "$EMAIL")"'","name":"'"$(esc "$NAME")"'","company":"'"$(esc "$COMPANY")"'","password":"'"$pw"'","shortSignup":false,"metadata":{"sessionId":"'"$(uuidgen 2>/dev/null || openssl rand -hex 16)"'","referrer":"skill","signup_source":"skill"},"datadogVariant":"standard"}}}'
+resp=$(printf '%s' "$body" | curl -s -c "$jar" -b "$jar" -X POST "$base/api/ui/signup" -H 'Content-Type: application/vnd.api+json' -H 'Accept: application/vnd.api+json' -H "x-csrf-token: $csrf" --data-binary @-)
+jwt=$(printf '%s' "$resp" | grep -oE '"jwt"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+[ -n "$jwt" ] && { ( umask 077; printf %s "$jwt" > "$jf" ); echo "Account created — a verification code was emailed to $EMAIL."; } \
+  || { echo "signup rejected:"; printf '%s' "$resp" | grep -oE '"detail"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4; }
+```
+By signing up the user agrees to Datadog's **Master Subscription Agreement** (`/legal/msa/`), **Privacy Policy** (`/legal/privacy/`), and **Cookie Policy** (`/legal/cookies/`) — mention this before submitting. A `detail` line means Datadog rejected an input (email already registered, password policy) — surface it and retry.
+
+**C4 — verify the emailed 8-digit code** (put it in `CODE`; `resend` = re-run C3's CSRF fetch then `POST $base/api/ui/signup/resend-code`):
+```bash
+site="$DD_SITE"; jar="${TMPDIR:-/tmp}/dd-signup-$(id -u).jar"; jf="${TMPDIR:-/tmp}/dd-signup-$(id -u).jwt"
+case "$site" in datadoghq.com|datadoghq.eu) base="https://app.$site";; *) base="https://$site";; esac
+CODE='<8-digit code from the user>'; jwt=$(cat "$jf")
+csrf=$(curl -s -c "$jar" -b "$jar" -H 'Accept: application/vnd.api+json' "$base/api/ui/signup?csrf=true" | grep -oE '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+printf '%s\tFALSE\t/\tTRUE\t0\tdd_sev\t%s\n' "${base#https://}" "$jwt" >> "$jar"   # dd_sev is an explicit cookie
+loc=$(curl -s -o /dev/null -D - -b "$jar" -X POST "$base/signup/process/verify?mobile=false" \
+  -H 'Content-Type: application/x-www-form-urlencoded' -H "Origin: $base" -H "Referer: $base/signup/process/verify" \
+  --data-urlencode "verification_token=$CODE" --data-urlencode "_authentication_token=$csrf" --data-urlencode "signup_source=skill" \
+  | grep -i '^location:' | head -1 | tr -d '\r')
+case "$loc" in
+  *error=1*) echo "too many attempts — wait a minute, then retry" ;;
+  *error=2*) echo "invalid code — re-enter it" ;;
+  *error=3*) echo "unexpected error — try again" ;;
+  *) echo "✓ account created and verified"; rm -f "$jf" ;;
+esac
+```
+Then **run Path B** to sign in (the user logs in with their email + the generated password from `.env`) → **Step 4** for the API key.
+
+> ↳ **Checklist (Path C):** tick **a** once the account is created (C3) and **b** once the code is verified (C4); **c** sign in runs via Path B. Then tick **3. Authenticate**, mark **4** ◔.

--- a/dd-account-setup/references/conventions.md
+++ b/dd-account-setup/references/conventions.md
@@ -1,0 +1,86 @@
+# Display & wording conventions (all steps)
+
+These rules govern *how every step in `SKILL.md` talks to the user and renders progress*.
+Read this once before Step 1; apply it to every step, every reprint.
+
+## Presentation contract — show the user a clean surface, not the machinery
+
+The commands in `SKILL.md` are the *engine*; they are not what the user should read. Raw `curl` bodies,
+JSON, and HTTP codes are noise. Follow this contract so every step looks the same and the screen
+stays calm:
+
+- **Emit only clean status lines**, one per meaningful transition, using this fixed vocabulary:
+  `▸` doing · `✓` done · `⚠` warning (recoverable) · `✗` failed (needs a decision) · `🔑` credential card.
+- **Send noise to a log, not the screen.** Every noisy command appends verbose output to
+  `DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"` (`>>"$DDLOG" 2>&1`) and echoes only a clean
+  line. The blocks in the steps already print clean lines — when you add a `curl`, redirect its body to
+  `$DDLOG` and echo a `▸`/`✓`/`✗` line, never the raw response.
+- **Details on demand.** If the user asks "why" / "show details" (or a step fails), then — and only
+  then — surface the relevant tail: `tail -n 30 "$DDLOG"`.
+- **Never** put a secret (key, token, password) in a status line or the log echo — only `…last4`.
+- **Never** dump machine detail to the screen: raw OAuth scope lists, HTTP `Location:`/redirect
+  headers, JSON bodies, and full response dumps go to `$DDLOG` — echo only a one-line `✓`/`✗`. (Both
+  bit a real run: a 40-scope wall and a `Location: /signup/setup` line leaked onto the user's screen.)
+- When you paraphrase a step for the user, describe the *outcome* ("Signed in as X on US1"), not
+  the tool call ("ran curl …"). Do not narrate Bash invocations.
+
+## Ask with the host's native UI — never letter-entry
+
+For **every** choice (region, and the connect method), use the host's **native question UI**
+(Claude Code `AskUserQuestion`; the equivalent in Codex/Cursor) so the user picks from an
+up/down-navigable selector. **Never ask the user to type a letter or number to choose** ("enter A",
+"press 1") — the letters below (A/B/C) are internal labels for *you* to map paths, not a prompt to
+show. Each native option's visible label is the human wording (e.g. "Use my existing credentials",
+"Sign in", "Create a new account"). Only fall back to a numbered text menu when no native picker
+exists at all; even then, still let the user reply in words, not a bare letter.
+
+## Show a live progress checklist
+
+This flow has five steps and it branches, so **keep the user oriented with a checklist.** Post it when Step 1 begins (right after the preflight board), then **reprint the whole list at each step transition.** Never put a secret (key, token, password) in the list.
+
+**Marker rules — the same on every line, every reprint (a real run corrupted this):**
+- Exactly one marker set: `●` done · `◔` current · `○` todo · `⊘` skipped · `✖` failed. Every line is `- <glyph> <number>.` — **no bare `a.` / `b.` / `2.`**.
+- **Top-level steps are always numbered `1.`–`5.`**; Path-C sub-items are lettered `a.`/`b.`/`c.` and **indented under step 3**. Never renumber a top-level step as a letter or swap the two — that conflation is exactly what broke the last run (`a. Detect … ◔ 2. Confirm … c. Authenticate`).
+- A completed step shows `●`, not a bare letter. Re-emit the full 5-line list each time; don't hand-edit a prior copy.
+
+Canonical shape to copy (fill the markers, keep the numbers/letters fixed):
+```
+**Datadog account setup**
+- ● 1. Detect existing credentials
+- ● 2. Confirm region / site
+- ◔ 3. Authenticate
+- ○ 4. Get & validate an API key
+- ○ 5. Ready — hand off
+```
+
+Each step in `SKILL.md` ends with a `↳ Checklist:` cue telling you what to flip.
+
+Interactive baseline:
+
+```
+**Datadog account setup**
+- ◔ 1. Detect existing credentials
+- ○ 2. Confirm region / site
+- ○ 3. Authenticate
+- ○ 4. Get & validate an API key
+- ○ 5. Ready — hand off
+```
+
+Adapt it to the path actually taken:
+
+- **Headless (Step H)** — collapse to two: `Check DD_API_KEY / DD_APP_KEY / DD_SITE` → `Validate & hand off`.
+- **Existing key already valid (Path A)** — steps 3–4 collapse to one: `3. Validate the existing key`.
+- **Create account in the terminal (Path C)** — expand step 3 so signup is legible, e.g. mid-flow:
+
+```
+- ● 1. Detect existing credentials
+- ● 2. Confirm region / site
+- ◔ 3. Create account & sign in
+  - ● a. Create the org (email + password)
+  - ◔ b. Verify email code
+  - ○ c. Sign in via OAuth
+- ○ 4. Get & validate an API key
+- ○ 5. Ready — hand off
+```
+
+Tick an item only when its outcome is real — check "Confirm region" after the user confirms (not when you suggest one), and "Authenticate" after a token/key is in hand (not when the browser opens).

--- a/dd-account-setup/references/get-api-key.md
+++ b/dd-account-setup/references/get-api-key.md
@@ -31,29 +31,27 @@ git ls-files --error-unmatch "$envf" >/dev/null 2>&1 && { echo "✗ $envf is git
 git check-ignore -q "$envf" 2>/dev/null || printf '\n# Datadog local credentials\n.env\n' >> .gitignore
 name="dd-account-setup-skill — $(basename "$PWD")"
 esc(){ local s=$1; s=${s//\\/\\\\}; s=${s//\"/\\\"}; printf %s "$s"; }
-key=""; outcome=""; keysrc=""
+key=""; outcome=""; keysrc=""; DDLOG="${TMPDIR:-/tmp}/dd-onboard-$(id -u).log"   # raw HTTP/URL machinery → log, clean lines → screen (conventions.md)
 if [ -n "$TOKEN" ]; then
   auth=(-H "Authorization: Bearer $TOKEN")
   # OAuth: retrieve most-recent key (NO create — unsupported on OAuth tokens)
   who=$(curl -s "${auth[@]}" "https://api.${DD_SITE}/api/v2/current_user" | grep -oE '"email"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "AUTH SOURCE: OAuth session token from your Step-3 sign-in (…${TOKEN: -4}), authenticated as ${who:-<unknown>}."
-  [ -n "$DD_API_KEY" ] && echo "NOTE: a DD_API_KEY is present in your environment, but this step is NOT using it — it fetches the key fresh from Datadog's backend for the org you just signed into."
-  echo "→ Calling Datadog backend: GET https://api.${DD_SITE}/api/v2/api_keys (list, most-recent first)…"
+  echo "AUTH SOURCE: OAuth session token from your Step-3 sign-in (…${TOKEN: -4}), authenticated as ${who:-<unknown>}." >> "$DDLOG"
+  echo "▸ fetching your org's most-recent API key — signed in as ${who:-signed-in user} (not reusing any ambient DD_API_KEY)"
   # -g/--globoff: the query has page[size] — without it curl treats [ ] as glob syntax and aborts (exit 3) before sending.
   lresp=$(curl -sg -w $'\n%{http_code}' "${auth[@]}" "https://api.${DD_SITE}/api/v2/api_keys?page[size]=1&sort=-created_at"); lrc=$?
   lcode=$(printf '%s' "$lresp" | tail -1)
   # first "id" in the response is data[0].id — correct for this page[size]=1, sort=-created_at query (single key object, no preceding id field).
   kid=$(printf '%s' "$lresp" | grep -oE '"id"[[:space:]]*:[[:space:]]*"[a-f0-9-]{36}"' | head -1 | cut -d'"' -f4)
   kname=$(printf '%s' "$lresp" | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "  ← list api_keys: HTTP ${lcode:-<none>}  (curl exit $lrc; key found: $([ -n "$kid" ] && echo "yes — id ${kid}, name \"${kname:-?}\"" || echo no))"
+  echo "GET /api/v2/api_keys (list, most-recent first): HTTP ${lcode:-<none>}  (curl exit $lrc; key found: $([ -n "$kid" ] && echo "yes — id ${kid}, name \"${kname:-?}\"" || echo no))" >> "$DDLOG"
   if [ "$lrc" != 0 ] || ! printf %s "$lcode" | grep -qE '^[0-9]{3}$'; then
     outcome="TRANSPORT_ERROR (curl exit $lrc, no HTTP status — network/URL/proxy, NOT a permission problem)"
   elif [ "$lcode" = 200 ] && [ -n "$kid" ]; then
-    echo "→ Calling Datadog backend: GET https://api.${DD_SITE}/api/v2/api_keys/${kid} (reveal secret)…"
     gresp=$(curl -sg -w $'\n%{http_code}' "${auth[@]}" "https://api.${DD_SITE}/api/v2/api_keys/${kid}"); grc=$?
     gcode=$(printf '%s' "$gresp" | tail -1)
     key=$(printf '%s' "$gresp" | grep -oE '"key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
-    echo "  ← get api_key secret: HTTP ${gcode:-<none>} (curl exit $grc)"
+    echo "GET /api/v2/api_keys/${kid} (reveal secret): HTTP ${gcode:-<none>} (curl exit $grc)" >> "$DDLOG"
     if [ -n "$key" ]; then outcome="retrieved existing key"; keysrc="Datadog backend (GET /api/v2/api_keys/${kid}) as ${who:-signed-in user}"
     else outcome="SECRET_DENIED (${gcode:-transport}) — could list keys but not reveal this one's secret"; fi
   elif [ "$lcode" = 200 ]; then outcome="EMPTY_ORG"
@@ -65,7 +63,7 @@ elif [ -n "$DD_API_KEY" ] && [ -n "$DD_APP_KEY" ]; then
   cresp=$(printf '%s' "$body" | curl -sg -w $'\n%{http_code}' -X POST "https://api.${DD_SITE}/api/v2/api_keys" "${auth[@]}" -H "Content-Type: application/json" --data-binary @-); crc=$?
   ccode=$(printf '%s' "$cresp" | tail -1)
   key=$(printf '%s' "$cresp" | grep -oE '"key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "  ← create api_key: HTTP ${ccode:-<none>} (curl exit $crc)"
+  echo "POST /api/v2/api_keys (create): HTTP ${ccode:-<none>} (curl exit $crc)" >> "$DDLOG"
   if [ -n "$key" ]; then outcome="created key \"$name\""; keysrc="Datadog backend (POST /api/v2/api_keys via your app key)"
   elif [ "$crc" != 0 ]; then outcome="TRANSPORT_ERROR (curl exit $crc — network/URL/proxy, NOT a permission problem)"
   else outcome="CREATE_DENIED (${ccode:-?})"; fi

--- a/dd-account-setup/references/get-api-key.md
+++ b/dd-account-setup/references/get-api-key.md
@@ -1,0 +1,107 @@
+# Step 4 — Turn the OAuth session into an API key (detail)
+
+Backs **Step 4** in `SKILL.md`. Runs after Step 3 authenticated the user (OAuth Bearer
+token in `${TMPDIR:-/tmp}/dd-oauth-$(id -u).token`, or a `DD_API_KEY`+`DD_APP_KEY` pair).
+Produces a validated `DD_API_KEY` in `.env`. Display/wording rules are in `conventions.md`.
+
+The OAuth token authenticates the user, but downstream instrumentation (e.g. LLM Observability) needs a **`DD_API_KEY`**. Use the Bearer token to confirm identity, then obtain a key — **retrieve** the org's most-recent key on an OAuth session (OAuth tokens cannot create keys), or **create** one when authenticating with an app key.
+
+**1. Confirm identity + region.** First load the Bearer token Path B wrote to its `0600` file — shells don't persist between commands, so re-read it at the top of each block that needs it. A `403` here means the token is for a different region — back to Step 2.
+
+```bash
+TOKEN=$(cat "${TMPDIR:-/tmp}/dd-oauth-$(id -u).token")   # written by Path B Step 2 (inline exchange)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.${DD_SITE}/api/v2/current_user" \
+  | grep -oE '"email"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1
+```
+
+**2. Get a `DD_API_KEY` and write it straight to `.env`.** How depends on the auth in hand — and the two cases are genuinely different:
+
+- **OAuth Bearer (Path B/C):** **retrieve** the org's most-recent key — `GET /api/v2/api_keys?page[size]=1&sort=-created_at` → `GET /api/v2/api_keys/{id}` → `data.attributes.key`. **Do NOT `POST` to create** — minting an API key is not supported with an OAuth access token (the server rejects it), so it always fails. If the org has **zero** keys, or listing is role-denied, there is no OAuth create path → send the user to the org key page (they're already signed in). Reading keys is **not** gated by a separate scope — it follows the OAuth user's role, so no `api_keys_read` scope is needed.
+- **API + APP key (`DD_API_KEY`+`DD_APP_KEY` present):** this path *can* `POST /api/v2/api_keys` to mint a fresh named key (an app key with `api_keys_write` is allowed to, unlike an OAuth token).
+
+The block below branches on that and **prints the HTTP code of each step** so a failure is diagnosable (list-denied vs empty-org vs secret-denied), not a blanket "403". The secret is written straight to `.env`, never echoed. Send **exactly one** auth mechanism (never Bearer + API/APP together — that resolves to the API key's org).
+
+```bash
+TOKEN=$(cat "${TMPDIR:-/tmp}/dd-oauth-$(id -u).token" 2>/dev/null)
+# Reload DD_* (env > .env.local > .env) so the app-key branch below sees a file-only DD_API_KEY/DD_APP_KEY.
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && export "$k=$v"; done; done
+envf=".env"
+git ls-files --error-unmatch "$envf" >/dev/null 2>&1 && { echo "✗ $envf is git-tracked — use .env.local or untrack it first"; exit 1; }
+git check-ignore -q "$envf" 2>/dev/null || printf '\n# Datadog local credentials\n.env\n' >> .gitignore
+name="dd-account-setup-skill — $(basename "$PWD")"
+esc(){ local s=$1; s=${s//\\/\\\\}; s=${s//\"/\\\"}; printf %s "$s"; }
+key=""; outcome=""; keysrc=""
+if [ -n "$TOKEN" ]; then
+  auth=(-H "Authorization: Bearer $TOKEN")
+  # OAuth: retrieve most-recent key (NO create — unsupported on OAuth tokens)
+  who=$(curl -s "${auth[@]}" "https://api.${DD_SITE}/api/v2/current_user" | grep -oE '"email"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+  echo "AUTH SOURCE: OAuth session token from your Step-3 sign-in (…${TOKEN: -4}), authenticated as ${who:-<unknown>}."
+  [ -n "$DD_API_KEY" ] && echo "NOTE: a DD_API_KEY is present in your environment, but this step is NOT using it — it fetches the key fresh from Datadog's backend for the org you just signed into."
+  echo "→ Calling Datadog backend: GET https://api.${DD_SITE}/api/v2/api_keys (list, most-recent first)…"
+  # -g/--globoff: the query has page[size] — without it curl treats [ ] as glob syntax and aborts (exit 3) before sending.
+  lresp=$(curl -sg -w $'\n%{http_code}' "${auth[@]}" "https://api.${DD_SITE}/api/v2/api_keys?page[size]=1&sort=-created_at"); lrc=$?
+  lcode=$(printf '%s' "$lresp" | tail -1)
+  # first "id" in the response is data[0].id — correct for this page[size]=1, sort=-created_at query (single key object, no preceding id field).
+  kid=$(printf '%s' "$lresp" | grep -oE '"id"[[:space:]]*:[[:space:]]*"[a-f0-9-]{36}"' | head -1 | cut -d'"' -f4)
+  kname=$(printf '%s' "$lresp" | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+  echo "  ← list api_keys: HTTP ${lcode:-<none>}  (curl exit $lrc; key found: $([ -n "$kid" ] && echo "yes — id ${kid}, name \"${kname:-?}\"" || echo no))"
+  if [ "$lrc" != 0 ] || ! printf %s "$lcode" | grep -qE '^[0-9]{3}$'; then
+    outcome="TRANSPORT_ERROR (curl exit $lrc, no HTTP status — network/URL/proxy, NOT a permission problem)"
+  elif [ "$lcode" = 200 ] && [ -n "$kid" ]; then
+    echo "→ Calling Datadog backend: GET https://api.${DD_SITE}/api/v2/api_keys/${kid} (reveal secret)…"
+    gresp=$(curl -sg -w $'\n%{http_code}' "${auth[@]}" "https://api.${DD_SITE}/api/v2/api_keys/${kid}"); grc=$?
+    gcode=$(printf '%s' "$gresp" | tail -1)
+    key=$(printf '%s' "$gresp" | grep -oE '"key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+    echo "  ← get api_key secret: HTTP ${gcode:-<none>} (curl exit $grc)"
+    if [ -n "$key" ]; then outcome="retrieved existing key"; keysrc="Datadog backend (GET /api/v2/api_keys/${kid}) as ${who:-signed-in user}"
+    else outcome="SECRET_DENIED (${gcode:-transport}) — could list keys but not reveal this one's secret"; fi
+  elif [ "$lcode" = 200 ]; then outcome="EMPTY_ORG"
+  elif printf %s "$lcode" | grep -qE '^(401|403|404)$'; then outcome="LIST_DENIED ($lcode)"
+  else outcome="LIST_ERROR ($lcode — server/transient, NOT a permission problem; retry)"; fi
+elif [ -n "$DD_API_KEY" ] && [ -n "$DD_APP_KEY" ]; then
+  auth=(-H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY")
+  body='{"data":{"type":"api_keys","attributes":{"name":"'"$(esc "$name")"'"}}}'
+  cresp=$(printf '%s' "$body" | curl -sg -w $'\n%{http_code}' -X POST "https://api.${DD_SITE}/api/v2/api_keys" "${auth[@]}" -H "Content-Type: application/json" --data-binary @-); crc=$?
+  ccode=$(printf '%s' "$cresp" | tail -1)
+  key=$(printf '%s' "$cresp" | grep -oE '"key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+  echo "  ← create api_key: HTTP ${ccode:-<none>} (curl exit $crc)"
+  if [ -n "$key" ]; then outcome="created key \"$name\""; keysrc="Datadog backend (POST /api/v2/api_keys via your app key)"
+  elif [ "$crc" != 0 ]; then outcome="TRANSPORT_ERROR (curl exit $crc — network/URL/proxy, NOT a permission problem)"
+  else outcome="CREATE_DENIED (${ccode:-?})"; fi
+else echo "No auth in hand — complete Step 3 first."; exit 1; fi
+
+if [ -n "$key" ]; then
+  echo "SOURCE OF KEY: $keysrc — value never printed; writing …${key: -4} to $envf now."
+  ( umask 077; new="$envf.new"; grep -vE '^(DD_API_KEY|DD_SITE)=' "$envf" 2>/dev/null > "$new"
+    printf 'DD_SITE=%s\nDD_API_KEY=%s\n' "$DD_SITE" "$key" >> "$new"; mv "$new" "$envf" )
+  echo "$outcome (…${key: -4}) → written to $envf"
+else
+  echo "No key obtained (${outcome:-unknown}) → use the manual step below."
+fi
+unset key TOKEN auth lresp gresp cresp
+```
+
+Read the outcome, don't guess:
+- **`retrieved existing key` / `created key`** → the secret is in `.env`; go to step 3. **You never see it** — intentional.
+- **`EMPTY_ORG`** (list `200`, zero keys) → the org has no keys and OAuth can't create one. Not an error — send the user to make one (they're already signed in):
+  > Your org has no API key yet, and I can't mint one from an OAuth session. Create one here: **`https://app.<DD_SITE>/organization-settings/api-keys`** → **+ New Key** → paste it back.
+- **`LIST_DENIED`** (list `403`/`404`) → the OAuth user's role can't manage API keys in this org (common on managed/enterprise orgs like `@datadoghq.com`), or wrong region (identity check would also `403`). Same manual step — or an org admin grants key-management, or use an app key (the `DD_API_KEY`+`DD_APP_KEY` path above).
+- **`SECRET_DENIED`** (list OK, `get` denied) → role can list but not reveal secrets. Manual step.
+- **`LIST_ERROR`** (list returned `5xx` or another non-`401/403/404` status) → a server-side or transient error, **not** permissions. Retry; if it persists, check the Datadog status page and connectivity to `api.<DD_SITE>`. Do **not** tell the user their access was denied.
+- **`CREATE_DENIED`** (app-key `POST` returned non-2xx) → the app key lacks `api_keys_write` or is for another region. Create one manually — same page as above: **`https://app.<DD_SITE>/organization-settings/api-keys`** → **+ New Key** → paste it back.
+- **`TRANSPORT_ERROR`** (curl exited non-zero, **no** HTTP status) → not a permission problem: network, proxy, or a malformed URL (e.g. unescaped `[ ]` without `-g`). Re-run; if it persists, check connectivity/proxy to `api.<DD_SITE>`. Do **not** tell the user their key was denied.
+
+In every manual case, when the user pastes a key, **don't echo it** — write it straight to `.env`: `printf 'DD_API_KEY=%s\n' '<pasted>' >> .env && chmod 600 .env` (after the same git-tracked/`.gitignore` guard as above).
+
+**3. Load it from `.env`** (the actual `/api/v1/validate` check runs in **Step 5**): the secret lives in `.env` now — read it back for this shell; never paste or export the literal value.
+
+```bash
+# Load DD_* (env > .env.local > .env) — parse, don't source, so a crafted .env can't execute.
+for f in .env.local .env; do [ -f "$f" ] || continue; for k in DD_SITE DD_API_KEY DD_APP_KEY; do eval "[ -n \"\${$k:-}\" ]" && continue; v=$(grep -E "^$k=" "$f" | head -1 | cut -d= -f2- | sed 's/^["'\'']//;s/["'\'']$//'); [ -n "$v" ] && export "$k=$v"; done; done
+# App key, only if a downstream flow needs one: https://app.<DD_SITE>/organization-settings/application-keys
+```
+
+Never fabricate or poll for a key — create it via the API (written to `.env`), or wait for the user to paste one (also written to `.env`). The secret never transits the model or stdout.
+
+> ↳ **Checklist:** once a validated key is in hand, tick **4. Get & validate an API key**, mark **5** ◔.

--- a/dd-account-setup/references/regions.md
+++ b/dd-account-setup/references/regions.md
@@ -1,0 +1,39 @@
+# Regions & IP auto-detection (Step 2)
+
+Reference tables for Step 2 in `SKILL.md`: the allowed sites, their app/signup base
+URLs, and the country→region mapping used when `DD_SITE` is unset. The decision logic
+(validate `DD_SITE`, else IP-detect and confirm) lives in Step 2 itself.
+
+## Region reference
+
+| Region | `DD_SITE` | App / signup base URL |
+|--------|-----------|-----------------------|
+| 🇺🇸 US1 — East (Virginia) | `datadoghq.com` | `https://app.datadoghq.com` |
+| 🇺🇸 US3 — West (Oregon) | `us3.datadoghq.com` | `https://us3.datadoghq.com` |
+| 🇺🇸 US5 — Central (Ohio) | `us5.datadoghq.com` | `https://us5.datadoghq.com` |
+| 🇪🇺 EU1 — Europe (Frankfurt) | `datadoghq.eu` | `https://app.datadoghq.eu` |
+| 🇯🇵 AP1 — Japan (Tokyo) | `ap1.datadoghq.com` | `https://ap1.datadoghq.com` |
+| 🇦🇺 AP2 — Australia (Sydney) | `ap2.datadoghq.com` | `https://ap2.datadoghq.com` |
+| 🇬🇧 UK1 — United Kingdom (London) | `uk1.datadoghq.com` | `https://uk1.datadoghq.com` |
+
+The API host is uniformly `https://api.${DD_SITE}`.
+
+The full allowed-site list (for validating a supplied `DD_SITE`) is exactly:
+
+`datadoghq.com` · `us3.datadoghq.com` · `us5.datadoghq.com` · `datadoghq.eu` · `ap1.datadoghq.com` · `ap2.datadoghq.com` · `uk1.datadoghq.com`
+
+## Country → region mapping (IP auto-detection)
+
+Given the ISO 3166-1 alpha-2 country code from `https://ipinfo.io/json`, suggest this region. **On no match, timeout, or error → default to US1 (`datadoghq.com`).**
+
+| Suggested region | `DD_SITE` | Country codes |
+|------------------|-----------|---------------|
+| 🇺🇸 US1 — East (Virginia) | `datadoghq.com` | US, CA, MX, PR, VI, BR, AR, CL, CO, PE, VE, EC, BO, PY, UY |
+| 🇪🇺 EU1 — Europe (Frankfurt) | `datadoghq.eu` | DE, FR, IT, ES, NL, BE, AT, CH, PT, SE, NO, DK, FI, PL, CZ, RO, HU, GR, BG, HR, SK, LT, LV, EE, SI, LU, MT, CY, IL, AE, SA, ZA, EG, NG, KE, TR, IN, PK, BD, LK |
+| 🇯🇵 AP1 — Japan (Tokyo) | `ap1.datadoghq.com` | JP, KR, TW, HK, SG, TH, MY, PH, VN, ID, CN |
+| 🇦🇺 AP2 — Australia (Sydney) | `ap2.datadoghq.com` | AU, NZ, FJ, PG |
+| 🇬🇧 UK1 — United Kingdom (London) | `uk1.datadoghq.com` | GB, IE |
+
+Notes:
+- There is no country routing to US3 or US5; those are chosen manually. Only suggest the five regions above from IP, and let the user pick US3/US5 explicitly if they want them.
+- The suggestion is a *default*, not a decision. Always let the user override — region is permanent once an account exists.

--- a/dd-account-setup/references/troubleshooting.md
+++ b/dd-account-setup/references/troubleshooting.md
@@ -1,0 +1,31 @@
+# Troubleshooting & reference
+
+Backs the Troubleshooting pointer in `SKILL.md`. Diagnose a failed step here, then
+return to the step that failed.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `403` from `/api/v1/validate` with a key you know is valid | Wrong region. The key belongs to a different `DD_SITE`. Set `DD_SITE` to the key's region (Step 2) and re-validate. |
+| `403` from `current_user` but `/validate` is `200` | The **application key** is wrong or from another region, not the api key. |
+| `DD_SITE` rejected as unrecognized | It must match the allowed list exactly (no `https://`, no trailing slash, no `app.` prefix). Use the `DD_SITE` column in `references/regions.md`. |
+| IP detection times out / returns nothing | Expected on restricted networks. Falls back to US1; just confirm or override the region manually. |
+| Headless run exits immediately | A non-interactive run needs `DD_API_KEY`, `DD_APP_KEY`, and `DD_SITE` all set. Neither OAuth nor signup works without a browser. |
+| Browser shows "localhost:8080 can't connect" after approving | The auto-capture listener isn't running (no `python3`, timed out after 180s, or port 8080 was busy). Copy the full address-bar URL and paste it into Path B Step 2's `PASTE_REDIRECT_URL`. |
+| Auto-capture never returns / "no callback in 180s" | `python3` missing, port 8080 in use, or the browser never redirected. Re-run Path B Step 1; if it persists, use the paste fallback. |
+| OAuth `state mismatch` (Path B Step 2) | The pasted URL's `state` didn't match the statefile (stale tab / CSRF, or Step 1 wasn't run). Re-run Path B Step 1 and paste the fresh redirect URL. |
+| `bad code or state mismatch` | The pasted URL had no `code`, or the statefile was cleared. Re-run Path B Step 1, approve again, paste the new URL. |
+| `openssl: command not found` (OAuth PKCE) | Install openssl (macOS/Linux usually ship it). On Windows, run under WSL or Git Bash. |
+| Authenticated, but key creation returns `403` | The OAuth token / app key lacks `api_keys_write`, or is for another region. Create one at `organization-settings/api-keys` (you're already logged in) and paste it. |
+| User pasted a key but validation still fails | Check for surrounding whitespace / quotes, and that it's an **API key** (32 hex) not an app key (40 hex). |
+| Path C: `.env is git-tracked` | Refusing to write a secret to a tracked file. Use `.env.local` (or `git rm --cached .env` first), then re-run C2. |
+| Path C: `signup unavailable (no CSRF token)` | Signup API unreachable or rate-limited. Retry shortly; if it persists, use the browser `<base>/signup` page. |
+| Path C: signup rejected with a field `detail` | Datadog rejected an input (email already registered, or the generated password hit a policy). Surface the `detail`; for a policy miss, regenerate (C2) and retry. |
+| Path C: verify returns `error=2` (invalid code) | Wrong 8-digit code. Re-enter it (C4), or resend a code. |
+
+## Reference
+
+- **No bundled scripts.** All auth/signup runs as small inline `bash` + `curl` commands (OAuth PKCE also uses `openssl`) in these files — nothing to install beyond a normal shell (Windows: WSL/Git Bash).
+- **Design decisions:** generated password → `.env` (a new-account password is a credential the skill controls, so it's *generated* off-context rather than prompted — masking needs a real TTY the tool lacks), inline/no-scripts, OAuth redirect caught by a one-shot stdlib `python3 http.server` listener on `localhost:8080` (paste fallback when `python3` is absent / it times out / the port is busy), and the token→API-key step. On an **OAuth session** it only **retrieves** the most-recent existing key (minting a key with an OAuth token is server-blocked); an **empty org** or a role that can't list keys falls back to **manual UI paste**. Key **creation** (`POST /api/v2/api_keys`) happens only on the **API+APP-key** path, never on an OAuth token.
+- Temp state (fixed paths): `${TMPDIR:-/tmp}/dd-signup-$(id -u).{jar,jwt}` and `${TMPDIR:-/tmp}/dd-oauth-$(id -u).state` are removed in Step 5; `${TMPDIR:-/tmp}/dd-oauth-$(id -u).token` (the Bearer token, `0600`) is **kept** as the downstream instrumentation handoff and removed by the onboarding caller when setup finishes (see Step 5).


### PR DESCRIPTION
## Add `dd-account-setup` skill

Adds a skill that guarantees the caller has an **authenticated Datadog account with a valid API key on the correct region** before any Datadog setup or instrumentation runs. It is the account/auth precondition for the other `dd-*` setup skills.

### How it works
1. **Detect** — reads existing `DD_API_KEY` / `DD_APP_KEY` / `DD_SITE` from the environment and `.env`, and infers the region from what it finds.
2. **Validate** — checks the key against the Datadog API on the resolved site. A `403` here is almost always a wrong-region mismatch, so it retries region resolution instead of failing the user.
3. **Acquire (if needed)** — when no usable key exists, it either signs the user in via **OAuth** (browser, PKCE + state) or **creates a new account** in-terminal, then obtains and re-validates an API key.
4. **Report** — a single status card summarizing account, region, and key state; machine detail (scopes, redirect headers, JSON bodies) is logged, not printed.

### Problems it solves
- "I want to set up Datadog but I don't have an account / API key yet."
- The wrong-region `403` — the most common first-run failure — is diagnosed and fixed automatically instead of surfacing as a raw permission error.
- Gives every downstream `*-setup` / instrumentation skill a reliable precondition: a validated key on the right site.

### Dependencies
- **No SDKs or bundled scripts.** Runs as inline `bash` / `curl` / `openssl`; no Node, no extra packages.
- Optionally uses `AskUserQuestion` in interactive sessions to choose OAuth vs. new-account; falls back to a plain-text prompt otherwise.