### PR TITLE
Add dd-instrument-llmo skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Datadog skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, OpenCod
 | **dd-software-delivery** | CI/CD workflow skills — unblock PR pipelines, triage flaky tests (MCP + pup) |
 | **dd-apps** | Build Datadog Apps — scaffold, run locally, upload, publish, CI/CD, DDSQL data access |
 | **dd-product-recommender** | Recommend the right Datadog products for a codebase and/or goal (recommendation only) |
+| **dd-instrument-llmo** | Instrument Python & Node.js/Next.js AI backends with Datadog LLM Observability — SDK init, agent/workflow spans, RUM↔LLMO session linking |
 | **dd-instrument-rum** | Instrument browser apps with Datadog Browser RUM — React, Next.js, Angular, Vue, Nuxt, Svelte, vanilla |
 
 ## Install

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,6 +28,7 @@ Essential Datadog skills for AI agents.
 | **dd-product-recommender** | Recommend the right Datadog products for a codebase and/or goal (recommendation only) |
 | **dd-pup** | Primary CLI - all pup commands, auth, PATH setup |
 | **dd-software-delivery** | CI/CD workflow skills — unblock PR, triage flaky tests |
+| **dd-instrument-llmo** | Instrument Python & Node.js/Next.js AI backends with Datadog LLM Observability — SDK init, agent/workflow spans, RUM↔LLMO session linking |
 | **dd-instrument-rum** | Instrument browser apps with Datadog Browser RUM — React, Next.js, Angular, Vue, Nuxt, Svelte, vanilla |
 
 ## Install

--- a/dd-instrument-llmo/SKILL.md
+++ b/dd-instrument-llmo/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: dd-instrument-llmo
+description: Instrument the current project with Datadog LLM Observability for Python or Node.js/Next.js backends that call LLMs or run AI agents. Detects the runtime and LLM framework, provisions credentials, adds SDK init (ddtrace/dd-trace) with the correct kwargs, persists the dependency into the deploy manifest, and audits RUM↔LLMObs session-ID plumbing for gaps — fixing them when found. Use when the user says "instrument this project with LLM Observability", "add LLM Observability", "monitor my AI app in Datadog", "add LLM spans", "add agent session tracking", or "verify/repair my LLM Observability setup".
+metadata:
+  version: "0.1.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,llm-observability,llmobs,instrumentation,python,nodejs,nextjs,ddtrace,dd-trace,agents
+  alwaysApply: "false"
+---
+
+# Datadog LLM Observability Instrumentation
+
+This skill assesses the current project (backend runtime, LLM/agent framework, existing instrumentation) and routes you to the right reference file under `references/` for the actual setup steps. It is fully self-contained — it does not call any Datadog MCP server. Credential provisioning uses the local **`CreateApiKey`** tool, and all code changes are made by you, directly, using your own file-editing tools.
+
+Stay within LLM Observability scope. Do not add RUM, APM application instrumentation, or unrelated Datadog products. RUM and a Datadog Agent are relevant only because they change what session/trace linking is achievable (see the "Beyond SDK init" section in the reference files).
+
+**Do NOT invent tool names.** Use only `CreateApiKey` as described in `references/common-credentials.md`; every other step is done with your normal file-editing/search tools.
+
+**Do NOT write anything to memory during or after this skill.** Project paths, frameworks, credentials, and ML app names are project-specific and must not be stored in persistent memory.
+
+## Ground rules while instrumenting
+
+- **Verify before you assert.** If you're not sure about file content or codebase structure, read the files — do not guess.
+- **Check for existing instrumentation first.** Before touching the backend, check whether `ddtrace`/`dd-trace` is already initialized with LLM Observability enabled. If it is, do not add a second, competing `init`/`enable` call. **This only means skip re-init — it does not mean skip the work.** SDK presence is not the same as a well-formed trace or a working RUM↔LLMO link; run the linkage audit in Phase 1d and close any gap it finds, even when the SDK is already present.
+- **Only use packages/features you've explicitly been told to add.** Don't decide on your own to enable an additional Datadog product or SDK feature beyond what this skill specifies.
+- **Persist added dependencies into the deploy's manifest.** Any Datadog package you add (`ddtrace`, `dd-trace`) must be written into the dependency manifest the build/deploy installs from — the one identified in Phase 1e — not just installed into the local environment. A clean deploy install reads only the manifest and will crash with a missing-module error (e.g. `ModuleNotFoundError: No module named 'ddtrace'`) if the package isn't declared there.
+- **Don't make stylistic changes** to code you're not otherwise touching.
+- **No package aliases** when importing Datadog packages.
+- **Copy Datadog SDK package names, import paths, and init keyword arguments verbatim from the applicable reference section — do not paraphrase them from memory.** The Python LLM Observability import is exactly `from ddtrace.llmobs import LLMObs` — the module is `ddtrace.llmobs`, **not** `ddtrace.llm_observability` (that module does not exist and produces a deploy-time `ModuleNotFoundError`). The Node package is `dd-trace`, initialized with the form that matches the project: CommonJS `require('dd-trace').init(...)`, an ESM `import`-based form for `"type": "module"`/`.mjs` projects, or Next.js's `dd-trace/initialize.mjs` in `instrumentation.ts` — all shown in `references/llmobs-nodejs.md`; never force `require(...)` into an ESM project. Use the exact `LLMObs.enable(...)` / `.init({...})` keyword arguments shown; do not add, drop, or rename kwargs based on general Datadog knowledge.
+- **Use a real edit tool for existing files** (`Edit`/`Write`, not `sed -i`, `awk`, or scripted find/replace via Bash). If an edit-by-text-match fails, re-read the file first rather than retrying the identical edit.
+- **Checklist discipline.** Before starting the instrumentation steps, post a short checklist of the steps you're about to take. Check items off as you go, and review the checklist at the end of the run.
+- **After any code change**, check `package.json` for a `lint:fix`, `fix`, or `format` script (or `eslint --fix` / `prettier --write` config) and run it automatically — no need to ask permission.
+- **Verify the app still builds/runs** before declaring success (see `references/common-verify-report.md`).
+- **LLM Observability session IDs propagate from the root span only.** Never pass a session ID to a child span/decorator — see the "Adding spans" section in `references/llmobs-python.md` / `references/llmobs-nodejs.md`.
+- **Don't promise what the environment doesn't support.** If no RUM SDK is detected, don't claim RUM session linking; if no dd-agent is detected, don't claim navigable APM trace linking. State the gap and the upgrade path instead (see the "Beyond SDK init" section in the reference files).
+
+---
+## Phase 1: Analysis
+
+Inspect the relevant application directory before asking questions or editing files.
+
+### 1a. Detecting the backend LLM/agent runtime
+
+- Python signals: `requirements.txt`, `pyproject.toml`, `Pipfile`, or `*.py` files → runtime **`python`**
+- Node.js signals: a backend entry point (`server.js`, `index.js`, an Express/Next.js/Fastify app) → runtime **`nodejs`**
+- If both exist (e.g. a Next.js app with a Python worker), instrument each backend runtime independently.
+- If neither is present, there is nothing to instrument — stop and tell the user.
+
+### 1b. Detecting the LLM framework/SDK (optional, informational)
+
+Check dependency files for signals of: `openai`, `@anthropic-ai/sdk` / `anthropic`, `langchain`, `langgraph`, `ai` (Vercel AI SDK), `boto3` + Bedrock usage, `google-generativeai` / `google-genai`, `crewai`, `litellm`, `pydantic-ai`, an MCP SDK, `google-adk`. This doesn't change the init code (ddtrace/dd-trace auto-instruments these SDKs once the tracer is initialized) — it's only used for confirming the setup with the user and for special-cased frameworks noted in the reference files (Next.js, Vercel AI SDK).
+
+### 1c. Detecting the backend application framework
+
+- Python: `fastapi`, `flask`, or `django` dependency
+- Node.js: `express` dependency, or `next` (Next.js API routes / server actions)
+
+### 1d. Detecting existing instrumentation, and auditing the link
+
+- Grep for `ddtrace` init (`LLMObs.enable(`, `ddtrace-run`) in Python, or `dd-trace` init (`require('dd-trace').init(`, `dd-trace/initialize`) in Node.js.
+- Also grep for a frontend RUM SDK (`datadogRum.init(`, `@datadog/browser-rum`) — not to set it up, but because its presence determines whether RUM↔LLMO session linking is achievable.
+- If LLMObs init is already present, do not add a second `enable`/`init` call — but **do not stop there.** SDK presence only means "don't re-init"; it says nothing about whether a session ID actually flows. Run this audit whenever its prerequisite surfaces are present:
+  - **RUM↔LLMO session plumbing** — applicable only when a RUM SDK is present on the frontend *and* Phase 1a found an LLM/agent backend. Check whether a session ID actually flows: frontend sends `datadogRum.getInternalContext()?.session_id`, the backend request model/route reads it, and a root `agent`/`workflow` span sets it as `session_id`/`sessionId` (see "Beyond SDK init" and "Session ID intake by environment" in `references/llmobs-python.md` / `references/llmobs-nodejs.md`). `LLMObs.enable()`/`dd-trace().init()` alone does not establish this. Skip this check if there's no RUM SDK — there's nothing to link.
+  - If the check finds a gap, tell the user what's missing and fix it (same reference files, same ground rules) even though the SDK itself doesn't need re-initializing. If it passes, say so explicitly. Note it as not applicable rather than a pass/fail when there's no RUM SDK.
+
+### 1e. Detecting the dependency manifest to persist into
+
+For each backend runtime found in 1a, identify the **dependency manifest the build/deploy actually installs from**. This is where any Datadog package you add (`ddtrace`/`dd-trace`) must be persisted so a clean deploy install includes it. It is *not* necessarily "whichever manifest file happens to exist": a repo can have several (e.g. an empty `requirements.txt` alongside a `pyproject.toml`, or multiple `package.json` files where only one is the deployed workspace), and editing a non-authoritative one is a silent no-op at deploy time.
+
+Resolve it in this order:
+
+1. **Deploy/build install command first (authoritative).** Read the project's build/deploy configuration and use the install source it names: `render.yaml` (`buildCommand`), `Procfile`, `Dockerfile` (`RUN … install …`), `Makefile`, CI workflows, `package.json` scripts. Examples: `pip install -r <file>` → that requirements file; `poetry install` / `uv sync` / `pdm install` → `pyproject.toml` (+ its lockfile); `pipenv install` → `Pipfile`; `npm ci` / `yarn install` / `pnpm i` → `package.json`.
+2. **Else, the highest-priority manifest present.** Python: a lockfile-backed manager (`uv.lock` or `poetry.lock` → `pyproject.toml`) > `pyproject.toml` `[project.dependencies]`/`[tool.poetry.dependencies]` > `requirements*.txt` > `Pipfile` > `setup.py`/`setup.cfg`. Node.js: `package.json` (always).
+
+Record the **manifest path** and the **manager** that owns it. Persisting commands (`poetry add`, `uv add`, `pdm add`, `pipenv install`, `npm`/`yarn`/`pnpm`/`bun add`) write the manifest. Non-persisting commands (`pip install`, `uv pip install`, `conda install`) touch only the current environment — with those you must **also** hand-edit the manifest. If `requirements.txt` is generated from a `requirements.in` (pip-tools), edit the `.in` and recompile. After hand-editing a manifest that has a lockfile, regenerate the lock so a frozen deploy install picks up the new package.
+
+---
+## Phase 2: Instrumentation — routing table
+
+Provision `DD_API_KEY` via `references/common-credentials.md`, then follow the reference for each backend runtime found in Phase 1a:
+
+| Need | Read |
+|---|---|
+| LLM Observability — Python (SDK init, spans, session ID, RUM/APM linking) | `references/llmobs-python.md` |
+| LLM Observability — Node.js / Next.js (SDK init, spans, session ID, RUM/APM linking) | `references/llmobs-nodejs.md` |
+
+If Phase 1d found existing LLMObs instrumentation on a runtime, skip only that runtime's `init`/`enable` call and credential provisioning — still act on any gap the Phase 1d linkage audit found, using the same reference files.
+
+---
+## Phase 3: Verification and Reporting
+
+See `references/common-verify-report.md` for the verify step and the JSON report shape.

--- a/dd-instrument-llmo/references/common-credentials.md
+++ b/dd-instrument-llmo/references/common-credentials.md
@@ -1,0 +1,41 @@
+# Credentials and API keys
+
+Used by the LLM Observability reference files (`llmobs-python.md` / `llmobs-nodejs.md`). Use only the local tool named below — do not invent tool names.
+
+## API key (`CreateApiKey`)
+
+`DD_API_KEY` is required for LLM Observability (dd-trace / ddtrace in agentless mode — see `llmobs-python.md` / `llmobs-nodejs.md`).
+
+```
+CreateApiKey(
+  name: string  REQUIRED  — display name for the API key (e.g. "<project-folder-name> - LLM Observability")
+)
+```
+
+On success it returns `{ apiKey, name }`.
+
+Ask the user to confirm before creating a new org-level API key on their behalf. If the call fails (e.g. insufficient scope), ask the user to create a key manually at `https://app.datadoghq.com/organization-settings/api-keys` and paste it in. Do not proceed until they confirm.
+
+Never log or print the key value in your final report.
+
+## Provisioning `DD_API_KEY` into a local env file
+
+### Identify the env file
+
+Scan the project root for env files in this order and use the **first one found**:
+
+`.env.local` → `.env.development.local` → `.env.development` → `.env`
+
+If none exist, choose which file to **create** based on framework:
+- Next.js or Create React App → create `.env.local`
+- All other projects → create `.env`
+
+### Check for an existing key
+
+Read the chosen env file (if it exists) and check whether `DD_API_KEY` (or `DATADOG_API_KEY`) is already set to a non-empty value. If a non-empty key is already present, skip key creation and reuse it.
+
+### Write the key
+
+Upsert `DD_API_KEY=<key>` into the file identified above (create it if needed). Preserve all existing lines — only add or replace the `DD_API_KEY` line.
+
+If a `.gitignore`/global-ignore rule blocks you from writing directly to an env file, use shell redirection (`echo "VAR=value" >> .env.local`) instead of a file-write tool that respects ignore rules.

--- a/dd-instrument-llmo/references/common-verify-report.md
+++ b/dd-instrument-llmo/references/common-verify-report.md
@@ -1,0 +1,26 @@
+# Verification and reporting
+
+## Verify
+
+**Confirm the `dd-trace`/`ddtrace` package you added is declared in the dependency manifest the deploy installs from** (the one identified in SKILL.md Phase 1e) — not merely present in your local environment. Grep that manifest for the package you added, or do a clean install into a throwaway env. This matters because a local `pip install ddtrace` followed by a successful `uvicorn` run passes the startup check below while the manifest is still missing the dependency — so the deploy would crash with `ModuleNotFoundError` even though local verification looked green.
+
+**For every backend runtime you instrumented, actually execute the instrumented entrypoint** — do not rely on "the project's `start`/`dev` script." In a split frontend/backend repo there is often no single script that runs both halves, so "run the start script" can pass while never importing the backend at all. Load the module that contains your `LLMObs.enable(...)` / `.init(...)` so that init line runs:
+- **Python**: from the same working directory the deploy uses (e.g. `cd backend` when the module lives under `backend/`, so `PYTHONPATH`/cwd match the deploy), run `python -c "import app.main"` (substitute the real module path), or boot the real start command (`uvicorn app.main:app`) and confirm it binds with no traceback. If you used the `ddtrace-run` / `import ddtrace.auto` alternative (no in-code `LLMObs.enable(...)` to import), boot with that wrapper instead — e.g. `ddtrace-run uvicorn app.main:app`.
+- **Node.js**: `node -e "require('./<entry>')"` (or an `import` for an ESM entry), or boot the server entrypoint. If instrumentation is via `NODE_OPTIONS='--import dd-trace/initialize.mjs'`, boot with that env set so the loader actually runs. For Next.js, run `next build` and confirm it completes without errors.
+
+This is the step that catches a wrong import path or bad `enable()`/`init()` arguments — e.g. `from ddtrace.llm_observability import LLMObs` raising `ModuleNotFoundError` — which a passing manifest check will not surface.
+
+If the app builds/runs successfully, tell the user where to look:
+- LLM Observability: `https://app.datadoghq.com/llm/traces?query=@ml_app:<mlAppName>`
+
+## Report
+
+```json
+{
+  "success": boolean,
+  "mlApp": "llm-app-name",
+  "message": "Human-friendly summary of what happened"
+}
+```
+
+Alongside this shape, summarize goal status in the human-readable `message` — see "Reporting goal status" in `llmobs-python.md` / `llmobs-nodejs.md`.

--- a/dd-instrument-llmo/references/llmobs-nodejs.md
+++ b/dd-instrument-llmo/references/llmobs-nodejs.md
@@ -1,0 +1,239 @@
+# LLM Observability: Node.js
+
+Provision `DD_API_KEY` first via `common-credentials.md` if you haven't already.
+
+Install — and **persist `dd-trace` into the dependency manifest the deploy installs from** (the one identified in SKILL.md Phase 1e, normally `package.json`). `npm install` / `yarn add` / `pnpm add` / `bun add` all write it to `package.json` by default, which is what you want:
+```sh
+npm install dd-trace
+```
+(substitute `yarn add` / `pnpm add` / `bun add` per the detected package manager). Do not pass `--no-save`, and confirm `dd-trace` appears in `package.json` afterward — a package present only in `node_modules` is missing from a clean deploy install and the deploy will crash with `Cannot find module 'dd-trace'`.
+
+## In-code init (non-Next.js)
+
+> **Copy the package name and `.init({...})` option keys verbatim** — the package is `dd-trace` and the options are exactly `llmobs: { mlApp, agentlessEnabled }` as shown below. Don't paraphrase the package name or invent option keys from memory. Adapt only the module *mechanism* to the project's module system: the CommonJS `require('dd-trace').init(...)` form is below; a project with `"type": "module"` in `package.json` or an `.mjs` entrypoint must use an ESM form instead (Node's `--import dd-trace/initialize.mjs` via `NODE_OPTIONS`, or `import tracer from 'dd-trace'` — both shown later in this file), because `require` is undefined in an ES module and forcing it there crashes at startup with `require is not defined`.
+
+Must run before any other application code, typically as the very first line of the entry file or in a separate `tracer.js` required first:
+```javascript
+require('dd-trace').init({
+    llmobs: {
+        mlApp: process.env.DD_LLMOBS_ML_APP,
+        agentlessEnabled: true,
+    },
+    site: process.env.DD_SITE,
+    env: process.env.DD_ENV || "dev",
+});
+// ... then require everything else
+```
+
+Env vars (`.env`/`.env.local`):
+```
+DD_API_KEY=<key from common-credentials.md>
+DD_LLMOBS_ML_APP=<suitable app name, e.g. project folder name>
+DD_SITE=<site, default datadoghq.com>
+```
+
+## Next.js
+
+Look for (or create) `instrumentation.ts`/`.js` at the project root and add:
+```typescript
+export async function register() {
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        const initializeImportName = 'dd-trace/initialize.mjs';
+        await import(/* webpackIgnore: true */ initializeImportName as 'dd-trace/initialize.mjs')
+    }
+}
+```
+Also add `serverExternalPackages: ["<llm-sdk-package>"]` (e.g. `"@anthropic-ai/sdk"`, `"openai"`) to `next.config.js`. Additionally set `DD_LLMOBS_ENABLED=true` and `DD_LLMOBS_AGENTLESS_ENABLED=true` in the env file. After making these changes, run `npx tsc --noEmit` and add `// @ts-ignore` only for genuinely new errors introduced by the dd-trace types.
+
+If the project already defines a `register()` export in `instrumentation.ts` (e.g. for other instrumentation), extend it rather than adding a second, competing `register()` export.
+
+## Vercel AI SDK (`ai` package)
+
+The LLM Observability integration requires `experimental_telemetry.isEnabled = true` to be explicitly set (not omitted) on every call to `generateText`, `streamText`, `generateObject`, `streamObject`, `embed`, `embedMany`, and any `tool.execute`. Grep for these call sites and fix each one; if `experimental_telemetry` is missing entirely, add `experimental_telemetry: { isEnabled: true }`. For Next.js apps using this SDK, also add `"ai"` to `serverExternalPackages`.
+
+Follow-up reading for the user: [Vercel AI SDK integration docs](https://docs.datadoghq.com/integrations/vercel-ai-sdk/).
+
+## Vercel-hosted projects: env var placement
+
+On Vercel, add these to the project's env vars — Vercel dashboard for deployed environments, `.env.local` for local dev:
+
+| Variable | Value |
+|---|---|
+| `DD_API_KEY` | From `common-credentials.md` |
+| `DD_SITE` | e.g. `datadoghq.com` |
+| `DD_LLMOBS_ENABLED` | `true` |
+| `DD_LLMOBS_AGENTLESS_ENABLED` | `true` |
+| `DD_LLMOBS_ML_APP` | A suitable ML app name (e.g. the Vercel project name) |
+
+## Alternative: no code change
+
+Use `NODE_OPTIONS` in `package.json` scripts:
+```json
+{ "scripts": { "start": "NODE_OPTIONS='--import dd-trace/initialize.mjs' node app.js" } }
+```
+For Next.js: `"start": "NODE_OPTIONS='--import dd-trace/initialize.mjs' next start"`, `"dev": "NODE_OPTIONS='--import dd-trace/initialize.mjs' next dev"`.
+
+Note: when running an app inline for a one-off manual test (not via its normal start script), `.env` values won't be picked up automatically — pass them on the command line directly:
+```sh
+DD_LLMOBS_ENABLED=1 DD_LLMOBS_ML_APP=<app-name> DD_API_KEY=<key> DD_LLMOBS_AGENTLESS_ENABLED=1 DD_SITE=datadoghq.com pnpm dev
+```
+
+## Beyond SDK init: a well-formed trace
+
+**Run this section even if `dd-trace`'s `init()` already exists in the project.** SDK init alone only turns on auto-instrumented `llm` spans — it does not by itself produce a session ID, a root span, or a RUM/APM link. Don't let Phase 1d's "SDK already present" finding stand in for this checklist.
+
+Enabling the SDK produces auto-instrumented `llm` spans for supported providers, but a useful trace also needs a root span, session ID, and annotations. Work toward these four goals; the first two are always achievable, the last two depend on the environment:
+
+| # | Goal | Always achievable? | What it requires |
+|---|------|-------------------|-------------------|
+| 1 | Well-formed LLMObs trace | Yes | SDK initialized; a root span with the right kind; nested child spans; `inputData`/`outputData` annotated |
+| 2 | Agent Session ID | Yes | A stable `sessionId` on the root span — it propagates to children automatically |
+| 3 | RUM session linking | Only with RUM SDK | RUM session ID (`datadogRum.getInternalContext().session_id`) passed to the backend as the LLMObs `sessionId`. Without RUM, fall back to a UUID — linking can be added later without restructuring |
+| 4 | APM trace linking | Partial — always | `apm_trace_id` is set on every span automatically. Full navigable linking in the UI needs a dd-agent; without one the tag is present but the APM trace won't exist |
+
+Detect what's achievable before instrumenting: check for `@datadog/browser-rum` on the frontend (goal 3), and for `DD_AGENT_HOST`/`DD_TRACE_AGENT_URL`/`NODE_OPTIONS=--require dd-trace/init`/an agent sidecar (goal 4). Never promise RUM or navigable APM linking that the detected environment doesn't support — state the gap and the upgrade path instead.
+
+**Goal 4 config knob:** the init snippets above hardcode `agentlessEnabled: true`. Flip it to `false` whenever a dd-agent is detected — leave it `true` otherwise (the `apm_trace_id` tag is still set either way, but only becomes a navigable APM trace with an agent present).
+
+## Adding spans
+
+Obtain `llmobs` from the already-initialized tracer (the `require('dd-trace').init(...)` from "In-code init" above) — don't call `.init()` again:
+```typescript
+import tracer from 'dd-trace';
+const { llmobs } = tracer;
+```
+(CommonJS: same tracer instance returned by the `require('dd-trace').init(...)` call above — `const { llmobs } = require('dd-trace');`)
+
+**`llmobs.trace()`** (preferred):
+```typescript
+const result = await llmobs.trace(
+  { kind: 'agent', name: 'my_agent', sessionId },   // set sessionId here only
+  async (span) => {
+    llmobs.annotate(span, { inputData: userMessage });
+    const res = await doWork(userMessage);
+    llmobs.annotate(span, { outputData: res });
+    return res;
+  }
+);
+```
+
+**`llmobs.wrap()`** for named functions:
+```typescript
+const instrumentedFn = llmobs.wrap({ kind: 'tool', name: 'my_tool' }, myFn);
+```
+
+**Annotation:**
+```typescript
+llmobs.annotate(span, {
+  inputData: 'user message',   // string or messages array
+  outputData: 'agent response',
+  metadata: { key: 'value' },
+});
+```
+
+**Session ID rule:** pass `sessionId` only to whichever `llmobs.trace()`/`llmobs.wrap()` call is the *root* span of the trace — typically `kind: 'agent'`, but `kind: 'workflow'` can be the root if the entry point has no direct LLM orchestration (see the LangChain.js/Vercel AI SDK notes below). Child spans created in the same async context inherit it automatically — never pass `sessionId` to a non-root span.
+
+## Session name (optional display title)
+
+`sessionId` has no companion "display name" field in the SDK — the UI otherwise shows a truncated session ID. If the application already has (or can cheaply derive) a human-readable label for the operation — a job type, a conversation topic, a ticket title — set it as a `session_name` tag on the same root span that carries `sessionId`, via `llmobs.annotate(span, { tags })`:
+
+```typescript
+const result = await llmobs.trace(
+  { kind: 'agent', name: 'my_agent', sessionId },
+  async (span) => {
+    llmobs.annotate(span, { tags: { session_name: 'Playlist for Milo (cat)' } });
+    return await doWork();
+  }
+);
+```
+
+Only set it once, on the root span — same rule as `sessionId`. Skip this if there's no natural label available; don't fabricate one from generic defaults (e.g. `` `session-${sessionId}` ``) since that's no more useful than the raw ID.
+
+## Session ID intake by environment
+
+**RUM present** — default the LLMO session ID to the RUM session ID. The frontend forwards it to the backend alongside the rest of the request payload, under whatever key name fits this project's existing request-body naming convention; read that value on the backend using the same request-parsing accessor the project already uses for the rest of that request's fields — do not assume Express's `req.body` (Fastify uses `request.body`, Next.js Route Handlers / Hono use `await req.json()`, etc.; see Framework-specific notes below for the accessor per framework):
+```typescript
+// Shown with Express's req.body — substitute the accessor your framework/route actually uses.
+const sessionId = req.body.sessionId;
+const result = await llmobs.trace({ kind: 'agent', name: 'my_agent', sessionId }, async (span) => {
+  llmobs.annotate(span, { inputData: req.body.message });
+  const res = await doWork(req.body.message);
+  llmobs.annotate(span, { outputData: res });
+  return res;
+});
+```
+Frontend side (show as instructions, never edit frontend files yourself in this reference — setting up the RUM SDK itself is out of scope for this LLM Observability skill):
+```javascript
+body: JSON.stringify({
+  message: userMessage,
+  sessionId: datadogRum.getInternalContext()?.session_id ?? crypto.randomUUID(),
+})
+```
+
+**Web framework, no RUM** — accept from caller, UUID fallback (same caveat: use the project's actual request accessor, not necessarily `req.body`):
+```typescript
+const sessionId = req.body.sessionId ?? req.headers['x-session-id'] ?? crypto.randomUUID();
+```
+
+**No web frontend (CLI / background job)** — reuse an existing per-operation identifier if the code already generates one before the pipeline runs (`jobId`, `requestId`, `taskId`, etc.) instead of minting a second ID; otherwise one UUID per invocation:
+```typescript
+const sessionId = jobId ?? crypto.randomUUID();
+```
+
+## Multi-agent pipelines and sub-agent orchestration
+
+When one function invokes multiple distinct agents (or the same agent multiple times) as sequential stages of a single logical operation — a background job that runs a profiler agent, then a theme agent, then a scout agent, then a curator agent, for example — wrap the **entire orchestrating function once**. One root span per logical operation, not one per agent-run call:
+
+```typescript
+async function runPipeline(jobId: string) {
+  return llmobs.trace({ kind: 'workflow', name: 'playlist_pipeline', sessionId: jobId }, async (span) => {
+    const vibe = await profilerAgent.run(...);
+    const theme = await themeAgent.run(...);
+    const candidates = await scoutAgent.run(...);
+    const selections = await curatorAgent.run(...);
+    llmobs.annotate(span, { inputData: jobId, outputData: selections });
+    return selections;
+  });
+}
+```
+
+Use `kind: 'workflow'` here, not `'agent'` — `runPipeline` doesn't call an LLM directly, it orchestrates other agents that do (see the decision table below). Each agent-run call auto-instruments as a nested `agent` span under this one root; all four land on a single trace and inherit `sessionId` through the same async context. This applies to any auto-instrumented agent framework (LangChain.js/LangGraph.js, Vercel AI SDK, OpenAI Agents JS) — the rule is about *where* you put the one enclosing span, not which framework is calling the LLM.
+
+**Anti-pattern — produces one trace/session per stage instead of one per operation:** calling each stage's agent-run function directly inside the pipeline function with no enclosing `llmobs.trace()`/`llmobs.wrap()`. Without an active span in scope, there's nothing for the auto-instrumentation to attach each call to, so every stage gets its own root span — a separate trace, and (with no explicit `sessionId`) a separate session in the UI. This is easy to miss because the SDK is "enabled" and traces do show up — they're just fragmented one-per-agent instead of grouped one-per-operation. Symptom in the trace list: what should be one conversation instead shows up as N separate single-agent conversations (e.g. `curator_agent`, `scout_agent`, `theme_agent`, `profiler_agent` each listed on their own, instead of one session containing all four).
+
+**Detecting this while verifying:** if a single logical operation (one job, one request, one pipeline run) produces more than one root span/trace in the LLM Obs UI, the fix is to add one enclosing `kind: 'workflow'`/`'agent'` span around the whole orchestrating function — not to sprinkle the same `sessionId` across each stage's own root span. Matching `sessionId`s across separate traces groups them into one *session*, but a single trace with nested children is the stronger, simpler, and intended fix; prefer it whenever the stages share one caller.
+
+## Span kind decision table
+
+| Code pattern | Span kind |
+|---|---|
+| Top-level function orchestrating LLM calls and tools | `agent` |
+| Multi-step pipeline not directly calling LLMs | `workflow` |
+| Function calling an LLM directly (only if not auto-instrumented) | `llm` (manual) |
+| Function wrapping a capability (web search, calculator, DB) | `tool` |
+| Pure data transformation / business logic | `task` |
+| RAG / vector search | `retrieval` |
+| Text embedding generation | `embedding` |
+
+**Auto-instrumented providers** (no manual `llm` span needed): OpenAI JS SDK, Anthropic JS SDK, LangChain.js/LangGraph.js, Vercel AI SDK. Wrap the *calling* function with `kind: 'tool'` or `kind: 'agent'` instead of the provider call itself.
+
+**Never add spans to:** web routing/middleware, data model/config classes, DB/cache clients, logging/metrics utilities, test files, pure utility functions.
+
+## Framework-specific notes
+
+- **LangChain.js / LangGraph.js:** auto-instrumented; wrap the top-level invoking function with `llmobs.trace({ kind: 'workflow', sessionId })` — `sessionId` is valid here only because this call *is* the root span; don't add it to any nested `kind: 'workflow'` call.
+- **Vercel AI SDK:** auto-instrumented; wrap the calling function with `llmobs.trace({ kind: 'workflow', sessionId })` (same root-span caveat) — do not wrap individual `generateText()`/`streamText()` calls, they're already traced. Also requires `experimental_telemetry.isEnabled = true` per call — see the Vercel AI SDK section above.
+- **OpenAI Agents JS:** auto-instrumented; wrap the function calling `Runner.run()` with `llmobs.trace({ kind: 'agent', sessionId })`. If that function calls more than one agent/`Runner.run()` (a multi-stage pipeline), wrap it **once**, enclosing every stage — see "Multi-agent pipelines and sub-agent orchestration" above; don't wrap each stage's call separately. Use `kind: 'workflow'` instead of `'agent'` when the wrapper orchestrates multiple agents without calling an LLM itself.
+- **Express / Fastify / Hono / Koa:** session ID from `req.body.sessionId` or `req.headers['x-session-id']` with `crypto.randomUUID()` fallback.
+- **Next.js App Router:** session ID from the request body in Route Handlers/API routes; the SDK itself still initializes in `instrumentation.ts` as shown above. **Pages Router:** same intake, init via `NODE_OPTIONS` — never in `_app.tsx`, which is a browser bundle.
+- **CLI / background job:** prefer an existing per-operation ID if the code already tracks one (`const sessionId = jobId ?? crypto.randomUUID()`); otherwise `crypto.randomUUID()` per run. RUM not applicable.
+
+## Reporting goal status
+
+Alongside the standard report shape in `common-verify-report.md`, summarize goal status in the human-readable message, e.g.:
+```
+✓ Well-formed LLMObs trace
+✓ Agent Session ID (UUID fallback — RUM upgrade path noted)
+~ RUM session linking: not available (no RUM SDK detected)
+~ APM trace linking: apm_trace_id set, but not navigable (no dd-agent detected)
+```

--- a/dd-instrument-llmo/references/llmobs-python.md
+++ b/dd-instrument-llmo/references/llmobs-python.md
@@ -1,0 +1,201 @@
+# LLM Observability: Python
+
+Provision `DD_API_KEY` first via `common-credentials.md` if you haven't already.
+
+Install — and **persist `ddtrace` into the dependency manifest the deploy installs from** (the one identified in SKILL.md Phase 1e), not just the local environment. A local-only install makes the app run for you, but a clean deploy install reads the manifest and will crash with `ModuleNotFoundError: No module named 'ddtrace'` if the package isn't declared there.
+
+**Persisting installs (preferred).** These commands record `ddtrace` in the manifest automatically — nothing else needed:
+```sh
+poetry add ddtrace      # writes pyproject.toml [tool.poetry.dependencies]
+uv add ddtrace          # writes pyproject.toml [project.dependencies] + uv.lock
+pdm add ddtrace         # writes pyproject.toml
+pipenv install ddtrace  # writes Pipfile
+```
+
+**Non-persisting installs (you must also hand-edit the manifest).** These commands touch the current environment **only** and do NOT write any manifest — after running one, add `ddtrace` to the manifest by hand:
+```sh
+pip install ddtrace              # env only — does not edit requirements.txt/pyproject.toml
+uv pip install ddtrace           # env only — prefer `uv add`
+conda install -c conda-forge ddtrace
+```
+Where to hand-edit: a `ddtrace` line in `requirements.txt`, or `"ddtrace"` in the `[project.dependencies]` (or `[tool.poetry.dependencies]`) array of `pyproject.toml` — matching whichever manifest Phase 1e identified.
+
+## In-code init
+
+> **Copy the import and `LLMObs.enable(...)` call verbatim.** The module is `ddtrace.llmobs` — there is **no** `ddtrace.llm_observability` module, and "correcting" the terse name to the spelled-out one is the most common way this instrumentation crashes on deploy (`ModuleNotFoundError: No module named 'ddtrace.llm_observability'`). Use exactly the kwargs shown below (`ml_app`, `api_key`, `site`, `agentless_enabled`); don't substitute `env`/`service` or add a `from ddtrace import tracer, config` line from memory.
+
+Must run before any other application imports:
+```python
+# any top-level imports, mainly os or dotenv
+import os
+import dotenv
+
+# import and enable LLM Observability _before_ any other module imports
+from ddtrace.llmobs import LLMObs
+
+LLMObs.enable(
+    ml_app=os.environ["DD_LLMOBS_ML_APP"],
+    api_key=os.environ["DD_API_KEY"],
+    site=os.environ.get("DD_SITE", "datadoghq.com"),
+    agentless_enabled=True,
+)
+
+# all other application-specific imports, and remaining application logic
+from openai import OpenAI
+# ...
+```
+
+## Alternative: no code change
+
+Wrap the run command with `ddtrace-run` and pass config via env vars:
+```sh
+DD_SITE=datadoghq.com DD_LLMOBS_ENABLED=1 DD_LLMOBS_ML_APP=<app-name> DD_API_KEY=<key> DD_LLMOBS_AGENTLESS_ENABLED=1 ddtrace-run app.py
+```
+For FastAPI/uvicorn: `ddtrace-run uvicorn main:app --reload`.
+
+## Beyond SDK init: a well-formed trace
+
+**Run this section even if `LLMObs.enable()` already exists in the project.** SDK init alone only turns on auto-instrumented `llm` spans — it does not by itself produce a session ID, a root span, or a RUM/APM link. Don't let Phase 1d's "SDK already present" finding stand in for this checklist.
+
+Enabling the SDK produces auto-instrumented `llm` spans for supported providers, but a useful trace also needs a root span, session ID, and annotations. Work toward these four goals; the first two are always achievable, the last two depend on the environment:
+
+| # | Goal | Always achievable? | What it requires |
+|---|------|-------------------|-------------------|
+| 1 | Well-formed LLMObs trace | Yes | SDK initialized; a root span with the right kind; nested child spans; `input_data`/`output_data` annotated |
+| 2 | Agent Session ID | Yes | A stable `session_id` on the root span — it propagates to children automatically |
+| 3 | RUM session linking | Only with RUM SDK | RUM session ID (`datadogRum.getInternalContext().session_id`) passed to the backend as the LLMObs `session_id`. Without RUM, fall back to a UUID — linking can be added later without restructuring |
+| 4 | APM trace linking | Partial — always | `apm_trace_id` is set on every span automatically. Full navigable linking in the UI needs a dd-agent; without one the tag is present but the APM trace won't exist |
+
+Detect what's achievable before instrumenting: check for `@datadog/browser-rum` on the frontend (goal 3), and for `DD_AGENT_HOST`/`DD_TRACE_AGENT_URL`/`ddtrace-run`/an agent sidecar (goal 4). Never promise RUM or navigable APM linking that the detected environment doesn't support — state the gap and the upgrade path instead.
+
+**Goal 4 config knob:** the init snippet above hardcodes `agentless_enabled=True`. Flip it to `False` whenever a dd-agent is detected — leave it `True` otherwise (the `apm_trace_id` tag is still set either way, but only becomes a navigable APM trace with an agent present).
+
+## Adding spans
+
+All imports come from `ddtrace.llmobs` (public package) — never import from underscore-prefixed submodules.
+
+**Decorators** (preferred for child functions):
+```python
+from ddtrace.llmobs.decorators import agent, workflow, task, tool, retrieval, embedding
+
+@agent(name="my_agent", session_id=session_id)   # orchestrates LLM calls — set session_id here only
+@workflow(name="my_workflow")                    # multi-step, no direct LLM calls — inherits session_id from root
+@task(name="my_task")                            # pure computation
+@tool(name="my_tool")                            # wraps a capability
+@retrieval(name="my_retrieval")                  # RAG / vector search
+@embedding(name="my_embedding")                  # embedding generation
+```
+
+**Context manager** (preferred for the root span when `session_id` is a runtime value):
+```python
+with LLMObs.agent(name="my_agent", session_id=session_id) as span:
+    LLMObs.annotate(span=span, input_data=user_message, output_data=response)
+```
+`LLMObs.agent(...)` returns a `Span`, which only supports the sync context manager protocol — always use `with`, even inside an `async def`. Using `async with` raises `'Span' object does not support the asynchronous context manager protocol`.
+
+**Annotation:**
+```python
+LLMObs.annotate(
+    span=span,                  # None = current active span
+    input_data="user message",  # str or messages list
+    output_data="agent response",
+    metadata={"key": "value"},
+)
+```
+
+**Session ID rule:** set `session_id` only on whichever decorator/context-manager is the *root* span of the trace — typically `@agent`/`LLMObs.agent(...)`, but a `@workflow` can be the root if the entry point has no direct LLM orchestration (see the LangChain/LangGraph note below). Descendants inherit it via `ddtrace` context propagation — never pass `session_id` to a non-root decorator.
+
+## Session name (optional display title)
+
+`session_id` has no companion "display name" field in the SDK — the UI otherwise shows a truncated session ID. If the application already has (or can cheaply derive) a human-readable label for the operation — a job type, a conversation topic, a ticket title — set it as a `session_name` tag on the same root span that carries `session_id`, via `LLMObs.annotate(tags=...)`:
+
+```python
+with LLMObs.agent(name="my_agent", session_id=session_id) as span:
+    LLMObs.annotate(span=span, tags={"session_name": "Playlist for Milo (cat)"})
+```
+
+Only set it once, on the root span — same rule as `session_id`. Skip this if there's no natural label available; don't fabricate one from generic defaults (e.g. `f"session-{session_id}"`) since that's no more useful than the raw ID.
+
+## Session ID intake by environment
+
+**RUM present** — default the LLMO session ID to the RUM session ID. The frontend forwards it to the backend alongside the rest of the request payload, under whatever key name fits this project's existing request-body naming convention; read that value on the backend using the same request-parsing accessor the project already uses for the rest of that request's fields — do not assume one framework's access pattern (FastAPI's Pydantic model gives attribute access like `request.session_id`; Flask needs `request.get_json()["session_id"]` or a schema's `.load()`; see Framework-specific notes below):
+```python
+# Shown with a FastAPI Pydantic request model — substitute the accessor your framework/route actually uses.
+session_id = request.session_id
+with LLMObs.agent(name="my_agent", session_id=session_id) as span:
+    LLMObs.annotate(span=span, input_data=request.message)
+    result = do_work(request.message)
+    LLMObs.annotate(span=span, output_data=result)
+```
+Frontend side (show as instructions, never edit frontend files yourself in this reference — setting up the RUM SDK itself is out of scope for this LLM Observability skill):
+```javascript
+body: JSON.stringify({
+  message: userMessage,
+  session_id: datadogRum.getInternalContext()?.session_id ?? crypto.randomUUID(),
+})
+```
+
+**Web framework, no RUM** — accept from caller, UUID fallback (same caveat: use the project's actual request accessor, not necessarily attribute access):
+```python
+session_id = request.session_id or request.headers.get("x-session-id") or str(uuid.uuid4())
+```
+
+**No web frontend (CLI / background job)** — reuse an existing per-operation identifier if the code already generates one before the pipeline runs (`job_id`, `request_id`, `task_id`, etc.) instead of minting a second ID; otherwise one UUID per invocation:
+```python
+session_id = job_id or str(uuid.uuid4())
+```
+
+## Multi-agent pipelines and sub-agent orchestration
+
+When one function invokes multiple distinct agents (or the same agent multiple times) as sequential stages of a single logical operation — a background job that runs a profiler agent, then a theme agent, then a scout agent, then a curator agent, for example — wrap the **entire orchestrating function once**. One root span per logical operation, not one per `agent.run()`/`agent.iter()` call:
+
+```python
+async def run_pipeline(job_id: str) -> None:
+    with LLMObs.workflow(name="playlist_pipeline", session_id=job_id) as span:
+        vibe = (await profiler_agent.run(...)).output
+        theme = (await theme_agent.run(...)).output
+        candidates = await scout_agent.run(...)
+        selections = (await curator_agent.run(...)).output
+        LLMObs.annotate(span, input_data=job_id, output_data=selections)
+```
+
+Use `workflow` here, not `agent` — `run_pipeline` doesn't call an LLM directly, it orchestrates other agents that do (see the decision table below). Each `agent.run()` call auto-instruments as a nested `agent` span under this one root; all four land on a single trace and inherit `session_id` through ddtrace's context propagation. This applies to any auto-patched agent framework (Pydantic AI, LangChain/LangGraph, OpenAI Agents SDK) — the rule is about *where* you put the one enclosing span, not which framework is calling the LLM.
+
+**Anti-pattern — produces one trace/session per stage instead of one per operation:** calling `agent.run()` for each stage directly inside the pipeline function with no enclosing span. Without an active parent span, there's nothing for the auto-instrumentation to attach each call to, so every `agent.run()` gets its own root span — a separate trace, and (with no explicit `session_id`) a separate session in the UI. This is easy to miss because the SDK is "enabled" and traces do show up — they're just fragmented one-per-agent instead of grouped one-per-operation. Symptom in the trace list: what should be one conversation instead shows up as N separate single-agent conversations (e.g. `curator_agent`, `scout_agent`, `theme_agent`, `profiler_agent` each listed on their own, instead of one session containing all four).
+
+**Detecting this while verifying:** if a single logical operation (one job, one request, one pipeline run) produces more than one root span/trace in the LLM Obs UI, the fix is to add one enclosing `workflow`/`agent` span around the whole orchestrating function — not to sprinkle the same `session_id` across each stage's own root span. Matching `session_id`s across separate traces groups them into one *session*, but a single trace with nested children is the stronger, simpler, and intended fix; prefer it whenever the stages share one caller.
+
+## Span kind decision table
+
+| Code pattern | Span kind |
+|---|---|
+| Top-level function orchestrating LLM calls and tools | `agent` |
+| Multi-step pipeline not directly calling LLMs | `workflow` |
+| Function calling an LLM directly (only if not auto-instrumented) | `llm` (manual) |
+| Function wrapping a capability (web search, calculator, DB) | `tool` |
+| Pure data transformation / business logic | `task` |
+| RAG / vector search | `retrieval` |
+| Text embedding generation | `embedding` |
+
+**Auto-instrumented providers** (no manual `llm` span needed): OpenAI, Anthropic, LangChain/LangGraph, AWS Bedrock, Google Vertex/Gemini, LiteLLM, CohereAI. Decorate the *calling* function with `tool`/`agent` instead of the provider call itself.
+
+**Never add spans to:** web routing/middleware, data model/config classes, DB/cache clients, logging/metrics utilities, test files, pure utility functions.
+
+## Framework-specific notes
+
+- **OpenAI Agents SDK:** coexists with its own `trace()`; `Runner.run()` is auto-instrumented — wrap the calling function with `@tool`/`@agent`; align `session_id` via `group_id` in `trace()` and `session_id` in the LLMObs context manager.
+- **Pydantic AI:** auto-patched on `LLMObs.enable()`; wrap the function calling `agent.run()`/`agent.iter()` with a context manager passing `session_id`. If that function calls more than one `Agent` (a multi-stage pipeline), wrap it **once**, enclosing every stage — see "Multi-agent pipelines and sub-agent orchestration" above; don't wrap each stage's `.run()` call separately.
+- **LangChain/LangGraph:** fully auto-instrumented; wrap the top-level invoking function with `@workflow(session_id=...)` or a context manager — `session_id` is valid here only because this `@workflow` *is* the root span; don't add it to any nested `@workflow`.
+- **FastAPI:** `LLMObs.enable()` where `app = FastAPI()` is created; session ID from request body or `x-session-id` header with UUID fallback.
+- **Flask:** `LLMObs.enable()` before `app.run()` or in `create_app()`; session ID from `request.get_json()["session_id"]` (or a schema's `.load()`), not attribute access — Flask's `request` has no Pydantic-style fields.
+- **CLI / background job:** prefer an existing per-operation ID if the code already tracks one (`session_id = job_id or str(uuid.uuid4())`); otherwise `str(uuid.uuid4())` per run. RUM not applicable.
+
+## Reporting goal status
+
+Alongside the standard report shape in `common-verify-report.md`, summarize goal status in the human-readable message, e.g.:
+```
+✓ Well-formed LLMObs trace
+✓ Agent Session ID (UUID fallback — RUM upgrade path noted)
+~ RUM session linking: not available (no RUM SDK detected)
+~ APM trace linking: apm_trace_id set, but not navigable (no dd-agent detected)
+```


### PR DESCRIPTION
## Add `dd-instrument-llmo` skill

Adds a skill that instruments a backend application with **Datadog LLM Observability** — detecting the runtime and LLM/agent framework and safely adding (or completing) SDK instrumentation without breaking the build or the deploy. Instrumentation only; it stays within LLM Observability scope and never adds RUM, APM application instrumentation, or unrelated products.

### How it works
1. **Analyze** — detects the backend runtime (Python vs Node.js/Next.js), the LLM/agent framework (OpenAI, Anthropic, LangChain/LangGraph, Vercel AI SDK, Bedrock, Pydantic AI, CrewAI, LiteLLM, and others), the application framework, and any existing `ddtrace`/`dd-trace` init — so it never adds a second competing initialization.
2. **Route** — reads a shared credentials reference plus exactly one runtime reference (`llmobs-python` or `llmobs-nodejs`), copying package names, import paths, and `LLMObs.enable(...)` / `.init({...})` keyword arguments verbatim rather than from memory.
3. **Instrument** — adds SDK init in the correct form for the project (Python `ddtrace-run` / `LLMObs.enable`, Node CommonJS / ESM / Next.js `dd-trace/initialize.mjs`), persists the dependency into the deploy's manifest, and adds `agent` / `workflow` / `tool` spans with the session ID set on the root span only.
4. **Verify** — confirms a single init path, checks the app still builds/runs, audits RUM↔LLMObs session-ID plumbing when a RUM SDK is present, and reports honestly — never claiming session/trace linking the environment can't support.

### Problems it solves
- "Add / set up / instrument Datadog LLM Observability", "monitor my AI app", "add LLM spans / agent session tracking" across Python and Node.js/Next.js backends.
- **Repairing** a partial setup — completes missing session-ID plumbing and span structure while leaving an existing valid init untouched (no duplicate init).
- The common failure modes: the non-existent `ddtrace.llm_observability` import, packages installed locally but missing from the deploy manifest, session IDs set on child spans instead of the root, and multiple root spans per logical operation in multi-agent pipelines.

### Dependencies
- **Backend SDK packages only** — `ddtrace` (Python) or `dd-trace` (Node.js), installed with the project's own package manager and written into its deploy manifest.
- Optionally uses a `CreateApiKey` tool when present to provision an API key; otherwise falls back to asking the user to create one in the Datadog UI. No new runtime dependencies beyond the tracer.
